### PR TITLE
feat(config): introduce bootstrap & init scopes

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -71,7 +71,8 @@ Future<void> runInstallerApp(
   tryRegisterService<ActiveDirectoryService>(
       () => SubiquityActiveDirectoryService(getService<SubiquityClient>()));
   tryRegisterServiceInstance<ArgResults>(options);
-  tryRegisterService<ConfigService>(() => ConfigService(options['config']));
+  tryRegisterService<ConfigService>(
+      () => ConfigService(scope: 'bootstrap', path: options['config']));
   tryRegisterService<DesktopService>(() => GnomeService());
   tryRegisterServiceFactory<GSettings>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(() => SubiquityIdentityService(

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -32,7 +32,8 @@ Future<void> registerInitServices(List<String> args) {
   }
 
   tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
-  tryRegisterService<ConfigService>(() => ConfigService(options!['config']));
+  tryRegisterService<ConfigService>(
+      () => ConfigService(scope: 'init', path: options!['config']));
   tryRegisterServiceFactory<GSettings>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(XdgIdentityService.new);
   tryRegisterService<KeyboardService>(XdgKeyboardService.new);

--- a/packages/ubuntu_init/test/init_model_test.mocks.dart
+++ b/packages/ubuntu_init/test/init_model_test.mocks.dart
@@ -67,10 +67,15 @@ class MockConfigService extends _i1.Mock implements _i3.ConfigService {
   }
 
   @override
-  _i4.Future<T?> get<T>(String? key) => (super.noSuchMethod(
+  _i4.Future<T?> get<T>(
+    String? key, {
+    String? scope,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #get,
           [key],
+          {#scope: scope},
         ),
         returnValue: _i4.Future<T?>.value(),
       ) as _i4.Future<T?>);

--- a/packages/ubuntu_provision/lib/src/services/config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/config_service.dart
@@ -13,19 +13,25 @@ import 'package:yaml/yaml.dart';
 final log = Logger('config');
 
 class ConfigService {
-  ConfigService(
-    String? path, {
+  ConfigService({
+    String? path,
+    String? scope,
     @visibleForTesting FileSystem fs = const LocalFileSystem(),
-  })  : _path = path ?? lookupPath(fs),
+  })  : _scope = scope,
+        _path = path ?? lookupPath(fs),
         _fs = fs;
 
   final String? _path;
+  final String? _scope;
   final FileSystem _fs;
   Map<String, dynamic>? _config;
 
-  Future<T?> get<T>(String key) async {
+  Future<T?> get<T>(String key, {String? scope}) async {
     _config ??= await load();
-    return _config?[key] as T?;
+    if (scope == null && _scope == null) {
+      return _config?[key] as T?;
+    }
+    return _config?[scope ?? _scope]?[key] as T?;
   }
 
   @visibleForTesting

--- a/packages/ubuntu_provision/test/services/config_service_test.dart
+++ b/packages/ubuntu_provision/test/services/config_service_test.dart
@@ -31,15 +31,7 @@ void main() {
     fs.file('/path/to/foo.yaml')
       ..createSync(recursive: true)
       ..writeAsStringSync('''
-b: true
-i: 123
-d: 123.456
-s: foo
-l:
-  - 1
-  - 2
-  - 3
-o:
+test1:
   b: true
   i: 123
   d: 123.456
@@ -48,9 +40,22 @@ o:
     - 1
     - 2
     - 3
+  o:
+    b: true
+    i: 123
+    d: 123.456
+    s: foo
+    l:
+      - 1
+      - 2
+      - 3
+
+test2:
+  foo: bar
 ''');
 
-    final config = ConfigService('/path/to/foo.yaml', fs: fs);
+    final config =
+        ConfigService(scope: 'test1', path: '/path/to/foo.yaml', fs: fs);
     expect(await config.get('b'), isTrue);
     expect(await config.get('i'), 123);
     expect(await config.get('d'), 123.456);
@@ -63,6 +68,7 @@ o:
       's': 'foo',
       'l': [1, 2, 3],
     });
+    expect(await config.get('foo', scope: 'test2'), 'bar');
   });
 
   test('toml', () async {
@@ -70,15 +76,20 @@ o:
     fs.file('/path/to/foo.toml')
       ..createSync(recursive: true)
       ..writeAsStringSync('''
-b = true
-i = 123
-d = 123.456
-s = "foo"
-l = [1, 2, 3]
-o = { b = true, i = 123, d = 123.456, s = "foo", l = [1, 2, 3] }
+[test1]
+  b = true
+  i = 123
+  d = 123.456
+  s = "foo"
+  l = [1, 2, 3]
+  o = { b = true, i = 123, d = 123.456, s = "foo", l = [1, 2, 3] }
+
+[test2]
+  foo = "bar"
 ''');
 
-    final config = ConfigService('/path/to/foo.toml', fs: fs);
+    final config =
+        ConfigService(scope: 'test1', path: '/path/to/foo.toml', fs: fs);
     expect(await config.get('b'), isTrue);
     expect(await config.get('i'), 123);
     expect(await config.get('d'), 123.456);
@@ -91,6 +102,7 @@ o = { b = true, i = 123, d = 123.456, s = "foo", l = [1, 2, 3] }
       's': 'foo',
       'l': [1, 2, 3],
     });
+    expect(await config.get('foo', scope: 'test2'), 'bar');
   });
 
   test('json', () async {
@@ -99,22 +111,28 @@ o = { b = true, i = 123, d = 123.456, s = "foo", l = [1, 2, 3] }
       ..createSync(recursive: true)
       ..writeAsStringSync('''
 {
-  "b": true,
-  "i": 123,
-  "d": 123.456,
-  "s": "foo",
-  "l": [1, 2, 3],
-  "o": {
+  "test1": {
     "b": true,
     "i": 123,
     "d": 123.456,
     "s": "foo",
-    "l": [1, 2, 3]
+    "l": [1, 2, 3],
+    "o": {
+      "b": true,
+      "i": 123,
+      "d": 123.456,
+      "s": "foo",
+      "l": [1, 2, 3]
+    }
+  },
+  "test2": {
+    "foo": "bar"
   }
 }
 ''');
 
-    final config = ConfigService('/path/to/foo.json', fs: fs);
+    final config =
+        ConfigService(scope: 'test1', path: '/path/to/foo.json', fs: fs);
     expect(await config.get('b'), isTrue);
     expect(await config.get('i'), 123);
     expect(await config.get('d'), 123.456);
@@ -127,5 +145,6 @@ o = { b = true, i = 123, d = 123.456, s = "foo", l = [1, 2, 3] }
       's': 'foo',
       'l': [1, 2, 3],
     });
+    expect(await config.get('foo', scope: 'test2'), 'bar');
   });
 }

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -270,10 +270,15 @@ class MockConfigService extends _i1.Mock implements _i9.ConfigService {
   }
 
   @override
-  _i8.Future<T?> get<T>(String? key) => (super.noSuchMethod(
+  _i8.Future<T?> get<T>(
+    String? key, {
+    String? scope,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #get,
           [key],
+          {#scope: scope},
         ),
         returnValue: _i8.Future<T?>.value(),
       ) as _i8.Future<T?>);


### PR DESCRIPTION
Makes it possible to run different wizard stages with the same config:
```ini
[bootstrap]
pages = ...

[init]
pages = ...
```