### PR TITLE
feat: add --dry-run-config CLI argument

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -38,6 +38,8 @@ Future<void> runInstallerApp(
     parser.addFlag('dry-run',
         defaultsTo: Platform.environment['LIVE_RUN'] != '1',
         help: 'Run Subiquity server in dry-run mode');
+    parser.addOption('dry-run-config',
+        valueHelp: 'path', help: 'Path of the dry-run config file');
     parser.addOption('machine-config',
         valueHelp: 'path',
         defaultsTo: 'examples/machines/simple.json',
@@ -114,6 +116,8 @@ Future<void> runInstallerApp(
   tryRegisterService(UrlLauncher.new);
 
   final initialized = getService<SubiquityServer>().start(args: [
+    if (options['dry-run-config'] != null)
+      '--dry-run-config=${options['dry-run-config']}',
     if (options['machine-config'] != null)
       '--machine-config=${options['machine-config']}',
     if (options['source-catalog'] != null)


### PR DESCRIPTION
For example:
```sh
$ ubuntu_bootstrap \
    --source-catalog=examples/sources/tpm.yaml \
    --dry-run-config examples/dry-run-configs/tpm.yaml
```
Manually cherry-picked from [udi/canary-23.10](https://github.com/canonical/ubuntu-desktop-installer/commit/509ac2b7647eecc01eadfb08a8dfcb52c3028e2c).