### PR TITLE
fix(timezone): fix XDG default

### DIFF
--- a/packages/ubuntu_bootstrap/lib/services/timezone_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/timezone_service.dart
@@ -12,7 +12,7 @@ class SubiquityTimezoneService implements TimezoneService {
   }
 
   @override
-  Future<void> setTimezone(String timezone) {
-    return _subiquity.setTimezone(timezone);
+  Future<void> setTimezone(String? timezone) {
+    return _subiquity.setTimezone(timezone ?? 'geoip');
   }
 }

--- a/packages/ubuntu_bootstrap/test/services/timezone_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/timezone_service_test.dart
@@ -26,6 +26,9 @@ void main() {
 
       final service = SubiquityTimezoneService(client);
 
+      await service.setTimezone(null);
+      verify(client.setTimezone('geoip')).called(1);
+
       await service.setTimezone('Europe/Oslo');
       verify(client.setTimezone('Europe/Oslo')).called(1);
     });

--- a/packages/ubuntu_init/lib/src/services/xdg_timezone_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_timezone_service.dart
@@ -28,11 +28,11 @@ class XdgTimezoneService implements TimezoneService {
   }
 
   @override
-  Future<void> setTimezone(String timezone) async {
+  Future<void> setTimezone(String? timezone) async {
     await _object.callMethod(
       'org.freedesktop.timedate1',
       'SetTimezone',
-      [DBusString(timezone), const DBusBoolean(false)],
+      [DBusString(timezone ?? 'Etc/UTC'), const DBusBoolean(false)],
       replySignature: DBusSignature.empty,
     );
   }

--- a/packages/ubuntu_init/test/services/xdg_timezone_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_timezone_service_test.dart
@@ -25,11 +25,24 @@ void main() {
     when(object.callMethod(
       'org.freedesktop.timedate1',
       'SetTimezone',
+      const [DBusString('Etc/UTC'), DBusBoolean(false)],
+      replySignature: DBusSignature.empty,
+    )).thenAnswer((_) async => DBusMethodSuccessResponse());
+    when(object.callMethod(
+      'org.freedesktop.timedate1',
+      'SetTimezone',
       const [DBusString('Europe/Berlin'), DBusBoolean(false)],
       replySignature: DBusSignature.empty,
     )).thenAnswer((_) async => DBusMethodSuccessResponse());
 
     final service = XdgTimezoneService(object);
+    await service.setTimezone(null);
+    verify(object.callMethod(
+      'org.freedesktop.timedate1',
+      'SetTimezone',
+      const [DBusString('Etc/UTC'), DBusBoolean(false)],
+      replySignature: DBusSignature.empty,
+    )).called(1);
     await service.setTimezone('Europe/Berlin');
     verify(object.callMethod(
       'org.freedesktop.timedate1',

--- a/packages/ubuntu_provision/lib/src/services/timezone_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/timezone_service.dart
@@ -1,4 +1,4 @@
 abstract class TimezoneService {
   Future<String> getTimezone();
-  Future<void> setTimezone(String timezone);
+  Future<void> setTimezone(String? timezone);
 }

--- a/packages/ubuntu_provision/lib/src/timezone/timezone_model.dart
+++ b/packages/ubuntu_provision/lib/src/timezone/timezone_model.dart
@@ -29,7 +29,7 @@ class TimezoneModel extends TimezoneController {
   }
 
   Future<void> save() async {
-    final timezone = selectedLocation?.timezone ?? 'geoip';
+    final timezone = selectedLocation?.timezone;
     log.debug('Saved $timezone');
     _service.setTimezone(timezone);
   }

--- a/packages/ubuntu_provision/test/timezone/timezone_model_test.dart
+++ b/packages/ubuntu_provision/test/timezone/timezone_model_test.dart
@@ -25,13 +25,13 @@ void main() {
 
   test('save', () async {
     final service = MockTimezoneService();
-    when(service.setTimezone('geoip')).thenAnswer((_) async {});
+    when(service.setTimezone(null)).thenAnswer((_) async {});
     when(service.setTimezone('Europe/Oslo')).thenAnswer((_) async {});
 
     final model = TimezoneModel(service, MockGeoService());
 
     await model.save();
-    verify(service.setTimezone('geoip')).called(1);
+    verify(service.setTimezone(null)).called(1);
 
     model.selectLocation(const GeoLocation(timezone: 'Europe/Oslo'));
 


### PR DESCRIPTION
While 'geoip' is the desired default for Subiquity, it's not a valid value for XDG so default to 'Etc/UTC' instead.

```
The following DBusInvalidArgsException was thrown running a test:
org.freedesktop.DBus.Error.InvalidArgs: Invalid or not installed time zone 'geoip'
```