### PR TITLE
refactor: ubuntu_provision_test for UDI

### DIFF
--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -3,252 +3,11 @@ import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_bootstrap/ubuntu_bootstrap.dart';
-import 'package:ubuntu_flavor/ubuntu_flavor.dart';
-import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
-import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru_test/yaru_test.dart';
-import 'package:yaru_widgets/yaru_widgets.dart';
 
-extension UbuntuProvisionPageTester on WidgetTester {
-  Future<void> testLocalePage({
-    String? language,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(LocalePage);
-
-    final context = element(find.byType(LocalePage));
-    final l10n = LocaleLocalizations.of(context);
-
-    final flavor = UbuntuFlavor.detect() ?? UbuntuFlavor.ubuntu;
-    expect(find.titleBar(l10n.localePageTitle(flavor.name)), findsOneWidget);
-
-    if (language != null) {
-      final tile = find.listTile(language, skipOffstage: false);
-      await ensureVisible(tile);
-      await pump();
-      await tap(tile);
-      await pump();
-    }
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-    }
-  }
-
-  Future<void> testKeyboardPage({
-    String? layout,
-    String? variant,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(KeyboardPage);
-
-    final context = element(find.byType(KeyboardPage));
-    final l10n = KeyboardLocalizations.of(context);
-
-    expect(find.titleBar(l10n.keyboardTitle), findsOneWidget);
-
-    if (layout != null) {
-      final tile = find.listTile(layout, skipOffstage: false);
-      await ensureVisible(tile.last);
-      await pump();
-      await tap(tile.last);
-      await pump();
-    }
-    if (variant != null) {
-      final tile = find.listTile(variant, skipOffstage: false);
-      await ensureVisible(tile.first);
-      await pump();
-      await tap(tile.first);
-      await pump();
-    }
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-
-      await tapButton(l10n.keyboardDetectButton);
-      await pumpAndSettle();
-
-      await takeScreenshot('$screenshot-detect');
-
-      await tap(find.descendant(
-          of: find.byType(AlertDialog),
-          matching: find.byType(YaruWindowControl)));
-      await pumpAndSettle();
-    }
-  }
-
-  Future<void> testNetworkPage({
-    ConnectMode? mode,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(NetworkPage);
-
-    final context = element(find.byType(NetworkPage));
-    final l10n = NetworkLocalizations.of(context);
-
-    expect(find.titleBar(l10n.networkPageTitle), findsOneWidget);
-
-    if (mode != null) {
-      await tapRadio<ConnectMode>(mode);
-    }
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-    }
-  }
-
-  Future<void> testTimezonePage({
-    String? location,
-    String? timezone,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(TimezonePage);
-
-    final context = element(find.byType(TimezonePage));
-    final l10n = TimezoneLocalizations.of(context);
-
-    expect(find.titleBar(l10n.timezonePageTitle), findsOneWidget);
-
-    if (location != null) {
-      await enterText(
-        find.textField(l10n.timezoneLocationLabel),
-        location,
-      );
-      await pump();
-      await testTextInput.receiveAction(TextInputAction.done);
-      await pump();
-    }
-
-    if (timezone != null) {
-      await enterText(
-        find.textField(l10n.timezoneTimezoneLabel),
-        timezone,
-      );
-      await pump();
-      await testTextInput.receiveAction(TextInputAction.done);
-      await pump();
-    }
-
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-    }
-  }
-
-  Future<void> testIdentityPage({
-    Identity? identity,
-    String? password,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(IdentityPage);
-
-    final context = element(find.byType(IdentityPage));
-    final l10n = IdentityLocalizations.of(context);
-
-    expect(find.titleBar(l10n.identityPageTitle), findsOneWidget);
-
-    if (identity?.realname != null) {
-      await enterText(
-        find.textField(l10n.identityRealNameLabel),
-        identity!.realname,
-      );
-    }
-    if (identity?.hostname != null) {
-      await enterText(
-        find.textField(l10n.identityHostnameLabel),
-        identity!.hostname,
-      );
-    }
-    if (identity?.username != null) {
-      await enterText(
-        find.textField(l10n.identityUsernameLabel),
-        identity!.username,
-      );
-    }
-    if (password != null) {
-      await enterText(
-        find.textField(l10n.identityPasswordLabel),
-        password,
-      );
-      await enterText(
-        find.textField(l10n.identityConfirmPasswordLabel),
-        password,
-      );
-    }
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-    }
-  }
-
-  Future<void> testActiveDirectoryPage({
-    String? domainName,
-    String? adminName,
-    String? password,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(ActiveDirectoryPage);
-
-    final context = element(find.byType(ActiveDirectoryPage));
-    final l10n = ActiveDirectoryLocalizations.of(context);
-
-    expect(find.titleBar(l10n.activeDirectoryTitle), findsOneWidget);
-
-    if (domainName != null) {
-      await enterText(
-        find.textField(l10n.activeDirectoryDomainLabel),
-        domainName,
-      );
-    }
-    if (adminName != null) {
-      await enterText(
-        find.textField(l10n.activeDirectoryAdminLabel),
-        adminName,
-      );
-    }
-    if (password != null) {
-      await enterText(
-        find.textField(l10n.activeDirectoryPasswordLabel),
-        password,
-      );
-    }
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-    }
-  }
-
-  Future<void> testThemePage({
-    Brightness? theme,
-    String? screenshot,
-  }) async {
-    await pumpUntilPage(ThemePage);
-
-    final context = element(find.byType(ThemePage));
-    final l10n = ThemeLocalizations.of(context);
-
-    expect(find.titleBar(l10n.themePageTitle), findsOneWidget);
-
-    if (theme != null) {
-      final asset = find.asset('assets/theme/${theme.name}-theme.png');
-      expect(asset, findsOneWidget);
-      await tap(asset);
-    }
-    await pumpAndSettle();
-
-    if (screenshot != null) {
-      await takeScreenshot(screenshot);
-    }
-  }
-}
+import 'wizard_tester.dart';
 
 extension UbuntuBootstrapPageTester on WidgetTester {
   Future<void> testWelcomePage({
@@ -294,10 +53,6 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot('$screenshot-confirm');
     }
-  }
-
-  Future<void> tapSkip() {
-    return tapButton(find.ul10n((l10n) => l10n.skipLabel));
   }
 
   Future<void> testRefreshPage({
@@ -396,10 +151,6 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (advancedFeature == null && screenshot != null) {
       await takeScreenshot(screenshot);
     }
-  }
-
-  Future<void> tapRestart() {
-    return tapButton(find.ul10n((l10n) => l10n.restartLabel));
   }
 
   Future<void> testBitLockerPage({
@@ -563,11 +314,6 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     }
   }
 
-  Future<void> tapConfirm() {
-    return tapButton(find.l10n(
-        (UbuntuBootstrapLocalizations l10n) => l10n.confirmInstallButton));
-  }
-
   Future<void> testConfirmPage({
     String? screenshot,
   }) async {
@@ -583,16 +329,6 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     }
   }
 
-  Future<void> tapRestartNow() {
-    return tapButton(
-        find.l10n((UbuntuBootstrapLocalizations l10n) => l10n.restartNow));
-  }
-
-  Future<void> tapContinueTesting() {
-    return tapButton(
-        find.l10n((UbuntuBootstrapLocalizations l10n) => l10n.continueTesting));
-  }
-
   Future<void> testInstallPage({
     String? screenshot,
   }) async {
@@ -606,23 +342,5 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     }
 
     await pumpUntil(find.button(l10n.continueTesting));
-  }
-}
-
-extension on WidgetTester {
-  Future<void> pumpUntilPage(Type page) async {
-    await pumpUntil(find.byType(page));
-    await pumpAndSettle();
-  }
-
-  Future<void> takeScreenshot(String screenshot) async {
-    // avoid blinking cursors to keep the screenshots deterministic
-    primaryFocus?.unfocus();
-    await pumpAndSettle();
-
-    await expectLater(
-      find.byType(WizardApp),
-      matchesGoldenFile('screenshots/$screenshot.png'),
-    );
   }
 }

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_flavor/ubuntu_flavor.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
+import 'package:yaru_test/yaru_test.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import 'wizard_tester.dart';
+
+extension UbuntuProvisionPageTester on WidgetTester {
+  Future<void> testLocalePage({
+    String? language,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(LocalePage);
+
+    final context = element(find.byType(LocalePage));
+    final l10n = LocaleLocalizations.of(context);
+
+    final flavor = UbuntuFlavor.detect() ?? UbuntuFlavor.ubuntu;
+    expect(find.titleBar(l10n.localePageTitle(flavor.name)), findsOneWidget);
+
+    if (language != null) {
+      final tile = find.listTile(language, skipOffstage: false);
+      await ensureVisible(tile);
+      await pump();
+      await tap(tile);
+      await pump();
+    }
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+    }
+  }
+
+  Future<void> testKeyboardPage({
+    String? layout,
+    String? variant,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(KeyboardPage);
+
+    final context = element(find.byType(KeyboardPage));
+    final l10n = KeyboardLocalizations.of(context);
+
+    expect(find.titleBar(l10n.keyboardTitle), findsOneWidget);
+
+    if (layout != null) {
+      final tile = find.listTile(layout, skipOffstage: false);
+      await ensureVisible(tile.last);
+      await pump();
+      await tap(tile.last);
+      await pump();
+    }
+    if (variant != null) {
+      final tile = find.listTile(variant, skipOffstage: false);
+      await ensureVisible(tile.first);
+      await pump();
+      await tap(tile.first);
+      await pump();
+    }
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+
+      await tapButton(l10n.keyboardDetectButton);
+      await pumpAndSettle();
+
+      await takeScreenshot('$screenshot-detect');
+
+      await tap(find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.byType(YaruWindowControl)));
+      await pumpAndSettle();
+    }
+  }
+
+  Future<void> testNetworkPage({
+    ConnectMode? mode,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(NetworkPage);
+
+    final context = element(find.byType(NetworkPage));
+    final l10n = NetworkLocalizations.of(context);
+
+    expect(find.titleBar(l10n.networkPageTitle), findsOneWidget);
+
+    if (mode != null) {
+      await tapRadio<ConnectMode>(mode);
+    }
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+    }
+  }
+
+  Future<void> testTimezonePage({
+    String? location,
+    String? timezone,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(TimezonePage);
+
+    final context = element(find.byType(TimezonePage));
+    final l10n = TimezoneLocalizations.of(context);
+
+    expect(find.titleBar(l10n.timezonePageTitle), findsOneWidget);
+
+    if (location != null) {
+      await enterText(
+        find.textField(l10n.timezoneLocationLabel),
+        location,
+      );
+      await pump();
+      await testTextInput.receiveAction(TextInputAction.done);
+      await pump();
+    }
+
+    if (timezone != null) {
+      await enterText(
+        find.textField(l10n.timezoneTimezoneLabel),
+        timezone,
+      );
+      await pump();
+      await testTextInput.receiveAction(TextInputAction.done);
+      await pump();
+    }
+
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+    }
+  }
+
+  Future<void> testIdentityPage({
+    Identity? identity,
+    String? password,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(IdentityPage);
+
+    final context = element(find.byType(IdentityPage));
+    final l10n = IdentityLocalizations.of(context);
+
+    expect(find.titleBar(l10n.identityPageTitle), findsOneWidget);
+
+    if (identity?.realname != null) {
+      await enterText(
+        find.textField(l10n.identityRealNameLabel),
+        identity!.realname,
+      );
+    }
+    if (identity?.hostname != null) {
+      await enterText(
+        find.textField(l10n.identityHostnameLabel),
+        identity!.hostname,
+      );
+    }
+    if (identity?.username != null) {
+      await enterText(
+        find.textField(l10n.identityUsernameLabel),
+        identity!.username,
+      );
+    }
+    if (password != null) {
+      await enterText(
+        find.textField(l10n.identityPasswordLabel),
+        password,
+      );
+      await enterText(
+        find.textField(l10n.identityConfirmPasswordLabel),
+        password,
+      );
+    }
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+    }
+  }
+
+  Future<void> testActiveDirectoryPage({
+    String? domainName,
+    String? adminName,
+    String? password,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(ActiveDirectoryPage);
+
+    final context = element(find.byType(ActiveDirectoryPage));
+    final l10n = ActiveDirectoryLocalizations.of(context);
+
+    expect(find.titleBar(l10n.activeDirectoryTitle), findsOneWidget);
+
+    if (domainName != null) {
+      await enterText(
+        find.textField(l10n.activeDirectoryDomainLabel),
+        domainName,
+      );
+    }
+    if (adminName != null) {
+      await enterText(
+        find.textField(l10n.activeDirectoryAdminLabel),
+        adminName,
+      );
+    }
+    if (password != null) {
+      await enterText(
+        find.textField(l10n.activeDirectoryPasswordLabel),
+        password,
+      );
+    }
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+    }
+  }
+
+  Future<void> testThemePage({
+    Brightness? theme,
+    String? screenshot,
+  }) async {
+    await pumpUntilPage(ThemePage);
+
+    final context = element(find.byType(ThemePage));
+    final l10n = ThemeLocalizations.of(context);
+
+    expect(find.titleBar(l10n.themePageTitle), findsOneWidget);
+
+    if (theme != null) {
+      final asset = find.asset('assets/theme/${theme.name}-theme.png');
+      expect(asset, findsOneWidget);
+      await tap(asset);
+    }
+    await pumpAndSettle();
+
+    if (screenshot != null) {
+      await takeScreenshot(screenshot);
+    }
+  }
+}

