### PR TITLE
fix(ci): semi-automated autoinstall test

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -118,10 +118,9 @@ class ConfirmPage extends ConsumerWidget {
             label: lang.confirmInstallButton,
             onNext: () {
               // start installation after the page transition (#1393)
-              Future.delayed(kThemeAnimationDuration).then((_) async {
-                await model.markNetworkConfigured();
-                await model.startInstallation();
-              });
+              model.markNetworkConfigured().then((_) =>
+                  Future.delayed(kThemeAnimationDuration)
+                      .then((_) => model.startInstallation()));
             },
           ),
         ],


### PR DESCRIPTION
This seems to fix the recent issues with semi-automated autoinstall test, which were presumably caused by #131.

I haven't had the time to debug this locally so I can't provide any subiquity logs yet. Giving subiquity some time between marking the network configured and starting the installation resolves the current problem, but this might mask an underlying issue that we should investigate (I'd open a separate issue if we decide to accept this as a fix for now).