### PR TITLE
chore: optimize melos & ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,36 @@ jobs:
     - run: melos pub get
     - run: melos analyze
 
+  coverage:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        package:
+          - ubuntu_bootstrap
+          - ubuntu_init
+          - ubuntu_provision
+          - ubuntu_utils
+          - ubuntu_wizard
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+        flutter-version: ${{env.FLUTTER_VERSION}}
+    - run: flutter pub get
+      working-directory: packages/${{matrix.package}}
+    - run: flutter test --coverage
+      working-directory: packages/${{matrix.package}}
+    - run: sudo apt update && sudo apt install lcov
+    - run: lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info
+      working-directory: packages/${{matrix.package}}
+    - uses: codecov/codecov-action@v3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+
   format:
     runs-on: ubuntu-22.04
     steps:
@@ -118,17 +148,5 @@ jobs:
         channel: 'stable'
         flutter-version: ${{env.FLUTTER_VERSION}}
     - run: flutter pub global activate melos
-    - name: Install dependencies
-      run: |
-        sudo apt update && sudo apt install lcov
-        make install_deps
-    - name: Setup environment
-      run: |
-        sudo loginctl enable-linger $USER
-        sudo systemctl start user@$UID.service
-        echo "XDG_RUNTIME_DIR=/run/user/$UID" >> $GITHUB_ENV
     - run: melos pub get
-    - run: melos coverage
-    - uses: codecov/codecov-action@v3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
+    - run: melos test

--- a/melos.yaml
+++ b/melos.yaml
@@ -9,18 +9,8 @@ ignore:
 scripts:
   # analyze all packages
   analyze: >
-    melos exec -c 1 -- \
+    melos exec -c 1 --ignore="subiquity_*" -- \
       flutter analyze .
-
-  # collect coverage information for all packages
-  coverage: >
-    melos exec -c 1 --fail-fast --dir-exists=test -- \
-      flutter test --coverage && melos run coverage:cleanup
-
-  # cleanup generated files from coverage
-  coverage:cleanup: >
-    melos exec --file-exists=coverage/lcov.info -- \
-      lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info
 
   # format all packages
   format: >
@@ -52,5 +42,5 @@ scripts:
 
   # run tests in all packages
   test: >
-    melos exec -c 1 --fail-fast --dir-exists=test -- \
+    melos exec -c 1 --fail-fast --dir-exists=test --ignore="subiquity_*" -- \
       flutter test


### PR DESCRIPTION
- Run coverage jobs in parallel. The downside is to have to list them in the matrix but on the upside, they only take a few minutes each.
- Run all tests without coverage collection to ensure no test gets skipped if they are forgotten from the manually maintained coverage matrix. Executing all tests without coverage collection doesn't take much longer than it takes to run the longest test with coverage collection.
- Ignore `subiquity_client` & `subiquity_test` units tests because they are already run at [subiquity_client.dart](https://github.com/canonical/subiquity_client.dart). This saves us from installing subiquity dependencies for running unit tests.
