### PR TITLE
fix(store): remove can-launch check

### DIFF
--- a/packages/ubuntu_init/lib/src/store/store_model.dart
+++ b/packages/ubuntu_init/lib/src/store/store_model.dart
@@ -16,7 +16,7 @@ class StoreModel extends ChangeNotifier {
 
   final UrlLauncher _launcher;
 
-  Future<bool> init() => _launcher.canLaunchUrl(kStoreUrl);
+  Future<bool> init() async => true;
 
   Future<void> launch() => _launcher.launchUrl(kStoreUrl);
 }

--- a/packages/ubuntu_init/test/store/store_model_test.dart
+++ b/packages/ubuntu_init/test/store/store_model_test.dart
@@ -7,16 +7,10 @@ import 'test_store.dart';
 void main() {
   test('launcher', () async {
     final launcher = MockUrlLauncher();
-    when(launcher.canLaunchUrl(kStoreUrl)).thenAnswer((_) async => true);
     when(launcher.launchUrl(kStoreUrl)).thenAnswer((_) async => true);
 
     final model = StoreModel(launcher);
     expect(await model.init(), isTrue);
-    verify(launcher.canLaunchUrl(kStoreUrl)).called(1);
-
-    when(launcher.canLaunchUrl(kStoreUrl)).thenAnswer((_) async => false);
-    expect(await model.init(), isFalse);
-    verify(launcher.canLaunchUrl(kStoreUrl)).called(1);
 
     await model.launch();
     verify(launcher.launchUrl(kStoreUrl)).called(1);


### PR DESCRIPTION
`canLaunchUrl()` doesn't work from a confined snap even if `launchUrl()` does.