### PR TITLE
fix(utils): fix app vs. package asset lookup

### DIFF
--- a/packages/ubuntu_utils/lib/src/proxy_asset_bundle.dart
+++ b/packages/ubuntu_utils/lib/src/proxy_asset_bundle.dart
@@ -29,6 +29,13 @@ class ProxyAssetBundle extends AssetBundle {
   }
 
   String _findAsset(String assetName, {required String package}) {
+    if (p.isWithin('packages/$package', assetName)) {
+      return _findAsset(
+        p.relative(assetName, from: 'packages/$package'),
+        package: package,
+      );
+    }
+
     // <app>/data/flutter_assets/
     final exePath = Platform.resolvedExecutable;
     final bundlePath = p.join(p.dirname(exePath), 'data', 'flutter_assets');

--- a/packages/ubuntu_utils/test/proxy_asset_bundle_test.dart
+++ b/packages/ubuntu_utils/test/proxy_asset_bundle_test.dart
@@ -70,6 +70,21 @@ void main() {
     verifyNever(bundle.load(assetName));
   });
 
+  test('app package asset', () async {
+    final bundle = MockAssetBundle();
+    final proxy = ProxyAssetBundle(bundle, package: 'qux');
+
+    await IOOverrides.runZoned(() async {
+      when(bundle.load(pkgAssetPath))
+          .thenAnswer((_) async => 'bar'.toByteData());
+      expect(await proxy.loadString('packages/qux/$assetName'), equals('bar'));
+    }, createFile: MockFileCreator({pkgAssetPath}));
+
+    verifyNever(bundle.load(appAssetPath));
+    verify(bundle.load(pkgAssetPath)).called(1);
+    verifyNever(bundle.load(assetName));
+  });
+
   test('structured package asset', () async {
     final bundle = MockAssetBundle();
     final proxy = ProxyAssetBundle(bundle, package: 'qux');


### PR DESCRIPTION
`ubuntu_bootstrap` can run as a standalone app or be used as a library. In the former case, `ubuntu_bootstrap`'s own assets (e.g. on the installation slides) must be looked up from `<bundle>/assets/` whereas in the latter case, they must be looked up from `<bundle>/packages/ubuntu_bootstrap/assets/`.

The problem came up in #35 while trying to run integration tests for `ubuntu_bootstrap`. The issue is easy to reproduce by simply running `ubuntu_bootstrap` as a standalone app and navigating until the installation slides:
```
══╡ EXCEPTION CAUGHT BY IMAGE RESOURCE SERVICE ╞════════════════════════════════════════════════════
The following assertion was thrown resolving an image codec:
Unable to load asset: "packages/ubuntu_bootstrap/assets/slides/mascot.png".
The asset does not exist or has empty data.

When the exception was thrown, this was the stack:
#0      PlatformAssetBundle.load.<anonymous closure> (package:flutter/src/services/asset_bundle.dart:328:9)
2
<asynchronous suspension>
(elided 6 frames from dart:async and package:stack_trace)

Image provider: AssetImage(bundle: null, name: "packages/ubuntu_bootstrap/assets/slides/mascot.png")
Image key: AssetBundleImageKey(bundle: ProxyAssetBundle#93f3a(), name:
  "packages/ubuntu_bootstrap/assets/slides/mascot.png", scale: 1.0)
════════════════════════════════════════════════════════════════════════════════════════════════════
```
In this particular case, `packages/ubuntu_bootstrap/assets/slides/mascot.png` does not exist - the correct path is `assets/slides/mascot.png` (but we cannot drop `package: 'ubuntu_bootstrap'` in code because then it wouldn't work as a library anymore).