### PR TITLE
fix(config): add missing `assets/` subdir

### DIFF
--- a/packages/ubuntu_provision/lib/src/services/config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/config_service.dart
@@ -64,8 +64,8 @@ class ConfigService {
   @visibleForTesting
   static String? lookupPath(FileSystem fs) {
     const exts = ['conf', 'yaml', 'yml'];
-    final assets = p.join(
-        p.dirname(Platform.resolvedExecutable), 'data', 'flutter_assets');
+    final assets = p.join(p.dirname(Platform.resolvedExecutable), 'data',
+        'flutter_assets', 'assets');
     final dirs = [
       ...xdg.configDirs,
       fs.directory('/etc'),

--- a/packages/ubuntu_provision/test/services/config_service_test.dart
+++ b/packages/ubuntu_provision/test/services/config_service_test.dart
@@ -21,7 +21,7 @@ void main() {
       '/usr/share/ubuntu-provision.yaml',
       '/usr/share/ubuntu-provision.yml',
       // app
-      '${p.dirname(Platform.resolvedExecutable)}/data/flutter_assets/ubuntu-provision.conf',
+      '${p.dirname(Platform.resolvedExecutable)}/data/flutter_assets/assets/ubuntu-provision.conf',
     ];
 
     final fs = MemoryFileSystem();


### PR DESCRIPTION
We'll copy a config file into `assets/` during snapcraft build process. `ubuntu_bootstrap` and `ubuntu_init` will automatically pick it from there as they both have:
```yaml
flutter:
  assets:
    - assets/
```