### PR TITLE
fix(wizard): don't disable the last next/done button

### DIFF
--- a/packages/ubuntu_provision/lib/src/theme/theme_page.dart
+++ b/packages/ubuntu_provision/lib/src/theme/theme_page.dart
@@ -25,7 +25,7 @@ class ThemePage extends ConsumerWidget {
       bottomBar: WizardBar(
         leading: WizardButton.previous(context),
         trailing: [
-          WizardButton.next(context, enabled: true),
+          WizardButton.next(context),
         ],
       ),
       title: YaruWindowTitleBar(

--- a/packages/ubuntu_wizard/lib/src/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_button.dart
@@ -93,7 +93,7 @@ class WizardButton extends StatefulWidget {
                 ? UbuntuLocalizations.of(context).nextLabel
                 : UbuntuLocalizations.of(context).doneLabel),
         visible: visible,
-        enabled: !isLoading && (enabled ?? hasNext),
+        enabled: !isLoading && enabled != false,
         loading: isLoading,
         flat: flat,
         highlighted: highlighted,


### PR DESCRIPTION
No individual pages should have to force-enable Next/Done. Any page could be configured as the last page. It must be possible to click Done to finish the wizard and close the window even if there's no next page route.