### PR TITLE
feat(slides): update accessibility slide

### DIFF
--- a/packages/ubuntu_bootstrap/lib/slides/default_slides.dart
+++ b/packages/ubuntu_bootstrap/lib/slides/default_slides.dart
@@ -293,17 +293,20 @@ Widget _buildAccessibilitySlide(BuildContext context) {
       rows: [
         [
           Text(lang.installationSlidesIncluded),
-          const SlideLabel(
-            icon: _SlideIcon('writer.png'),
-            label: Text('LibreOffice Writer'),
+          SlideLabel(
+            icon: const _SlideIcon('languages.png'),
+            label: Text(lang.installationSlidesAccessibilityLanguages),
           ),
           SlideLabel(
             icon: const _SlideIcon('orca.png'),
             label: Text(lang.installationSlidesAccessibilityOrca),
           ),
-          SlideLabel(
-            icon: const _SlideIcon('languages.png'),
-            label: Text(lang.installationSlidesAccessibilityLanguages),
+        ],
+        [
+          Text(lang.installationSlidesAvailable),
+          const SlideLabel(
+            icon: _SlideIcon('writer.png'),
+            label: Text('LibreOffice Writer'),
           ),
         ],
       ],


### PR DESCRIPTION
* Lists LibreOffice Writer as 'available' instead of 'included'
* Moves Language Support and Orca Screen Reader to the first row
![image](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/eb3d80e4-4015-4789-829d-8a4889944d7b)
