### PR TITLE
feat(flavors): restore the ability to pass flavor data

### DIFF
--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
       ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
+  ubuntu_flavor: ^0.2.0
   ubuntu_localizations: ^0.3.4
   ubuntu_logger: ^0.1.0
   ubuntu_provision:

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
       ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
+  ubuntu_flavor: ^0.2.0
   ubuntu_localizations: ^0.3.3
   ubuntu_logger: ^0.1.0
   ubuntu_provision:

--- a/packages/ubuntu_provision/lib/flavor.dart
+++ b/packages/ubuntu_provision/lib/flavor.dart
@@ -2,4 +2,4 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 
 final flavorProvider =
-    Provider((_) => UbuntuFlavor.detect() ?? UbuntuFlavor.ubuntu);
+    StateProvider((_) => UbuntuFlavor.detect() ?? UbuntuFlavor.ubuntu);

--- a/packages/ubuntu_wizard/lib/src/wizard_app.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
@@ -7,6 +8,7 @@ import 'wizard_theme.dart';
 class WizardApp extends StatelessWidget {
   const WizardApp({
     super.key,
+    this.flavor,
     this.theme,
     this.darkTheme,
     this.onGenerateTitle,
@@ -16,6 +18,7 @@ class WizardApp extends StatelessWidget {
     required this.home,
   });
 
+  final UbuntuFlavor? flavor;
   final ThemeData? theme;
   final ThemeData? darkTheme;
   final GenerateAppTitle? onGenerateTitle;
@@ -35,8 +38,9 @@ class WizardApp extends StatelessWidget {
             YaruWindow.of(context).setTitle(title);
             return title;
           },
-          theme: (theme ?? yaru.theme)?.customize(),
-          darkTheme: (darkTheme ?? yaru.darkTheme)?.customize(),
+          theme: (theme ?? flavor?.theme ?? yaru.theme)?.customize(),
+          darkTheme:
+              (darkTheme ?? flavor?.darkTheme ?? yaru.darkTheme)?.customize(),
           highContrastTheme: yaruHighContrastLight.customize(),
           highContrastDarkTheme: yaruHighContrastDark.customize(),
           debugShowCheckedModeBanner: false,

--- a/packages/ubuntu_wizard/lib/src/wizard_theme.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_theme.dart
@@ -1,6 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
+
+extension WizardFlavorX on UbuntuFlavor {
+  ThemeData? get theme => yaru?.theme;
+  ThemeData? get darkTheme => yaru?.darkTheme;
+
+  YaruVariant? get yaru => switch (this) {
+        UbuntuFlavor.budgie => YaruVariant.ubuntuBudgieBlue,
+        UbuntuFlavor.cinnamon => YaruVariant.ubuntuCinnamonBrown,
+        UbuntuFlavor.kubuntu => YaruVariant.kubuntuBlue,
+        UbuntuFlavor.lubuntu => YaruVariant.lubuntuBlue,
+        UbuntuFlavor.mate => YaruVariant.ubuntuMateGreen,
+        UbuntuFlavor.studio => YaruVariant.ubuntuStudioBlue,
+        UbuntuFlavor.unity => YaruVariant.ubuntuUnityPurple,
+        UbuntuFlavor.xubuntu => YaruVariant.xubuntuBlue,
+        _ => null,
+      };
+}
 
 extension WizardThemeDataX on ThemeData {
   ThemeData customize() {

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  ubuntu_flavor: ^0.2.0
   ubuntu_localizations: ^0.3.3
   ubuntu_widgets: ^0.2.0
   wizard_router: ^1.0.1


### PR DESCRIPTION
Even if [ubuntu_flavor](https://pub.dev/packages/ubuntu_flavor) is able to detect most official Ubuntu flavors, there needs to be a way to pass a specific flavor for being able to:
- lock down a specific flavor regardless of the host platform (ubuntu-xxx-installer should always run as xxx)
- pass an imaginary custom flavor for demoing purposes (ubuntu-flavor-installer)