### PR TITLE
fix: typo in shown command to retrieve recovery key (#2282)

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_model.dart
@@ -2,7 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/services/storage_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
-const kRecoveryKeyCommand = 'snap recovery -show-keys';
+const kRecoveryKeyCommand = 'snap recovery --show-keys';
 
 final recoveryKeyModelProvider = Provider(
   (_) => RecoveryKeyModel(getService<StorageService>()),


### PR DESCRIPTION
Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>
(cherry picked from ubuntu_desktop_installer commit f4c79e57d47acec293ea7d70e78438eb080434b6)

/cc @ogayot 