### PR TITLE
feat(init): allow passing app title & l10n delegates to runInitApp()

### DIFF
--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -16,6 +16,8 @@ Future<void> runInitApp(
   String package = 'ubuntu_init',
   ThemeData? theme,
   ThemeData? darkTheme,
+  GenerateAppTitle? onGenerateTitle,
+  Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
 }) async {
   final log = Logger.setup();
 
@@ -33,8 +35,12 @@ Future<void> runInitApp(
         builder: (context, ref, child) => WizardApp(
           theme: theme,
           darkTheme: darkTheme,
+          onGenerateTitle: onGenerateTitle,
           locale: ref.watch(localeProvider),
-          localizationsDelegates: GlobalUbuntuInitLocalizations.delegates,
+          localizationsDelegates: [
+            ...?localizationsDelegates,
+            ...GlobalUbuntuInitLocalizations.delegates,
+          ],
           supportedLocales: supportedLocales,
           home: DefaultAssetBundle(
             bundle: ProxyAssetBundle(rootBundle, package: package),


### PR DESCRIPTION
I missed that `ubuntu-welcome` has its own localized app title that it must pass in to be able to use `runInitApp()`.