### PR TITLE
fix: Only show installation sources if there is more than one

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/source/source_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/source/source_page.dart
@@ -23,6 +23,7 @@ class SourcePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final model = ref.watch(sourceModelProvider);
+    final showSources = model.sources.length > 1;
     final lang = UbuntuBootstrapLocalizations.of(context);
     return WizardPage(
       title: YaruWindowTitleBar(
@@ -40,7 +41,7 @@ class SourcePage extends ConsumerWidget {
               .map((source) => Align(
                     alignment: AlignmentDirectional.centerStart,
                     child: Visibility(
-                      visible: model.sources.length > 1,
+                      visible: showSources,
                       child: YaruRadioButton<String>(
                         title: Text(source.localizeTitle(context)),
                         subtitle: Text(source.localizeSubtitle(context)),
@@ -54,7 +55,7 @@ class SourcePage extends ConsumerWidget {
               .withSpacing(kWizardSpacing)
               .toList(),
           Visibility(
-            visible: model.sources.length > 1,
+            visible: showSources,
             child: Padding(
               padding: const EdgeInsets.all(kYaruPagePadding),
               child: Text(lang.otherOptions),

--- a/packages/ubuntu_bootstrap/lib/pages/source/source_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/source/source_page.dart
@@ -39,20 +39,26 @@ class SourcePage extends ConsumerWidget {
           ...model.sources
               .map((source) => Align(
                     alignment: AlignmentDirectional.centerStart,
-                    child: YaruRadioButton<String>(
-                      title: Text(source.localizeTitle(context)),
-                      subtitle: Text(source.localizeSubtitle(context)),
-                      contentPadding: kWizardPadding,
-                      value: source.id,
-                      groupValue: model.sourceId,
-                      onChanged: model.setSourceId,
+                    child: Visibility(
+                      visible: model.sources.length > 1,
+                      child: YaruRadioButton<String>(
+                        title: Text(source.localizeTitle(context)),
+                        subtitle: Text(source.localizeSubtitle(context)),
+                        contentPadding: kWizardPadding,
+                        value: source.id,
+                        groupValue: model.sourceId,
+                        onChanged: model.setSourceId,
+                      ),
                     ),
                   ))
               .withSpacing(kWizardSpacing)
               .toList(),
-          Padding(
-            padding: const EdgeInsets.all(kYaruPagePadding),
-            child: Text(lang.otherOptions),
+          Visibility(
+            visible: model.sources.length > 1,
+            child: Padding(
+              padding: const EdgeInsets.all(kYaruPagePadding),
+              child: Text(lang.otherOptions),
+            ),
           ),
           Align(
             alignment: AlignmentDirectional.centerStart,


### PR DESCRIPTION
Sources are a radio button and it should not be displayed if there is just one source. In this case we go with the default.

closes: https://github.com/canonical/ubuntu-desktop-installer/issues/2305