### PR TITLE
fix(logging): specify path to log file, not directory

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -57,7 +57,9 @@ Future<void> runInstallerApp(
         valueHelp: 'path', help: 'A comma-separated list of pages', hide: true);
   })!;
   final liveRun = options['dry-run'] != true;
-  final log = Logger.setup(path: liveRun ? '/var/log/installer' : null);
+  final exe = p.basename(Platform.resolvedExecutable);
+  final log =
+      Logger.setup(path: liveRun ? '/var/log/installer/$exe.log' : null);
 
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
   final subiquityPath = await getSubiquityPath()


### PR DESCRIPTION
UDENG-1423
Fix https://github.com/canonical/ubuntu-desktop-installer/issues/2342.

The `path` parameter in `Logger.setup()` from `ubuntu_logger` is supposed to be the path to the actual log file, not the directory containing it. 