### PR TITLE
feat: mark network configured on ConfirmPage

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_model.dart
@@ -2,17 +2,21 @@ import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_bootstrap/services.dart';
+import 'package:ubuntu_provision/services.dart';
 
-final confirmModelProvider = ChangeNotifierProvider((_) =>
-    ConfirmModel(getService<InstallerService>(), getService<StorageService>()));
+final confirmModelProvider = ChangeNotifierProvider(
+  (_) => ConfirmModel(getService<InstallerService>(),
+      getService<StorageService>(), getService<NetworkService>()),
+);
 
 /// View model for [ConfirmPage].
 class ConfirmModel extends SafeChangeNotifier {
   /// Creates a model with the given installer and storage services.
-  ConfirmModel(this._installer, this._storage);
+  ConfirmModel(this._installer, this._storage, this._network);
 
   final InstallerService _installer;
   final StorageService _storage;
+  final NetworkService _network;
   List<Disk>? _disks;
   Map<String, List<Partition>>? _partitions;
   Map<String, List<Partition>>? _originals;
@@ -46,6 +50,8 @@ class ConfirmModel extends SafeChangeNotifier {
     _storage.securityKey = null; // no longer needed
     await _installer.start();
   }
+
+  Future<void> markNetworkConfigured() => _network.markConfigured();
 
   void _updateDisks(List<Disk> disks) {
     bool isPartitionModified(Partition p) {

--- a/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -118,8 +118,9 @@ class ConfirmPage extends ConsumerWidget {
             label: lang.confirmInstallButton,
             onNext: () {
               // start installation after the page transition (#1393)
-              Future.delayed(kThemeAnimationDuration).then((_) {
-                model.startInstallation();
+              Future.delayed(kThemeAnimationDuration).then((_) async {
+                await model.markNetworkConfigured();
+                await model.startInstallation();
               });
             },
           ),

--- a/packages/ubuntu_bootstrap/test/confirm/confirm_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/confirm/confirm_model_test.dart
@@ -58,11 +58,12 @@ void main() {
   test('get storage', () async {
     final installer = MockInstallerService();
     final storage = MockStorageService();
+    final network = MockNetworkService();
     when(storage.guidedTarget).thenReturn(null);
     when(storage.getStorage()).thenAnswer((_) async => testDisks);
     when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
 
-    final model = ConfirmModel(installer, storage);
+    final model = ConfirmModel(installer, storage, network);
     await model.init();
     verifyInOrder([
       storage.getStorage(),
@@ -95,13 +96,14 @@ void main() {
 
     final installer = MockInstallerService();
     final storage = MockStorageService();
+    final network = MockNetworkService();
     when(storage.guidedTarget).thenReturn(target);
     when(storage.getStorage()).thenAnswer((_) async => testDisks);
     when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
     when(storage.setGuidedStorage())
         .thenAnswer((_) async => fakeGuidedStorageResponse());
 
-    final model = ConfirmModel(installer, storage);
+    final model = ConfirmModel(installer, storage, network);
     await model.init();
     verify(storage.setGuidedStorage()).called(1);
   });
@@ -109,17 +111,34 @@ void main() {
   test('start installation', () async {
     final installer = MockInstallerService();
     final storage = MockStorageService();
+    final network = MockNetworkService();
     when(storage.guidedTarget).thenReturn(null);
     when(storage.getStorage()).thenAnswer((_) async => testDisks);
     when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
     when(storage.setStorage()).thenAnswer((_) async => modifiedDisks);
 
-    final model = ConfirmModel(installer, storage);
+    final model = ConfirmModel(installer, storage, network);
     await model.init();
     await model.startInstallation();
 
     verifyNever(storage.setStorage());
     verify(storage.securityKey = null).called(1);
     verify(installer.start()).called(1);
+  });
+
+  test('mark network configured', () async {
+    final installer = MockInstallerService();
+    final storage = MockStorageService();
+    final network = MockNetworkService();
+    when(storage.guidedTarget).thenReturn(null);
+    when(storage.getStorage()).thenAnswer((_) async => testDisks);
+    when(storage.getOriginalStorage()).thenAnswer((_) async => testDisks);
+    when(storage.setStorage()).thenAnswer((_) async => modifiedDisks);
+
+    final model = ConfirmModel(installer, storage, network);
+    await model.init();
+    await model.markNetworkConfigured();
+
+    verify(network.markConfigured()).called(1);
   });
 }

--- a/packages/ubuntu_bootstrap/test/confirm/confirm_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/confirm/confirm_page_test.dart
@@ -131,6 +131,7 @@ void main() {
     verifyNever(model.startInstallation());
 
     await tester.pumpAndSettle(kThemeAnimationDuration);
+    verify(model.markNetworkConfigured()).called(1);
     verify(model.startInstallation()).called(1);
   });
 }

--- a/packages/ubuntu_bootstrap/test/confirm/test_confirm.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/confirm/test_confirm.mocks.dart
@@ -80,6 +80,15 @@ class MockConfirmModel extends _i1.Mock implements _i2.ConfirmModel {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
+  _i4.Future<void> markNetworkConfigured() => (super.noSuchMethod(
+        Invocation.method(
+          #markNetworkConfigured,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+  @override
   void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,

--- a/packages/ubuntu_provision/lib/src/network/network_model.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_model.dart
@@ -103,8 +103,6 @@ class NetworkModel extends SafeChangeNotifier implements ConnectModel {
     }
   }
 
-  Future<void> markConfigured() => _service.markConfigured();
-
   @override
   Future<void> cleanup() async {
     for (final model in _connectModels.values) {

--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -89,11 +89,8 @@ class NetworkPage extends ConsumerWidget {
             enabled:
                 model.isEnabled && !model.isConnecting && model.isConnected,
             visible: !model.isEnabled || !model.canConnect,
-            onNext: () => Future.wait([
-              // suspend network activity when proceeding on the next page
-              model.cleanup(),
-              model.markConfigured(),
-            ]),
+            // suspend network activity when proceeding on the next page
+            onNext: model.cleanup,
             // resume network activity if/when returning back to this page
             onBack: model.init,
           ),

--- a/packages/ubuntu_provision/test/network/network_model_test.dart
+++ b/packages/ubuntu_provision/test/network/network_model_test.dart
@@ -235,11 +235,4 @@ void main() {
     model.selectConnectMode();
     expect(model.connectMode, equals(ConnectMode.wifi));
   });
-
-  test('mark network configured', () async {
-    final service = MockNetworkService();
-    final model = NetworkModel(service);
-    await model.markConfigured();
-    verify(service.markConfigured()).called(1);
-  });
 }

--- a/packages/ubuntu_provision/test/network/network_page_test.dart
+++ b/packages/ubuntu_provision/test/network/network_page_test.dart
@@ -169,7 +169,5 @@ void main() {
 
     await tester.tapNext();
     await tester.pumpAndSettle();
-
-    verify(model.markConfigured()).called(1);
   });
 }

--- a/packages/ubuntu_provision/test/network/test_network.mocks.dart
+++ b/packages/ubuntu_provision/test/network/test_network.mocks.dart
@@ -313,15 +313,6 @@ class MockNetworkModel extends _i1.Mock implements _i8.NetworkModel {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
-  _i6.Future<void> markConfigured() => (super.noSuchMethod(
-        Invocation.method(
-          #markConfigured,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-  @override
   _i6.Future<void> cleanup() => (super.noSuchMethod(
         Invocation.method(
           #cleanup,


### PR DESCRIPTION
Moves the call to the network service's `markConfigured()` from the NetworkPage to the ConfirmPage in order to resolve https://bugs.launchpad.net/subiquity/+bug/2017278 .