### PR TITLE
feat(config): allow passing pages as comma-delimited string

### DIFF
--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -54,7 +54,10 @@ extension ApplicationStatusX on ApplicationStatus {
 }
 
 extension on ConfigService {
-  Future<List<String>?> getPages() {
-    return get<List>('pages').then((value) => value?.cast());
+  Future<List<String>?> getPages() async {
+    final value = await get('pages');
+    return (value is List ? value.cast<String>() : value?.toString().split(','))
+        ?.map((p) => p.trim())
+        .toList();
   }
 }

--- a/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
@@ -142,7 +142,7 @@ void main() {
     expect(service.hasRoute('c'), isTrue);
   });
 
-  test('configured pages', () async {
+  test('configured page array', () async {
     final client = MockSubiquityClient();
     when(client.getInteractiveSections()).thenAnswer((_) async => null);
     when(client.monitorStatus()).thenAnswer(
@@ -157,6 +157,23 @@ void main() {
     expect(service.hasRoute('a'), isTrue);
     expect(service.hasRoute('b'), isTrue);
     expect(service.hasRoute('c'), isFalse);
+  });
+
+  test('configured page string', () async {
+    final client = MockSubiquityClient();
+    when(client.getInteractiveSections()).thenAnswer((_) async => null);
+    when(client.monitorStatus()).thenAnswer(
+        (_) => Stream.value(fakeApplicationStatus(ApplicationState.WAITING)));
+
+    final config = MockConfigService();
+    when(config.get('pages')).thenAnswer((_) async => 'c, e');
+
+    final service = InstallerService(client, config: config);
+    await service.load();
+
+    expect(service.hasRoute('c'), isTrue);
+    expect(service.hasRoute('d'), isFalse);
+    expect(service.hasRoute('e'), isTrue);
   });
 
   test('start installation', () async {

--- a/packages/ubuntu_init/lib/src/init_model.dart
+++ b/packages/ubuntu_init/lib/src/init_model.dart
@@ -34,8 +34,11 @@ class InitModel {
 }
 
 extension on ConfigService {
-  Future<List<String>?> getPages() {
-    return get<List>('pages').then((value) => value?.cast());
+  Future<List<String>?> getPages() async {
+    final value = await get('pages');
+    return (value is List ? value.cast<String>() : value?.toString().split(','))
+        ?.map((p) => p.trim())
+        .toList();
   }
 }
 

--- a/packages/ubuntu_init/test/init_model_test.dart
+++ b/packages/ubuntu_init/test/init_model_test.dart
@@ -22,7 +22,7 @@ void main() {
     verify(args['pages']).called(1);
   });
 
-  test('has route', () async {
+  test('configured page array', () async {
     final config = MockConfigService();
     when(config.get('pages')).thenAnswer((_) async => ['a', '/b']);
 
@@ -37,5 +37,17 @@ void main() {
 
     expect(model.hasRoute('c'), isFalse);
     expect(model.hasRoute('/c'), isFalse);
+  });
+
+  test('configured page string', () async {
+    final config = MockConfigService();
+    when(config.get('pages')).thenAnswer((_) async => 'c, e');
+
+    final model = InitModel(config: config);
+    await model.init();
+
+    expect(model.hasRoute('c'), isTrue);
+    expect(model.hasRoute('d'), isFalse);
+    expect(model.hasRoute('e'), isTrue);
   });
 }


### PR DESCRIPTION
Allow "foo,bar" instead of ["foo", "bar"] for convenience.