### PR TITLE
feat(init): add app runner for ubuntu_init

### DIFF
--- a/packages/ubuntu_init/.metadata
+++ b/packages/ubuntu_init/.metadata
@@ -1,10 +1,30 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled and should not be manually edited.
+# This file should be version controlled.
 
 version:
   revision: 796c8ef79279f9c774545b3771238c3098dbefab
   channel: stable
 
-project_type: package
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: 796c8ef79279f9c774545b3771238c3098dbefab
+      base_revision: 796c8ef79279f9c774545b3771238c3098dbefab
+    - platform: linux
+      create_revision: 796c8ef79279f9c774545b3771238c3098dbefab
+      base_revision: 796c8ef79279f9c774545b3771238c3098dbefab
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/packages/ubuntu_init/lib/main.dart
+++ b/packages/ubuntu_init/lib/main.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ubuntu_init/ubuntu_init.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_utils/ubuntu_utils.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+Future<void> main(List<String> args) async {
+  final options = parseCommandLine(args, onPopulateOptions: (parser) {
+    addLoggingOptions(parser);
+  })!;
+  setupLogger(options);
+
+  final log = Logger();
+
+  return runZonedGuarded(() async {
+    FlutterError.onError = (error) {
+      log.error('Unhandled exception', error.exception, error.stack);
+    };
+
+    await YaruWindowTitleBar.ensureInitialized();
+
+    await registerInitServices();
+
+    runApp(ProviderScope(
+      child: Consumer(
+        builder: (context, ref, child) => WizardApp(
+          locale: ref.watch(localeProvider),
+          localizationsDelegates: const [
+            ...UbuntuProvisionLocalizations.localizationsDelegates,
+            ...GlobalUbuntuLocalizations.delegates,
+          ],
+          supportedLocales: supportedLocales,
+          home: DefaultAssetBundle(
+            bundle: ProxyAssetBundle(rootBundle, package: 'ubuntu_init'),
+            child: const InitWizard(),
+          ),
+        ),
+      ),
+    ));
+  }, (error, stack) => log.error('Unhandled exception', error, stack));
+}

