### PR TITLE
fix(test): add missing MockNetworkService

### DIFF
--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -155,7 +155,9 @@ Future<void> main() async {
   }, variant: themeVariant);
 
   testWidgets('06.storage-advanced-features', (tester) async {
-    await tester.runApp(() => runInstallerApp([], theme: currentTheme));
+    await tester.runApp(() => runInstallerApp([
+          '--dry-run-config=examples/dry-run-configs/tpm.yaml',
+        ], theme: currentTheme));
     await tester.pumpAndSettle();
 
     await tester.jumpToStorageWizard();

--- a/packages/ubuntu_bootstrap/test/installer_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_test.dart
@@ -131,6 +131,7 @@ extension on WidgetTester {
     registerMockService<StorageService>(StorageService(MockSubiquityClient()));
     registerMockService<SubiquityClient>(MockSubiquityClient());
     registerMockService<TelemetryService>(MockTelemetryService());
+    registerMockService<NetworkService>(MockNetworkService());
 
     return ProviderScope(
       child: SlidesContext(

--- a/packages/ubuntu_bootstrap/test/installer_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_test.dart
@@ -86,6 +86,7 @@ void main() {
       '--machine-config=examples/machines/simple.json',
       '--source-catalog=examples/sources/desktop.yaml',
       '--storage-version=2',
+      '--dry-run-config=examples/dry-run-configs/tpm.yaml',
       '--foo',
       'bar',
     ])).called(1);


### PR DESCRIPTION
I noticed that #131 introduced a test failure due to a missing mock for the `NetworkService`