### PR TITLE
feat(config): allow apps to ship default config asset

### DIFF
--- a/packages/ubuntu_provision/lib/src/services/config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/config_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
@@ -59,10 +60,18 @@ class ConfigService {
   /// - /etc/ubuntu-provision.{conf,yaml,yml} (admin)
   /// - /usr/local/share/ubuntu-provision.{conf,yaml,yml} (oem)
   /// - /usr/share/ubuntu-provision.{conf,yaml,yml} (distro)
+  /// - <app>/data/flutter_assets/ubuntu-provision.{conf,yaml,yml} (app)
   @visibleForTesting
   static String? lookupPath(FileSystem fs) {
     const exts = ['conf', 'yaml', 'yml'];
-    final dirs = [...xdg.configDirs, fs.directory('/etc'), ...xdg.dataDirs];
+    final assets = p.join(
+        p.dirname(Platform.resolvedExecutable), 'data', 'flutter_assets');
+    final dirs = [
+      ...xdg.configDirs,
+      fs.directory('/etc'),
+      ...xdg.dataDirs,
+      fs.directory(assets),
+    ];
     for (final dir in dirs) {
       for (final ext in exts) {
         final path = p.join(dir.path, 'ubuntu-provision.$ext');

--- a/packages/ubuntu_provision/test/services/config_service_test.dart
+++ b/packages/ubuntu_provision/test/services/config_service_test.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:ubuntu_provision/src/services/config_service.dart';
 
 void main() {
@@ -17,6 +20,8 @@ void main() {
       '/usr/share/ubuntu-provision.conf',
       '/usr/share/ubuntu-provision.yaml',
       '/usr/share/ubuntu-provision.yml',
+      // app
+      '${p.dirname(Platform.resolvedExecutable)}/data/flutter_assets/ubuntu-provision.conf',
     ];
 
     final fs = MemoryFileSystem();


### PR DESCRIPTION
If nothing else is configured on the system, allow specific `ubuntu_bootstrap` or `ubuntu_init` builds to configure which pages they should show by default.