--- a/packages/ubuntu_provision_test/lib/src/wizard_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/wizard_tester.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_bootstrap/ubuntu_bootstrap.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru_test/yaru_test.dart';
+
+extension UbuntuWizardTester on WidgetTester {
+  Future<void> tapConfirm() {
+    return tapButton(find.l10n(
+        (UbuntuBootstrapLocalizations l10n) => l10n.confirmInstallButton));
+  }
+
+  Future<void> tapContinueTesting() {
+    return tapButton(
+        find.l10n((UbuntuBootstrapLocalizations l10n) => l10n.continueTesting));
+  }
+
+  Future<void> tapSkip() {
+    return tapButton(find.ul10n((l10n) => l10n.skipLabel));
+  }
+
+  Future<void> tapRestart() {
+    return tapButton(find.ul10n((l10n) => l10n.restartLabel));
+  }
+
+  Future<void> tapRestartNow() {
+    return tapButton(
+        find.l10n((UbuntuBootstrapLocalizations l10n) => l10n.restartNow));
+  }
+
+  Future<void> pumpUntilPage(Type page) async {
+    await pumpUntil(find.byType(page));
+    await pumpAndSettle();
+  }
+
+  Future<void> jumpToPage(String route) async {
+    final context = element(find.byType(WizardPage));
+    Wizard.of(context).jump(route);
+    await pumpUntil(find.byElementPredicate((element) {
+      return Wizard.maybeOf(element)?.controller.currentRoute == route;
+    }));
+    await pumpAndSettle();
+  }
+
+  Future<void> takeScreenshot(String screenshot) async {
+    // avoid blinking cursors to keep the screenshots deterministic
+    primaryFocus?.unfocus();
+    await pumpAndSettle();
+
+    await expectLater(
+      find.byType(WizardApp),
+      matchesGoldenFile('screenshots/$screenshot.png'),
+    );
+  }
+}

--- a/packages/ubuntu_provision_test/lib/ubuntu_provision_test.dart
+++ b/packages/ubuntu_provision_test/lib/ubuntu_provision_test.dart
@@ -1,5 +1,7 @@
 library ubuntu_provision_test;
 
+export 'src/bootstrap_tester.dart';
 export 'src/expect.dart';
 export 'src/fake_init.dart';
-export 'src/page_tester.dart';
+export 'src/provision_tester.dart';
+export 'src/wizard_tester.dart';


### PR DESCRIPTION
Split `page_tester.dart` into smaller pieces and expose more helpers for UDI:
- `bootstrap_tester.dart` with `testXxxPage()` for bootstrap-specific pages
- `provision_tester.dart` with `testXxxPage()` for common provisioning pages
- `wizard_tester.dart` with `tapXxx()` and `takeScreenshot()` etc. helpers (previously unexposed, needed by udi/screenshot_test).