--- a/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
@@ -21,8 +21,7 @@ class XdgKeyboardService implements KeyboardService {
   final GSettings _inputSourceSettings;
   final AssetBundle _assetBundle;
 
-  String _langFilename(String lang) =>
-      'packages/ubuntu_init/assets/kbds/$lang.jsonl';
+  String _langFilename(String lang) => 'assets/kbds/$lang.jsonl';
 
   Future<String> _getLanguage() async {
     await _client.connect();
@@ -48,7 +47,10 @@ class XdgKeyboardService implements KeyboardService {
 
   Future<List<KeyboardLayout>> _getLayouts() async {
     final lang = await _getLanguage();
-    final keyboardData = await _assetBundle.loadString(_langFilename(lang));
+    final keyboardData = await _assetBundle
+        .loadString(_langFilename(lang))
+        .onError((error, stackTrace) => _assetBundle
+            .loadString('packages/ubuntu_init/${_langFilename(lang)}'));
     return keyboardData
         .split('\n')
         .where((line) => line.isNotEmpty)

--- a/packages/ubuntu_init/linux/.gitignore
+++ b/packages/ubuntu_init/linux/.gitignore
@@ -1,0 +1,3 @@
+flutter/ephemeral
+flutter/generated_plugin_registrant.*
+flutter/generated_plugins.cmake

--- a/packages/ubuntu_init/linux/CMakeLists.txt
+++ b/packages/ubuntu_init/linux/CMakeLists.txt
@@ -1,0 +1,132 @@
+cmake_minimum_required(VERSION 3.10)
+project(runner LANGUAGES CXX)
+
+set(BINARY_NAME "ubuntu_init")
+set(APPLICATION_ID "com.canonical.ubuntu_init")
+
+cmake_policy(SET CMP0063 NEW)
+
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+set(USE_LIBHANDY ON)
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Define the application target. To change its name, change BINARY_NAME above,
+# not the value here, or `flutter run` will no longer work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/packages/ubuntu_init/linux/flutter/CMakeLists.txt
+++ b/packages/ubuntu_init/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/packages/ubuntu_init/linux/main.cc
+++ b/packages/ubuntu_init/linux/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/packages/ubuntu_init/linux/my_application.cc
+++ b/packages/ubuntu_init/linux/my_application.cc
@@ -1,0 +1,137 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <handy.h>
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+static void my_application_get_workarea(GtkWindow* window,
+                                        GdkRectangle* workarea) {
+  GdkWindow* gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+  GdkDisplay* gdk_display = gdk_window_get_display(gdk_window);
+  GdkMonitor* monitor =
+      gdk_display_get_monitor_at_window(gdk_display, gdk_window);
+  gdk_monitor_get_workarea(monitor, workarea);
+
+  // gdk_monitor_get_workarea() is not reliable early on startup. compare the
+  // reported workarea to the full geometry and subtract some margins if the
+  // system is not reporting the correct workarea with the dock and the top bar
+  // excluded.
+  GdkRectangle geometry;
+  gdk_monitor_get_geometry(monitor, &geometry);
+  if (workarea->width == geometry.width &&
+      workarea->height == geometry.height) {
+    // by default, the dock is ~90px wide and the top bar is ~30px high.
+    workarea->width -= 100;
+    workarea->height -= 40;
+  }
+}
+
+static gboolean my_application_fit_to_workarea(GtkWindow* window) {
+  gint window_width = 0;
+  gint window_height = 0;
+  gtk_window_get_default_size(window, &window_width, &window_height);
+
+  GdkRectangle workarea;
+  my_application_get_workarea(window, &workarea);
+
+  gboolean fits_workarea =
+      window_width <= workarea.width && window_height <= workarea.height;
+  if (!fits_workarea) {
+    gtk_window_fullscreen(window);
+  }
+  return fits_workarea;
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+
+#ifdef NDEBUG
+  // Activate an existing app instance if already running but only in
+  // production/release mode. Allow multiple instances in debug mode for
+  // easier debugging and testing.
+  GList* windows = gtk_application_get_windows(GTK_APPLICATION(application));
+  if (windows) {
+    gtk_window_present(GTK_WINDOW(windows->data));
+    return;
+  }
+#endif
+
+  GtkWindow* window = GTK_WINDOW(hdy_application_window_new());
+  gtk_window_set_application(window, GTK_APPLICATION(application));
+  gtk_window_set_type_hint(window, GDK_WINDOW_TYPE_HINT_DIALOG);  // no min/max
+  gtk_window_set_default_size(window, 960, 680);
+  gtk_widget_realize(GTK_WIDGET(window));
+
+  if (my_application_fit_to_workarea(window)) {
+#ifdef NDEBUG
+    // The window has a fixed size in production/release mode, but resizing
+    // the window is allowed in debug mode for testing purposes, or if it
+    // doesn't fit the available workarea.
+    gtk_window_set_resizable(window, FALSE);
+#endif
+  }
+  gtk_widget_show(GTK_WIDGET(window));
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  return MY_APPLICATION(g_object_new(
+      my_application_get_type(), "application-id", APPLICATION_ID, nullptr));
+}

--- a/packages/ubuntu_init/linux/my_application.h
+++ b/packages/ubuntu_init/linux/my_application.h
@@ -1,0 +1,18 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.3.6
   gsettings: ^0.2.7
+  handy_window: ^0.3.0
   meta: ^1.7.0
   stdlibc: ^0.1.0
   timezone_map:
@@ -23,10 +24,13 @@ dependencies:
       path: packages/timezone_map
       ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
   ubuntu_localizations: ^0.3.3
+  ubuntu_logger: ^0.0.3
   ubuntu_provision:
     path: ../ubuntu_provision
   ubuntu_service: ^0.2.0
   ubuntu_session: ^0.0.4
+  ubuntu_utils:
+    path: ../ubuntu_utils
   ubuntu_wizard:
     path: ../ubuntu_wizard
   xdg_locale: ^0.0.1

--- a/packages/ubuntu_init/test/services/xdg_keyboard_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_keyboard_service_test.dart
@@ -47,10 +47,9 @@ void main() {
 
     final fakeAssetBundle = FakeAssetBundle(
       {
-        'packages/ubuntu_init/assets/kbds/en.jsonl':
-            '["us", "English (US)", [["", "English (US)"],'
-                '["altgr-intl", "English (US) - English (intl., with AltGr dead keys)"]]]\n'
-                '["de", "German", [["", "German"]]]'
+        'assets/kbds/en.jsonl': '["us", "English (US)", [["", "English (US)"],'
+            '["altgr-intl", "English (US) - English (intl., with AltGr dead keys)"]]]\n'
+            '["de", "German", [["", "German"]]]'
       },
     );
 


### PR DESCRIPTION
Mainly for development and testing purposes.

Note: the asset lookup in xdg_keyboard_service had to be tweaked so that it's able to look up assets either from the app or from the ubuntu_init package.