### PR TITLE
feat(bootstrap): add minimal changes for dd targets

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -90,6 +90,10 @@ class StorageModel extends SafeChangeNotifier {
           c == GuidedCapability.CORE_BOOT_ENCRYPTED ||
           c == GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED));
 
+  /// Whether DD guided storage targets are available.
+  bool get hasDd => _getTargets<GuidedStorageTargetReformat>()
+      .any((t) => t.allowed.contains(GuidedCapability.DD));
+
   /// Whether installation alongside an existing OS is possible.
   ///
   /// That is, whether a) an existing partition can be safely resized smaller to
@@ -101,13 +105,16 @@ class StorageModel extends SafeChangeNotifier {
 
   /// Whether erasing the disk is possible i.e. whether any guided reformat
   /// targets are allowed.
-  bool get canEraseDisk => hasDirect || hasLvm || hasZfs || hasTpm;
+  bool get canEraseDisk => hasDirect || hasLvm || hasZfs || hasTpm || hasDd;
 
   /// Whether manual partitioning is possible i.e. whether a manual partitioning
   /// target is allowed.
   bool get canManualPartition {
     return _getTargets<GuidedStorageTargetManual>().isNotEmpty;
   }
+
+  /// Whether any advanced features are available.
+  bool get hasAdvancedFeatures => hasLvm || hasZfs || hasTpm;
 
   /// Initializes the model.
   Future<void> init() async {

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -95,22 +95,23 @@ class StoragePage extends ConsumerWidget {
                 onChanged: (value) => model.type = value!,
               ),
             ),
-            Padding(
-              padding: kWizardIndentation,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  OutlinedButton(
-                    onPressed: model.type == StorageType.erase
-                        ? () => showAdvancedFeaturesDialog(context, model)
-                        : null,
-                    child: Text(lang.installationTypeAdvancedLabel),
-                  ),
-                  const SizedBox(width: kWizardSpacing),
-                  Text(model.guidedCapability?.localize(lang) ?? ''),
-                ],
+            if (model.hasAdvancedFeatures)
+              Padding(
+                padding: kWizardIndentation,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    OutlinedButton(
+                      onPressed: model.type == StorageType.erase
+                          ? () => showAdvancedFeaturesDialog(context, model)
+                          : null,
+                      child: Text(lang.installationTypeAdvancedLabel),
+                    ),
+                    const SizedBox(width: kWizardSpacing),
+                    Text(model.guidedCapability?.localize(lang) ?? ''),
+                  ],
+                ),
               ),
-            ),
             const SizedBox(height: kWizardSpacing),
           ],
           if (model.canManualPartition)

--- a/packages/ubuntu_bootstrap/test/storage/storage_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_page_test.dart
@@ -403,6 +403,16 @@ void main() {
 
       expect(find.text(l10n.installationTypeZFSSelected), findsOneWidget);
     });
+
+    testWidgets('no advanced features', (tester) async {
+      final model = buildStorageModel(hasAdvancedFeatures: false);
+      await tester.pumpWidget(tester.buildApp((_) => buildPage(model)));
+
+      final context = tester.element(find.byType(StoragePage));
+      final l10n = UbuntuBootstrapLocalizations.of(context);
+
+      expect(find.text(l10n.installationTypeAdvancedLabel), findsNothing);
+    });
   });
 
   testWidgets('no capabilities', (tester) async {

--- a/packages/ubuntu_bootstrap/test/storage/test_storage.dart
+++ b/packages/ubuntu_bootstrap/test/storage/test_storage.dart
@@ -24,11 +24,13 @@ StorageModel buildStorageModel({
   bool? canInstallAlongside,
   bool? canEraseDisk,
   bool? canManualPartition,
+  bool? hasAdvancedFeatures,
   bool? hasBitLocker,
   bool? hasDirect,
   bool? hasLvm,
   bool? hasZfs,
   bool? hasTpm,
+  bool? hasDd,
 }) {
   final model = MockStorageModel();
   when(model.type).thenReturn(type);
@@ -38,10 +40,12 @@ StorageModel buildStorageModel({
   when(model.canInstallAlongside).thenReturn(canInstallAlongside ?? false);
   when(model.canEraseDisk).thenReturn(canEraseDisk ?? true);
   when(model.canManualPartition).thenReturn(canManualPartition ?? true);
+  when(model.hasAdvancedFeatures).thenReturn(hasAdvancedFeatures ?? true);
   when(model.hasBitLocker).thenReturn(hasBitLocker ?? false);
   when(model.hasDirect).thenReturn(hasDirect ?? true);
   when(model.hasLvm).thenReturn(hasLvm ?? true);
   when(model.hasZfs).thenReturn(hasZfs ?? true);
   when(model.hasTpm).thenReturn(hasTpm ?? false);
+  when(model.hasDd).thenReturn(hasDd ?? false);
   return model;
 }

--- a/packages/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
@@ -90,6 +90,11 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
         returnValue: false,
       ) as bool);
   @override
+  bool get hasDd => (super.noSuchMethod(
+        Invocation.getter(#hasDd),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get canInstallAlongside => (super.noSuchMethod(
         Invocation.getter(#canInstallAlongside),
         returnValue: false,
@@ -102,6 +107,11 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
   @override
   bool get canManualPartition => (super.noSuchMethod(
         Invocation.getter(#canManualPartition),
+        returnValue: false,
+      ) as bool);
+  @override
+  bool get hasAdvancedFeatures => (super.noSuchMethod(
+        Invocation.getter(#hasAdvancedFeatures),
         returnValue: false,
       ) as bool);
   @override


### PR DESCRIPTION
DD targets are handled the same way as other reformat targets. Additionally, advanced features are only offered if appropriate.

```
$ ubuntu_bootstrap --source-catalog=examples/sources/core.yaml
```

![image](https://github.com/canonical/ubuntu-desktop-provision/assets/140617/858d3935-034b-4c22-bff4-e4b0d827606f)
