### PR TITLE
fix: DBus SetPassword method expects a crypted pass 

### DIFF
--- a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
@@ -1,3 +1,4 @@
+import 'package:crypt/crypt.dart';
 import 'package:dbus/dbus.dart';
 import 'package:stdlibc/stdlibc.dart';
 import 'package:ubuntu_provision/services.dart';
@@ -108,7 +109,7 @@ class XdgIdentityService implements IdentityService {
     await userObject.callMethod(
       'org.freedesktop.Accounts.User',
       'SetPassword',
-      [DBusString(_identity!.password), const DBusString('')],
+      [DBusString(Crypt.sha512(_identity!.password).toString()), const DBusString('')],
       replySignature: DBusSignature.empty,
     );
     await userObject.callMethod(

--- a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
@@ -109,7 +109,12 @@ class XdgIdentityService implements IdentityService {
     await userObject.callMethod(
       'org.freedesktop.Accounts.User',
       'SetPassword',
-      [DBusString(Crypt.sha512(_identity!.password).toString()), const DBusString('')],
+      [
+        DBusString(
+          Crypt.sha512(_identity!.password, salt: _passwordSalt).toString(),
+        ),
+        const DBusString(''),
+      ],
       replySignature: DBusSignature.empty,
     );
     await userObject.callMethod(

--- a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
@@ -1,20 +1,27 @@
 import 'package:crypt/crypt.dart';
 import 'package:dbus/dbus.dart';
+import 'package:meta/meta.dart';
 import 'package:stdlibc/stdlibc.dart';
 import 'package:ubuntu_provision/services.dart';
 
 class XdgIdentityService implements IdentityService {
-  XdgIdentityService({DBusClient? bus})
+  XdgIdentityService({DBusClient? bus, @visibleForTesting String? passwordSalt})
       : _client = bus ?? DBusClient.system(),
+        _passwordSalt = passwordSalt,
         _userId = getuid();
 
-  XdgIdentityService.uid(this._userId, {DBusClient? bus})
-      : _client = bus ?? DBusClient.system();
+  XdgIdentityService.uid(
+    this._userId, {
+    DBusClient? bus,
+    @visibleForTesting passwordSalt,
+  })  : _client = bus ?? DBusClient.system(),
+        _passwordSalt = passwordSalt;
 
   static const _defaultUserId = 1000;
 
   final DBusClient _client;
   final int _userId;
+  final String? _passwordSalt;
   Identity? _identity;
 
   DBusRemoteObject get _accountObject => DBusRemoteObject(

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   args: ^2.2.0
   collection: ^1.17.0
+  crypt: ^4.3.0
   dartx: ^1.0.0
   dbus: ^0.7.3
   flutter:

--- a/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
+++ b/packages/ubuntu_init/test/services/xdg_identity_service_test.dart
@@ -30,7 +30,8 @@ void main() {
 
   test('apply', () async {
     final client = createMockDBusClient();
-    final service = XdgIdentityService.uid(0, bus: client);
+    final service =
+        XdgIdentityService.uid(0, bus: client, passwordSalt: 'testsalt');
     await service.setIdentity(testIdentity.copyWith(password: 'password'));
 
     verify(client.callMethod(
@@ -55,7 +56,8 @@ void main() {
       interface: 'org.freedesktop.Accounts.User',
       name: 'SetPassword',
       values: [
-        const DBusString('password'),
+        const DBusString(
+            '\$6\$testsalt\$n5m85kZD9QCuizzEg/zol4HTaQ7qa9Z009rBoYAQaxBOhwiJwJsjgcZs2mwYMElypap3uDPrmdOPlLy4S28M5.'),
         const DBusString(''),
       ],
       replySignature: DBusSignature.empty,


### PR DESCRIPTION
The method org.freedesktop.Accounts.User.SetPassword expects a crypted password as its first parameter. Unfortunately, the current code is sending the password in plain text. That plain text password is being stored as-is in the 'shadow' file, and that prevents ubuntu-core-desktop-init to work on core desktop, because the created user has an invalid password field.

This patch fixes it.