### PR TITLE
test(init): register a fake product for screenshots

### DIFF
--- a/packages/ubuntu_provision_test/lib/src/fake_init.dart
+++ b/packages/ubuntu_provision_test/lib/src/fake_init.dart
@@ -38,7 +38,8 @@ Future<void> registerFakeInitServices({
   registerService<KeyboardService>(() => XdgKeyboardService(bus: client));
   registerService<LocaleService>(() => XdgLocaleService(bus: client));
   registerService<NetworkService>(() => NetworkService(bus: client));
-  registerService<Sysmetrics>(FakeSysmetrics.new);
+  registerService<ProductService>(_FakeProductService.new);
+  registerService<Sysmetrics>(_FakeSysmetrics.new);
   registerService<ThemeService>(() => GtkThemeService(bus: client));
   registerService<TimezoneService>(() => XdgTimezoneService(bus: client));
   addTearDown(resetAllServices);
@@ -338,7 +339,7 @@ class _FakeXdgTimedateObject extends DBusObject {
   }
 }
 
-class FakeSysmetrics implements Sysmetrics {
+class _FakeSysmetrics implements Sysmetrics {
   @override
   Future<String?> collect() async => null;
 
@@ -356,4 +357,13 @@ class FakeSysmetrics implements Sysmetrics {
   Future<String?> sendReport(String data,
           {bool alwaysReport = false, String baseUrl = ''}) async =>
       null;
+}
+
+class _FakeProductService implements ProductService {
+  @override
+  ProductInfo getProductInfo() => ProductInfo(name: 'Ubuntu', version: '23.10');
+
+  @override
+  String getReleaseNotesURL(String languageCode) =>
+      'https://wiki.ubuntu.com/ManticMinotaur/ReleaseNotes';
 }


### PR DESCRIPTION
Make sure `ubuntu_init/screenshot_test` produces stable screenshots. It should not use the actual host product version because it could change from time to time and cause bogus updates:
- https://github.com/canonical/ubuntu-desktop-provision-screenshots/pull/186

[Screencast from 2023-08-09 14-12-45.webm](https://github.com/canonical/ubuntu-desktop-provision/assets/140617/0c40eeaf-4631-4558-993a-512412275098)

With this change, it'll be:

![image](https://github.com/canonical/ubuntu-desktop-provision/assets/140617/1997c269-7153-470c-a127-32f3b883e34b)
