### PR TITLE
feat(config): look up the config file unless explicitly specified

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -73,9 +73,7 @@ Future<void> runInstallerApp(
   tryRegisterService<ActiveDirectoryService>(
       () => SubiquityActiveDirectoryService(getService<SubiquityClient>()));
   tryRegisterServiceInstance<ArgResults>(options);
-  if (options['config'] != null) {
-    tryRegisterService(() => ConfigService(options['config']!));
-  }
+  tryRegisterService<ConfigService>(() => ConfigService(options['config']));
   tryRegisterService<DesktopService>(() => GnomeService());
   tryRegisterServiceFactory<GSettings>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(() => SubiquityIdentityService(

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -32,9 +32,7 @@ Future<void> registerInitServices(List<String> args) {
   }
 
   tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
-  if (options['config'] != null) {
-    tryRegisterService(() => ConfigService(options!['config']!));
-  }
+  tryRegisterService<ConfigService>(() => ConfigService(options!['config']));
   tryRegisterServiceFactory<GSettings>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(XdgIdentityService.new);
   tryRegisterService<KeyboardService>(XdgKeyboardService.new);

--- a/packages/ubuntu_init/test/init_services_test.dart
+++ b/packages/ubuntu_init/test/init_services_test.dart
@@ -13,7 +13,7 @@ void main() {
 
     expect(tryGetService<ActiveDirectoryService>(), isNotNull);
     expect(tryGetService<ArgResults>(), isNotNull);
-    expect(tryGetService<ConfigService>(), isNull);
+    expect(tryGetService<ConfigService>(), isNotNull);
     expect(tryGetService<GeoService>(), isNotNull);
     expect(tryGetService<IdentityService>(), isNotNull);
     expect(tryGetService<KeyboardService>(), isNotNull);
@@ -22,11 +22,5 @@ void main() {
     expect(tryGetService<SessionService>(), isNotNull);
     expect(tryGetService<ThemeService>(), isNotNull);
     expect(tryGetService<TimezoneService>(), isNotNull);
-  });
-
-  test('register config service', () async {
-    await registerInitServices(['--config=foo.yaml']);
-
-    expect(tryGetService<ConfigService>(), isNotNull);
   });
 }

--- a/packages/ubuntu_provision/lib/src/services/config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/config_service.dart
@@ -6,16 +6,20 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:toml/toml.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import 'package:yaml/yaml.dart';
 
 /// @internal
 final log = Logger('config');
 
 class ConfigService {
-  ConfigService(this._path, {@visibleForTesting FileSystem? fs})
-      : _fs = fs ?? const LocalFileSystem();
+  ConfigService(
+    String? path, {
+    @visibleForTesting FileSystem fs = const LocalFileSystem(),
+  })  : _path = path ?? lookupPath(fs),
+        _fs = fs;
 
-  final String _path;
+  final String? _path;
   final FileSystem _fs;
   Map<String, dynamic>? _config;
 
@@ -26,14 +30,15 @@ class ConfigService {
 
   @visibleForTesting
   Future<Map<String, dynamic>?> load() async {
-    final file = _fs.file(_path);
+    final file = _fs.file(_path ?? '');
+    if (!file.existsSync()) return {};
     try {
       final data = await file.readAsString();
-      final config = switch (p.extension(_path)) {
+      final config = switch (p.extension(_path!)) {
         '.yml' || '.yaml' => loadYaml(data),
-        '.tml' || '.toml' => TomlDocument.parse(data).toMap(),
+        '.conf' || '.tml' || '.toml' => TomlDocument.parse(data).toMap(),
         '.json' => jsonDecode(data),
-        _ => throw UnsupportedError(_path),
+        _ => throw UnsupportedError(_path!),
       };
       log.debug('loaded $_path');
       return (config as Map).cast();
@@ -41,5 +46,23 @@ class ConfigService {
       log.error('failed to load $_path', e);
       return null;
     }
+  }
+
+  /// Looks up the config file path in the following order:
+  ///
+  /// - /etc/ubuntu-provision.{conf,yaml,yml} (admin)
+  /// - /usr/local/share/ubuntu-provision.{conf,yaml,yml} (oem)
+  /// - /usr/share/ubuntu-provision.{conf,yaml,yml} (distro)
+  @visibleForTesting
+  static String? lookupPath(FileSystem fs) {
+    const exts = ['conf', 'yaml', 'yml'];
+    final dirs = [...xdg.configDirs, fs.directory('/etc'), ...xdg.dataDirs];
+    for (final dir in dirs) {
+      for (final ext in exts) {
+        final path = p.join(dir.path, 'ubuntu-provision.$ext');
+        if (fs.file(path).existsSync()) return path;
+      }
+    }
+    return null;
   }
 }

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
     path: ../ubuntu_wizard
   udev: ^0.0.3
   upower: ^0.7.0
+  xdg_directories: ^1.0.1
   yaml: ^3.1.2
   yaru: ^0.9.0
   yaru_icons: ^1.0.0

--- a/packages/ubuntu_provision/test/services/config_service_test.dart
+++ b/packages/ubuntu_provision/test/services/config_service_test.dart
@@ -3,6 +3,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_provision/src/services/config_service.dart';
 
 void main() {
+  test('lookup path', () {
+    final priority = [
+      // admin
+      '/etc/ubuntu-provision.conf',
+      '/etc/ubuntu-provision.yaml',
+      '/etc/ubuntu-provision.yml',
+      // oem
+      '/usr/local/share/ubuntu-provision.conf',
+      '/usr/local/share/ubuntu-provision.yaml',
+      '/usr/local/share/ubuntu-provision.yml',
+      // distro
+      '/usr/share/ubuntu-provision.conf',
+      '/usr/share/ubuntu-provision.yaml',
+      '/usr/share/ubuntu-provision.yml',
+    ];
+
+    final fs = MemoryFileSystem();
+    for (final path in priority.reversed) {
+      fs.file(path).createSync(recursive: true);
+      expect(ConfigService.lookupPath(fs), path);
+    }
+  });
+
   test('yaml', () async {
     final fs = MemoryFileSystem();
     fs.file('/path/to/foo.yaml')


### PR DESCRIPTION
Unless `--config <path>` is passed, look up the config file path in the following order:

- `/etc/ubuntu-provision.{conf,yaml,yml}` (admin)
- `/usr/local/share/ubuntu-provision.{conf,yaml,yml}` (oem)
- `/usr/share/ubuntu-provision.{conf,yaml,yml}` (distro)

Notes:
- The standard [XDG config and data dirs](https://pub.dev/packages/xdg_directories) are supported.
- To limit the amount of FS checks, only a subset of the supported extensions are looked up.

Ref: canonical/ubuntu-desktop-installer#2194