### PR TITLE
fix(provision): broadcast journal stream

### DIFF
--- a/packages/ubuntu_provision/test/services/journal_service_test.dart
+++ b/packages/ubuntu_provision/test/services/journal_service_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_provision/services.dart';
+
+void main() {
+  test('broadcast stream', () {
+    final service = JournalService();
+    expect(service.start([]).isBroadcast, isTrue);
+  });
+}


### PR DESCRIPTION
In Dart, generator streams are always single-subscription streams, even if it yields a broadcast stream, and a single-subscription stream does not allow closing and re-subscribing.

The journal stream for the log view must be a broadcast stream to be able to resubscribe in case of state changes and rebuilds. The issue was noticed in #35:

```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following StateError was thrown building _JournalView(dependencies: [_InheritedTheme,
_LocalizationsScope-[GlobalKey#05e92]]):
Bad state: Stream has already been listened to.

The relevant error-causing widget was:
  _JournalView
  _JournalView:file:///home/runner/work/ubuntu-desktop-provision/ubuntu-desktop-provision/packages/ubuntu_bootstrap/lib/pages/install/install_page.dart:104:26
```