### PR TITLE
take first capability from allowed as default

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -137,7 +137,6 @@ class StorageModel extends SafeChangeNotifier {
     _storage.guidedCapability ??= _targets
         ?.whereType<GuidedStorageTargetReformat>()
         .expand((t) => t.allowed)
-        .toSet()
         .firstOrNull;
     _hasBitLocker = await _storage.hasBitLocker();
     notifyListeners();


### PR DESCRIPTION
Before https://github.com/canonical/subiquity/pull/1774 the order of the capabilities in `allowed` was arbitrary, resulting in https://bugs.launchpad.net/ubuntu-desktop-installer/+bug/2033093 and other confusing behaviour. The subiquity PR puts the capability that should be considered the default first, so that's what the client side code should do too.