### PR TITLE
refactor(init): tweak XDG services

### DIFF
--- a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
@@ -1,28 +1,28 @@
 import 'package:dbus/dbus.dart';
-import 'package:meta/meta.dart';
 import 'package:stdlibc/stdlibc.dart';
 import 'package:ubuntu_provision/services.dart';
 
 class XdgIdentityService implements IdentityService {
-  XdgIdentityService([
-    @visibleForTesting DBusClient? dBusClient,
-    @visibleForTesting int? userId,
-  ])  : _dBusClient = dBusClient ?? DBusClient.system(),
-        _userId = userId ?? getuid();
+  XdgIdentityService({DBusClient? bus})
+      : _client = bus ?? DBusClient.system(),
+        _userId = getuid();
+
+  XdgIdentityService.uid(this._userId, {DBusClient? bus})
+      : _client = bus ?? DBusClient.system();
 
   static const _defaultUserId = 1000;
 
-  final DBusClient _dBusClient;
+  final DBusClient _client;
   final int _userId;
   Identity? _identity;
 
   DBusRemoteObject get _accountObject => DBusRemoteObject(
-        _dBusClient,
+        _client,
         name: 'org.freedesktop.Accounts',
         path: DBusObjectPath('/org/freedesktop/Accounts'),
       );
   DBusRemoteObject get _hostnameObject => DBusRemoteObject(
-        _dBusClient,
+        _client,
         name: 'org.freedesktop.hostname1',
         path: DBusObjectPath('/org/freedesktop/hostname1'),
       );
@@ -42,7 +42,7 @@ class XdgIdentityService implements IdentityService {
               replySignature: DBusSignature.objectPath)
           .then((response) => response.values.first.asObjectPath());
       final userObject = DBusRemoteObject(
-        _dBusClient,
+        _client,
         name: 'org.freedesktop.Accounts',
         path: userObjectPath,
       );
@@ -101,7 +101,7 @@ class XdgIdentityService implements IdentityService {
         .then((response) => response.values.first.asObjectPath());
 
     final userObject = DBusRemoteObject(
-      _dBusClient,
+      _client,
       name: 'org.freedesktop.Accounts',
       path: userObjectPath,
     );

--- a/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
@@ -8,13 +8,14 @@ import 'package:ubuntu_provision/services.dart';
 import 'package:xdg_locale/xdg_locale.dart';
 
 class XdgKeyboardService implements KeyboardService {
-  XdgKeyboardService([
+  XdgKeyboardService({
+    DBusClient? bus,
     @visibleForTesting XdgLocaleClient? client,
-    @visibleForTesting GSettings? inputSourceSettings,
+    @visibleForTesting GSettings? settings,
     @visibleForTesting AssetBundle? assetBundle,
-  ])  : _client = client ?? XdgLocaleClient(),
-        _inputSourceSettings =
-            inputSourceSettings ?? GSettings('org.gnome.desktop.input-sources'),
+  })  : _client = client ?? XdgLocaleClient(bus: bus),
+        _inputSourceSettings = settings ??
+            GSettings(sessionBus: bus, 'org.gnome.desktop.input-sources'),
         _assetBundle = assetBundle ?? rootBundle;
 
   final XdgLocaleClient _client;

--- a/packages/ubuntu_init/lib/src/services/xdg_locale_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_locale_service.dart
@@ -1,10 +1,13 @@
+import 'package:dbus/dbus.dart';
 import 'package:meta/meta.dart';
 import 'package:ubuntu_provision/services.dart';
 import 'package:xdg_locale/xdg_locale.dart';
 
 class XdgLocaleService implements LocaleService {
-  XdgLocaleService([@visibleForTesting XdgLocaleClient? client])
-      : _client = client ?? XdgLocaleClient();
+  XdgLocaleService({
+    DBusClient? bus,
+    @visibleForTesting XdgLocaleClient? client,
+  }) : _client = client ?? XdgLocaleClient(bus: bus);
 
   final XdgLocaleClient _client;
   @override

--- a/packages/ubuntu_init/lib/src/services/xdg_timezone_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_timezone_service.dart
@@ -3,12 +3,14 @@ import 'package:meta/meta.dart';
 import 'package:ubuntu_provision/services.dart';
 
 class XdgTimezoneService implements TimezoneService {
-  XdgTimezoneService([@visibleForTesting DBusRemoteObject? object])
-      : _object = object ?? _createRemoteObject();
+  XdgTimezoneService({
+    DBusClient? bus,
+    @visibleForTesting DBusRemoteObject? object,
+  }) : _object = object ?? _createRemoteObject(bus);
 
-  static DBusRemoteObject _createRemoteObject() {
+  static DBusRemoteObject _createRemoteObject(DBusClient? bus) {
     return DBusRemoteObject(
-      DBusClient.system(),
+      bus ?? DBusClient.system(),
       name: 'org.freedesktop.timedate1',
       path: DBusObjectPath('/org/freedesktop/timedate1'),
     );

--- a/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
@@ -16,24 +16,24 @@ void main() {
     autoLogin: true,
   );
   test('get default user identity', () async {
-    final dBusClient = createMockDBusClient(identityData: testIdentity);
-    final service = XdgIdentityService(dBusClient, 1000);
+    final client = createMockDBusClient(identityData: testIdentity);
+    final service = XdgIdentityService.uid(1000, bus: client);
     expect(await service.getIdentity(), equals(testIdentity));
   });
 
   test('set identity', () async {
-    final dBusClient = createMockDBusClient();
-    final service = XdgIdentityService(dBusClient, 0);
+    final client = createMockDBusClient();
+    final service = XdgIdentityService.uid(0, bus: client);
     await service.setIdentity(testIdentity);
     expect(await service.getIdentity(), equals(testIdentity));
   });
 
   test('apply', () async {
-    final dBusClient = createMockDBusClient();
-    final service = XdgIdentityService(dBusClient, 0);
+    final client = createMockDBusClient();
+    final service = XdgIdentityService.uid(0, bus: client);
     await service.setIdentity(testIdentity.copyWith(password: 'password'));
 
-    verify(dBusClient.callMethod(
+    verify(client.callMethod(
       destination: 'org.freedesktop.Accounts',
       path: DBusObjectPath('/org/freedesktop/Accounts'),
       interface: 'org.freedesktop.Accounts',
@@ -49,7 +49,7 @@ void main() {
       allowInteractiveAuthorization: false,
     )).called(1);
 
-    verify(dBusClient.callMethod(
+    verify(client.callMethod(
       destination: 'org.freedesktop.Accounts',
       path: DBusObjectPath('/test/object/path'),
       interface: 'org.freedesktop.Accounts.User',
@@ -64,7 +64,7 @@ void main() {
       allowInteractiveAuthorization: false,
     )).called(1);
 
-    verify(dBusClient.callMethod(
+    verify(client.callMethod(
       destination: 'org.freedesktop.Accounts',
       path: DBusObjectPath('/test/object/path'),
       interface: 'org.freedesktop.Accounts.User',
@@ -78,7 +78,7 @@ void main() {
       allowInteractiveAuthorization: false,
     )).called(1);
 
-    verify(dBusClient.callMethod(
+    verify(client.callMethod(
       destination: 'org.freedesktop.hostname1',
       path: DBusObjectPath('/org/freedesktop/hostname1'),
       interface: 'org.freedesktop.hostname1',

--- a/packages/ubuntu_init/test/services/xdg_keyboard_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_keyboard_service_test.dart
@@ -54,9 +54,9 @@ void main() {
     );
 
     final service = XdgKeyboardService(
-      client,
-      MockGSettings(),
-      fakeAssetBundle,
+      client: client,
+      settings: MockGSettings(),
+      assetBundle: fakeAssetBundle,
     );
     expect(await service.getKeyboard(), equals(keyboardSetup));
   });
@@ -68,7 +68,10 @@ void main() {
     when(client.x11Model).thenReturn('pc105');
     when(client.x11Options).thenReturn('terminate:ctrl_alt_bksp');
 
-    final service = XdgKeyboardService(client, MockGSettings());
+    final service = XdgKeyboardService(
+      client: client,
+      settings: MockGSettings(),
+    );
     await service.setKeyboard(keyboardSetup.setting);
 
     verify(client.setX11Keyboard(
@@ -85,7 +88,10 @@ void main() {
     final gsettings = MockGSettings();
     when(gsettings.set('sources', any)).thenAnswer((_) async {});
 
-    final service = XdgKeyboardService(MockXdgLocaleClient(), gsettings);
+    final service = XdgKeyboardService(
+      client: MockXdgLocaleClient(),
+      settings: gsettings,
+    );
     await service.setInputSource(keyboardSetup.setting);
 
     verify(gsettings.set(

--- a/packages/ubuntu_init/test/services/xdg_locale_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_locale_service_test.dart
@@ -12,7 +12,7 @@ void main() {
     final client = MockXdgLocaleClient();
     when(client.locale).thenAnswer((_) => {'LANG': 'en_US.UTF-8'});
 
-    final service = XdgLocaleService(client);
+    final service = XdgLocaleService(client: client);
     expect(await service.getLocale(), equals('en_US.UTF-8'));
   });
 
@@ -23,7 +23,7 @@ void main() {
           'LC_MESSAGES': 'en_US.UTF-8',
         });
 
-    final service = XdgLocaleService(client);
+    final service = XdgLocaleService(client: client);
     await service.setLocale('en_GB.UTF-8');
 
     verify(client.setLocale({

--- a/packages/ubuntu_init/test/services/xdg_timezone_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_timezone_service_test.dart
@@ -16,7 +16,7 @@ void main() {
       signature: DBusSignature.string,
     )).thenAnswer((_) async => const DBusString('Europe/Rome'));
 
-    final service = XdgTimezoneService(object);
+    final service = XdgTimezoneService(object: object);
     expect(await service.getTimezone(), equals('Europe/Rome'));
   });
 
@@ -35,7 +35,7 @@ void main() {
       replySignature: DBusSignature.empty,
     )).thenAnswer((_) async => DBusMethodSuccessResponse());
 
-    final service = XdgTimezoneService(object);
+    final service = XdgTimezoneService(object: object);
     await service.setTimezone(null);
     verify(object.callMethod(
       'org.freedesktop.timedate1',

--- a/packages/ubuntu_provision/lib/src/services/network_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/network_service.dart
@@ -5,6 +5,8 @@ export 'package:nm/nm.dart';
 
 /// Extends [NetworkManagerClient] with convenience properties and methods.
 class NetworkService extends NetworkManagerClient {
+  NetworkService({super.bus});
+
   /// `true` if there is a full network connection.
   bool get isConnected {
     return connectivity == NetworkManagerConnectivityState.full;

--- a/packages/ubuntu_provision/lib/src/services/theme_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_service.dart
@@ -6,11 +6,17 @@ import 'package:meta/meta.dart';
 
 /// An interface for managing the system theme.
 abstract class ThemeService {
+  /// Returns the current brightness.
+  Future<Brightness> getBrightness();
+
   /// Applies a [brightness].
   Future<void> setBrightness(Brightness brightness);
 
+  /// Returns the current accent.
+  Future<String?> getAccent();
+
   /// Applies an [accent].
-  Future<void> setAccent(String accent);
+  Future<void> setAccent(String? accent);
 
   /// Closes the service and releases any resources.
   Future<void> close();
@@ -25,6 +31,12 @@ class GtkThemeService implements ThemeService {
   final GSettings settings;
 
   @override
+  Future<Brightness> getBrightness() async {
+    final scheme = await settings.get('color-scheme').then((v) => v.asString());
+    return scheme.hasSuffix('dark') ? Brightness.dark : Brightness.light;
+  }
+
+  @override
   Future<void> setBrightness(Brightness brightness) async {
     final theme = await settings.get('gtk-theme').then((v) => v.asString());
     switch (brightness) {
@@ -37,6 +49,12 @@ class GtkThemeService implements ThemeService {
         await settings.set('color-scheme', const DBusString('prefer-light'));
         break;
     }
+  }
+
+  @override
+  Future<String?> getAccent() async {
+    final theme = await settings.get('gtk-theme').then((v) => v.asString());
+    return theme.removeSuffix('dark').split('-').elementAtOrNull(1);
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/services/theme_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_service.dart
@@ -17,8 +17,9 @@ abstract class ThemeService {
 }
 
 class GtkThemeService implements ThemeService {
-  GtkThemeService([GSettings? settings])
-      : settings = settings ?? GSettings('org.gnome.desktop.interface');
+  GtkThemeService({DBusClient? bus, GSettings? settings})
+      : settings = settings ??
+            GSettings(sessionBus: bus, 'org.gnome.desktop.interface');
 
   @protected
   final GSettings settings;

--- a/packages/ubuntu_provision/test/services/theme_service_test.dart
+++ b/packages/ubuntu_provision/test/services/theme_service_test.dart
@@ -10,24 +10,30 @@ import 'theme_service_test.mocks.dart';
 
 @GenerateMocks([GSettings])
 void main() {
-  test('set color-scheme via gsettings', () async {
+  test('color-scheme via gsettings', () async {
     final settings = MockGSettings();
     when(settings.set(any, any)).thenAnswer((_) async {});
 
     final service = GtkThemeService(settings: settings);
 
+    when(settings.get('color-scheme'))
+        .thenAnswer((_) async => const DBusString('prefer-dark'));
     when(settings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru-dark'));
 
+    expect(await service.getBrightness(), Brightness.dark);
     await service.setBrightness(Brightness.light);
     verifyInOrder([
       settings.set('gtk-theme', const DBusString('Yaru')),
       settings.set('color-scheme', const DBusString('prefer-light')),
     ]);
 
+    when(settings.get('color-scheme'))
+        .thenAnswer((_) async => const DBusString('prefer-light'));
     when(settings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru'));
 
+    expect(await service.getBrightness(), Brightness.light);
     await service.setBrightness(Brightness.dark);
     verifyInOrder([
       settings.set('gtk-theme', const DBusString('Yaru-dark')),
@@ -35,7 +41,7 @@ void main() {
     ]);
   });
 
-  test('set accent color via gsettings', () async {
+  test('accent color via gsettings', () async {
     final settings = MockGSettings();
     when(settings.set('gtk-theme', any)).thenAnswer((_) async {});
 
@@ -44,6 +50,9 @@ void main() {
     when(settings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru-dark'));
 
+    expect(await service.getAccent(), null);
+    when(settings.get('gtk-theme'))
+        .thenAnswer((_) async => const DBusString('Yaru-red-dark'));
     await service.setAccent('red');
     verify(settings.set('gtk-theme', const DBusString('Yaru-red-dark')))
         .called(1);
@@ -51,6 +60,7 @@ void main() {
     when(settings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Any-red'));
 
+    expect(await service.getAccent(), 'red');
     await service.setAccent('prussianGreen');
     verify(settings.set('gtk-theme', const DBusString('Any-prussiangreen')))
         .called(1);

--- a/packages/ubuntu_provision/test/services/theme_service_test.dart
+++ b/packages/ubuntu_provision/test/services/theme_service_test.dart
@@ -14,7 +14,7 @@ void main() {
     final settings = MockGSettings();
     when(settings.set(any, any)).thenAnswer((_) async {});
 
-    final service = GtkThemeService(settings);
+    final service = GtkThemeService(settings: settings);
 
     when(settings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru-dark'));
@@ -39,7 +39,7 @@ void main() {
     final settings = MockGSettings();
     when(settings.set('gtk-theme', any)).thenAnswer((_) async {});
 
-    final service = GtkThemeService(settings);
+    final service = GtkThemeService(settings: settings);
 
     when(settings.get('gtk-theme'))
         .thenAnswer((_) async => const DBusString('Yaru-dark'));

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -1073,6 +1073,14 @@ class MockThemeService extends _i1.Mock implements _i23.ThemeService {
   }
 
   @override
+  _i8.Future<_i24.Brightness> getBrightness() => (super.noSuchMethod(
+        Invocation.method(
+          #getBrightness,
+          [],
+        ),
+        returnValue: _i8.Future<_i24.Brightness>.value(_i24.Brightness.dark),
+      ) as _i8.Future<_i24.Brightness>);
+  @override
   _i8.Future<void> setBrightness(_i24.Brightness? brightness) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1082,6 +1090,14 @@ class MockThemeService extends _i1.Mock implements _i23.ThemeService {
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+  @override
+  _i8.Future<String?> getAccent() => (super.noSuchMethod(
+        Invocation.method(
+          #getAccent,
+          [],
+        ),
+        returnValue: _i8.Future<String?>.value(),
+      ) as _i8.Future<String?>);
   @override
   _i8.Future<void> setAccent(String? accent) => (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
Follow the same convention as Canonical's dbus.dart-based libraries that allow optionally passing a named `{DBusClient? bus}` property to client constructors. This allows using a fake D-Bus server for integration testing and easily passing the appropriate bus to all services without having to deal with XdgLocaleClient, GSettings, and friends. In this scenario, all services and clients are real, only the server side is fake.

```dart
final server = FakeDBusServer();
final client = DBusClient(await server.start(...));

registerService<IdentityService>(() => XdgIdentityService.uid(0, bus: client));
registerService<KeyboardService>(() => XdgKeyboardService(bus: client));
registerService<LocaleService>(() => XdgLocaleService(bus: client));
registerService<NetworkService>(() => NetworkService(bus: client));
registerService<TimezoneService>(() => XdgTimezoneService(bus: client));

await tester.runApp(() => app.main([]));
...
```