### PR TITLE
refactor(config): rename 'routes' to 'pages'

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -27,7 +27,7 @@ export 'slides.dart';
 
 Future<void> runInstallerApp(
   List<String> args, {
-  List<String>? routes,
+  List<String>? pages,
   List<WidgetBuilder>? slides,
   ThemeData? theme,
   ThemeData? darkTheme,
@@ -47,10 +47,8 @@ Future<void> runInstallerApp(
         defaultsTo: 'examples/sources/desktop.yaml',
         help: 'Path of the source catalog (dry-run only)');
     parser.addFlag('welcome', aliases: ['try-or-install'], hide: true);
-    parser.addOption('routes',
-        valueHelp: 'path',
-        help: 'A comma-separated list of page routes',
-        hide: true);
+    parser.addOption('pages',
+        valueHelp: 'path', help: 'A comma-separated list of pages', hide: true);
   })!;
   final liveRun = options['dry-run'] != true;
   final log = Logger.setup(path: liveRun ? '/var/log/installer' : null);
@@ -81,7 +79,7 @@ Future<void> runInstallerApp(
   tryRegisterService<InstallerService>(() => InstallerService(
       getService<SubiquityClient>(),
       config: tryGetService<ConfigService>(),
-      routes: options['routes']?.split(',') ?? routes));
+      pages: options['pages']?.split(',') ?? pages));
   tryRegisterService(JournalService.new);
   tryRegisterService<KeyboardService>(
       () => SubiquityKeyboardService(getService<SubiquityClient>()));

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -3,11 +3,11 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_provision/services.dart';
 
 class InstallerService {
-  InstallerService(this._client, {ConfigService? config, List<String>? routes})
+  InstallerService(this._client, {ConfigService? config, List<String>? pages})
       : _config = config,
-        _routes = routes?.map((r) => r.removePrefix('/')).toList();
+        _pages = pages?.map((r) => r.removePrefix('/')).toList();
 
-  List<String>? _routes;
+  List<String>? _pages;
   final SubiquityClient _client;
   final ConfigService? _config;
 
@@ -30,8 +30,8 @@ class InstallerService {
 
   Future<void> load() async {
     await monitorStatus().firstWhere((s) => s?.isLoading == false);
-    _routes ??=
-        await _client.getInteractiveSections() ?? await _config?.getRoutes();
+    _pages ??=
+        await _client.getInteractiveSections() ?? await _config?.getPages();
   }
 
   Future<void> start() => _client.confirm('/dev/tty1');
@@ -39,7 +39,7 @@ class InstallerService {
   Stream<ApplicationStatus?> monitorStatus() => _client.monitorStatus();
 
   bool hasRoute(String route) {
-    return _routes?.contains(route.removePrefix('/')) ?? true;
+    return _pages?.contains(route.removePrefix('/')) ?? true;
   }
 }
 
@@ -54,7 +54,7 @@ extension ApplicationStatusX on ApplicationStatus {
 }
 
 extension on ConfigService {
-  Future<List<String>?> getRoutes() {
-    return get<List>('routes').then((value) => value?.cast());
+  Future<List<String>?> getPages() {
+    return get<List>('pages').then((value) => value?.cast());
   }
 }

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -321,7 +321,7 @@ void main() {
     verify(activeDirectoryModel.init()).called(1);
   });
 
-  testWidgets('routes', (tester) async {
+  testWidgets('pages', (tester) async {
     final keyboardModel = buildKeyboardModel();
     final confirmModel = buildConfirmModel();
     final identityModel = buildIdentityModel(isValid: true);
@@ -341,7 +341,7 @@ void main() {
               .overrideWith((_) => activeDirectoryModel),
           installModelProvider.overrideWith((_) => installModel),
         ],
-        child: tester.buildTestWizard(routes: [
+        child: tester.buildTestWizard(pages: [
           Routes.keyboard,
           Routes.identity,
           Routes.activeDirectory,
@@ -379,10 +379,10 @@ void main() {
 }
 
 extension on WidgetTester {
-  Widget buildTestWizard({bool? welcome, List<String>? routes}) {
+  Widget buildTestWizard({bool? welcome, List<String>? pages}) {
     final installer = MockInstallerService();
     when(installer.hasRoute(any)).thenAnswer((i) {
-      return routes?.contains(i.positionalArguments.single) ?? true;
+      return pages?.contains(i.positionalArguments.single) ?? true;
     });
     when(installer.monitorStatus()).thenAnswer((_) => const Stream.empty());
     registerMockService<InstallerService>(installer);

--- a/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
@@ -142,14 +142,14 @@ void main() {
     expect(service.hasRoute('c'), isTrue);
   });
 
-  test('configured routes', () async {
+  test('configured pages', () async {
     final client = MockSubiquityClient();
     when(client.getInteractiveSections()).thenAnswer((_) async => null);
     when(client.monitorStatus()).thenAnswer(
         (_) => Stream.value(fakeApplicationStatus(ApplicationState.WAITING)));
 
     final config = MockConfigService();
-    when(config.get('routes')).thenAnswer((_) async => ['a', 'b']);
+    when(config.get('pages')).thenAnswer((_) async => ['a', 'b']);
 
     final service = InstallerService(client, config: config);
     await service.load();

--- a/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
+++ b/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
@@ -60,8 +60,8 @@ void main() {
     await expectLater(windowClosed, completes);
   });
 
-  testWidgets('routes', (tester) async {
-    await tester.runApp(() => app.main(['--routes=locale,keyboard,identity']));
+  testWidgets('pages', (tester) async {
+    await tester.runApp(() => app.main(['--pages=locale,keyboard,identity']));
 
     await tester.testLocalePage();
     await tester.tapNext();

--- a/packages/ubuntu_init/lib/src/init_model.dart
+++ b/packages/ubuntu_init/lib/src/init_model.dart
@@ -20,25 +20,25 @@ class InitModel {
 
   final ConfigService? _config;
   final ArgResults? _args;
-  Set<String>? _routes;
+  Set<String>? _pages;
 
   Future<void> init() async {
-    _routes ??= (await _config?.getRoutes() ?? _args?.getRoutes())
+    _pages ??= (await _config?.getPages() ?? _args?.getPages())
         ?.map((r) => r.removePrefix('/'))
         .toSet();
   }
 
   bool hasRoute(String route) {
-    return _routes?.contains(route.removePrefix('/')) ?? true;
+    return _pages?.contains(route.removePrefix('/')) ?? true;
   }
 }
 
 extension on ConfigService {
-  Future<List<String>?> getRoutes() {
-    return get<List>('routes').then((value) => value?.cast());
+  Future<List<String>?> getPages() {
+    return get<List>('pages').then((value) => value?.cast());
   }
 }
 
 extension on ArgResults {
-  List<String>? getRoutes() => (this['routes'] as String?)?.split(',');
+  List<String>? getPages() => (this['pages'] as String?)?.split(',');
 }

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -26,7 +26,7 @@ Future<void> registerInitServices(List<String> args) {
   if (options == null) {
     options = parseCommandLine(args, onPopulateOptions: (parser) {
       parser.addOption('config', valueHelp: 'path', help: 'Config file path');
-      parser.addOption('routes', hide: true);
+      parser.addOption('pages', hide: true);
     })!;
     registerServiceInstance<ArgResults>(options);
   }

--- a/packages/ubuntu_init/test/init_model_test.dart
+++ b/packages/ubuntu_init/test/init_model_test.dart
@@ -11,20 +11,20 @@ import 'init_model_test.mocks.dart';
 void main() {
   test('init', () async {
     final config = MockConfigService();
-    when(config.get('routes')).thenAnswer((_) async => null);
+    when(config.get('pages')).thenAnswer((_) async => null);
 
     final args = MockArgResults();
-    when(args['routes']).thenReturn(null);
+    when(args['pages']).thenReturn(null);
 
     final model = InitModel(config: config, args: args);
     await model.init();
-    verify(config.get('routes')).called(1);
-    verify(args['routes']).called(1);
+    verify(config.get('pages')).called(1);
+    verify(args['pages']).called(1);
   });
 
   test('has route', () async {
     final config = MockConfigService();
-    when(config.get('routes')).thenAnswer((_) async => ['a', '/b']);
+    when(config.get('pages')).thenAnswer((_) async => ['a', '/b']);
 
     final model = InitModel(config: config);
     await model.init();

--- a/packages/ubuntu_init/test/init_wizard_test.dart
+++ b/packages/ubuntu_init/test/init_wizard_test.dart
@@ -23,11 +23,11 @@ import '../../ubuntu_provision/test/timezone/test_timezone.dart';
 
 import 'init_wizard_test.mocks.dart';
 
-InitModel buildInitModel({List<String>? routes}) {
+InitModel buildInitModel({List<String>? pages}) {
   final model = MockInitModel();
   when(model.hasRoute(any)).thenAnswer((i) {
     final a = i.positionalArguments.single as String;
-    return routes
+    return pages
             ?.map((r) => r.removePrefix('/'))
             .contains(a.removePrefix('/')) ??
         true;
@@ -109,8 +109,8 @@ void main() {
     await expectLater(windowClosed, completes);
   });
 
-  testWidgets('routes', (tester) async {
-    final initModel = buildInitModel(routes: [
+  testWidgets('pages', (tester) async {
+    final initModel = buildInitModel(pages: [
       InitRoutes.locale,
       InitRoutes.keyboard,
       InitRoutes.identity,


### PR DESCRIPTION
The term "page" is more user-friendly and matches with GIS, whereas "route" basically refers to an implementation detail.