### PR TITLE
feat(bootstrap): zfs

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/security_key/security_key_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/security_key/security_key_model.dart
@@ -43,7 +43,8 @@ class SecurityKeyModel extends SafeChangeNotifier {
 
   /// Initializes the model.
   Future<bool> init() async {
-    if (_service.guidedCapability != GuidedCapability.LVM_LUKS) {
+    if (_service.guidedCapability != GuidedCapability.LVM_LUKS &&
+        _service.guidedCapability != GuidedCapability.ZFS) {
       return false;
     }
     await loadSecurityKey();

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
@@ -70,13 +70,12 @@ Future<void> showAdvancedFeaturesDialog(
                   ),
                 ),
                 const SizedBox(height: kWizardSpacing),
-                // https://github.com/canonical/ubuntu-desktop-installer/issues/373
-                // YaruRadioButton<AdvancedFeature>(
-                //   title: Text(lang.installationTypeZFS),
-                //   value: AdvancedFeature.zfs,
-                //   groupValue: advancedFeature.value,
-                //   onChanged: (v) => advancedFeature.value = v!,
-                // ),
+                YaruRadioButton<AdvancedFeature>(
+                  title: Text(lang.installationTypeZFS),
+                  value: AdvancedFeature.zfs,
+                  groupValue: advancedFeature.value,
+                  onChanged: (v) => advancedFeature.value = v!,
+                ),
               ],
             );
           },
@@ -108,6 +107,8 @@ extension on GuidedCapability {
       case GuidedCapability.LVM:
       case GuidedCapability.LVM_LUKS:
         return AdvancedFeature.lvm;
+      case GuidedCapability.ZFS:
+        return AdvancedFeature.zfs;
       default:
         return AdvancedFeature.none;
     }
@@ -121,6 +122,8 @@ extension on AdvancedFeature {
         return encryption == true
             ? GuidedCapability.LVM_LUKS
             : GuidedCapability.LVM;
+      case AdvancedFeature.zfs:
+        return GuidedCapability.ZFS;
       default:
         return GuidedCapability.DIRECT;
     }

--- a/packages/ubuntu_bootstrap/test/storage/storage_dialogs_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_dialogs_test.dart
@@ -17,6 +17,10 @@ void main() {
     when(model.existingOS).thenReturn(null);
     when(model.type).thenReturn(StorageType.erase);
     when(model.guidedCapability).thenReturn(null);
+    when(model.canInstallAlongside).thenReturn(false);
+    when(model.canEraseDisk).thenReturn(true);
+    when(model.canManualPartition).thenReturn(true);
+    when(model.hasBitLocker).thenReturn(false);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -43,7 +47,7 @@ void main() {
     await result;
 
     verify(model.guidedCapability = GuidedCapability.ZFS).called(1);
-  }, skip: true); // #373
+  });
 
   testWidgets('select lvm', (tester) async {
     final model = MockStorageModel();

--- a/packages/ubuntu_bootstrap/test/storage/storage_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_page_test.dart
@@ -393,6 +393,16 @@ void main() {
       expect(find.text(l10n.installationTypeLVMEncryptionSelected),
           findsOneWidget);
     });
+
+    testWidgets('zfs selected', (tester) async {
+      final model = buildStorageModel(guidedCapability: GuidedCapability.ZFS);
+      await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+      final context = tester.element(find.byType(StoragePage));
+      final l10n = UbuntuBootstrapLocalizations.of(context);
+
+      expect(find.text(l10n.installationTypeZFSSelected), findsOneWidget);
+    });
   });
 
   testWidgets('no type', (tester) async {

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -138,6 +138,10 @@ extension UbuntuBootstrapPageTester on WidgetTester {
           await pump();
           await tap(find.text(l10n.installationTypeEncrypt('Ubuntu')));
           break;
+        case GuidedCapability.ZFS:
+          await tap(find.text(l10n.installationTypeZFS));
+          await pump();
+          break;
         default:
           break;
       }


### PR DESCRIPTION
Restores the old ZFS selection that has been commented out since 2021, and wires it up with `GuidedCapability.ZFS` recently introduced in Subiquity.

![image](https://github.com/canonical/ubuntu-desktop-provision/assets/140617/75ae58b1-8fcd-4038-b84e-00c29f34bcf7)

Original design: https://people.canonical.com/~platform/desktop/installer/8.%20Installation%20Type/#artboard2

Close: https://github.com/canonical/ubuntu-desktop-installer/issues/417