### PR TITLE
refactor(sysmetrics): move blocking FFI calls into isolates

### DIFF
--- a/packages/sysmetrics/lib/src/sysmetrics.dart
+++ b/packages/sysmetrics/lib/src/sysmetrics.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi' as ffi;
+import 'dart:isolate';
 
 import 'package:ffi/ffi.dart' as ffi;
 
@@ -18,12 +19,14 @@ enum ReportType {
 
 class Sysmetrics {
   // Collect system info and return a pretty printed version of collected data.
-  String? collect() {
-    return ffi.using((arena) {
-      final out = arena<ffi.Pointer<ffi.Char>>();
-      lib.sysmetrics_collect(out);
-      return out.value.toDartString();
-    });
+  Future<String?> collect() {
+    return Isolate.run(
+      () => ffi.using((arena) {
+        final out = arena<ffi.Pointer<ffi.Char>>();
+        lib.sysmetrics_collect(out);
+        return out.value.toDartString();
+      }),
+    );
   }
 
   /// Sends provided metrics data to server.
@@ -31,20 +34,22 @@ class Sysmetrics {
   /// The report will not be sent if a report has already been sent for this
   /// version unless `alwaysReport` is true. If specified, `baseURL` overrides
   /// the server the report is sent to.
-  String? sendReport(
+  Future<String?> sendReport(
     String data, {
     bool alwaysReport = false,
     String baseUrl = '',
   }) {
-    return ffi.using((arena) {
-      return lib
-          .sysmetrics_send_report(
-            data.toCString(arena),
-            alwaysReport.toInt(),
-            baseUrl.toCString(arena),
-          )
-          .toDartString();
-    });
+    return Isolate.run(
+      () => ffi.using((arena) {
+        return lib
+            .sysmetrics_send_report(
+              data.toCString(arena),
+              alwaysReport.toInt(),
+              baseUrl.toCString(arena),
+            )
+            .toDartString();
+      }),
+    );
   }
 
   /// Sends denial message to server.
@@ -52,35 +57,40 @@ class Sysmetrics {
   /// The denial message will not be sent if a report has already been sent for
   /// this version unless `alwaysReport` is true. If specified, `baseURL`
   /// overrides the server the report is sent to.
-  String? sendDecline({bool alwaysReport = false, String baseUrl = ''}) {
-    return ffi.using((arena) {
-      return lib
-          .sysmetrics_send_decline(
-            alwaysReport.toInt(),
-            baseUrl.toCString(arena),
-          )
-          .toDartString();
-    });
+  Future<String?> sendDecline(
+      {bool alwaysReport = false, String baseUrl = ''}) {
+    return Isolate.run(
+      () => ffi.using((arena) {
+        return lib
+            .sysmetrics_send_decline(
+              alwaysReport.toInt(),
+              baseUrl.toCString(arena),
+            )
+            .toDartString();
+      }),
+    );
   }
 
   /// Gather system info and send them.
   ///
   /// The report will not be sent if a report has already been sent for this version unless "alwaysReport" is true.
   /// It can be send to an alternative url via baseURL to send the report to, if not empty
-  String? collectAndSend(
+  Future<String?> collectAndSend(
     ReportType type, {
     bool alwaysReport = false,
     String baseUrl = '',
   }) {
-    return ffi.using((arena) {
-      return lib
-          .sysmetrics_collect_and_send(
-            type.index,
-            alwaysReport.toInt(),
-            baseUrl.toCString(arena),
-          )
-          .toDartString();
-    });
+    return Isolate.run(
+      () => ffi.using((arena) {
+        return lib
+            .sysmetrics_collect_and_send(
+              type.index,
+              alwaysReport.toInt(),
+              baseUrl.toCString(arena),
+            )
+            .toDartString();
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
It takes a significant amount of time to collect the data. Hide the FFI calls into isolates rather than forcing the telemetry view model to do that because it makes the sysmetrics calls non-mockable/verifiable.

[Screencast from 2023-08-08 14-09-47.webm](https://github.com/canonical/ubuntu-desktop-provision/assets/140617/4d39ba62-5785-42e2-b7e8-9aa5056921f6)

Ref: #42 