### PR TITLE
refactor: register GSettings factory

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gsettings/gsettings.dart';
 import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_client/subiquity_server.dart';
@@ -75,6 +76,7 @@ Future<void> runInstallerApp(
     tryRegisterService(() => ConfigService(options['config']!));
   }
   tryRegisterService<DesktopService>(() => GnomeService());
+  tryRegisterServiceFactory<GSettings>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(() => SubiquityIdentityService(
       getService<SubiquityClient>(), getService<PostInstallService>()));
   tryRegisterService<InstallerService>(() => InstallerService(

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   flutter_spinbox: ^0.13.0
   flutter_svg: ^2.0.0
   form_field_validator: ^1.1.0
+  gsettings: ^0.2.7
   handy_window: ^0.3.0
   intl: ^0.18.0
   meta: ^1.7.0

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -1,3 +1,4 @@
+import 'package:gsettings/gsettings.dart';
 import 'package:timezone_map/timezone_map.dart';
 import 'package:ubuntu_provision/services.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -19,6 +20,7 @@ export 'services/xdg_timezone_service.dart';
 
 Future<void> registerInitServices() {
   tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
+  tryRegisterServiceFactory<GSettings>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(XdgIdentityService.new);
   tryRegisterService<KeyboardService>(XdgKeyboardService.new);
   tryRegisterService<LocaleService>(XdgLocaleService.new);

--- a/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:ubuntu_provision/services.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:xdg_locale/xdg_locale.dart';
 
 class XdgKeyboardService implements KeyboardService {
@@ -15,7 +16,7 @@ class XdgKeyboardService implements KeyboardService {
     @visibleForTesting AssetBundle? assetBundle,
   })  : _client = client ?? XdgLocaleClient(bus: bus),
         _inputSourceSettings = settings ??
-            GSettings(sessionBus: bus, 'org.gnome.desktop.input-sources'),
+            createService<GSettings>('org.gnome.desktop.input-sources'),
         _assetBundle = assetBundle ?? rootBundle;
 
   final XdgLocaleClient _client;

--- a/packages/ubuntu_provision/lib/src/services/desktop_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/desktop_service.dart
@@ -2,6 +2,7 @@ import 'package:dbus/dbus.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:meta/meta.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';
 
 /// @internal
@@ -27,14 +28,14 @@ class GnomeService implements DesktopService {
     @visibleForTesting GSettings? sessionSettings,
     @visibleForTesting GSettings? screensaverSettings,
     @visibleForTesting GnomeSessionManager? gnomeSessionManager,
-  })  : _dingSettings =
-            dingSettings ?? GSettings('org.gnome.shell.extensions.ding'),
+  })  : _dingSettings = dingSettings ??
+            createService<GSettings>('org.gnome.shell.extensions.ding'),
         _mediaHandlingSettings = mediaHandlingSettings ??
-            GSettings('org.gnome.desktop.media-handling'),
-        _screensaverSettings =
-            screensaverSettings ?? GSettings('org.gnome.desktop.screensaver'),
-        _sessionSettings =
-            sessionSettings ?? GSettings('org.gnome.desktop.session'),
+            createService<GSettings>('org.gnome.desktop.media-handling'),
+        _screensaverSettings = screensaverSettings ??
+            createService<GSettings>('org.gnome.desktop.screensaver'),
+        _sessionSettings = sessionSettings ??
+            createService<GSettings>('org.gnome.desktop.session'),
         _gnomeSessionManager = gnomeSessionManager ?? GnomeSessionManager();
 
   final GSettings _dingSettings;

--- a/packages/ubuntu_provision/lib/src/services/theme_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_service.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:dbus/dbus.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:meta/meta.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 
 /// An interface for managing the system theme.
 abstract class ThemeService {
@@ -24,8 +25,8 @@ abstract class ThemeService {
 
 class GtkThemeService implements ThemeService {
   GtkThemeService({DBusClient? bus, GSettings? settings})
-      : settings = settings ??
-            GSettings(sessionBus: bus, 'org.gnome.desktop.interface');
+      : settings =
+            settings ?? createService<GSettings>('org.gnome.desktop.interface');
 
   @protected
   final GSettings settings;


### PR DESCRIPTION
Allows wiring up custom D-Bus clients and keyfile backends for GSettings for testing purposes.

GSettings is somewhat complicated because it writes through DConf's D-Bus API but reads directly from the file system. Even though `gsettings.dart` allows setting environment variables for customization, this is not usable in tests because the immutable `Platform.environment` is already accessed and cached before the test entry point gets called so it's too late to set any environment variables at the beginning of tests.

See also:
- #19