### PR TITLE
fix(init): model initialization on startup

### DIFF
--- a/packages/ubuntu_init/lib/src/init_wizard.dart
+++ b/packages/ubuntu_init/lib/src/init_wizard.dart
@@ -25,27 +25,18 @@ class InitRoutes {
   static const String theme = '/theme';
 }
 
-class InitWizard extends ConsumerStatefulWidget {
+class InitWizard extends ConsumerWidget {
   const InitWizard({super.key});
 
   @override
-  ConsumerState<InitWizard> createState() => _InitWizardState();
-}
-
-class _InitWizardState extends ConsumerState<InitWizard> {
-  @override
-  void initState() {
-    super.initState();
-    ref.read(initModelProvider).init();
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return WizardBuilder(
       routes: {
         // TODO: loading screen?
         InitRoutes.initial: WizardRoute(
           builder: (_) => const SizedBox.shrink(),
+          onReplace: (_) =>
+              ref.read(initModelProvider).init().then((_) => null),
         ),
         InitRoutes.locale: WizardRoute(
           builder: (_) => const LocalePage(),


### PR DESCRIPTION
Calling asynchronous `InitModel.init()` from within `InitWizard.initState()` leaves the future dangling. Make use of `WizardRoute.onReplace` from the initial loading route to ensure that the initialization routine finishes before proceeding to the next route.