### PR TITLE
chore: Pin Flutter and SDK version to 3.10.6/3.0.6

### DIFF
--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -3,8 +3,8 @@ description: Ubuntu Bootstrap
 publish_to: 'none'
 
 environment:
-  sdk: '^3.0.6'
-  flutter: '^3.10.6'
+  sdk: '3.0.6'
+  flutter: '3.10.6'
 
 dependencies:
   args: ^2.2.0

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -3,8 +3,8 @@ description: Ubuntu Init
 publish_to: 'none'
 
 environment:
-  sdk: '^3.0.6'
-  flutter: '^3.10.6'
+  sdk: '3.0.6'
+  flutter: '3.10.6'
 
 dependencies:
   args: ^2.2.0

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -3,8 +3,8 @@ description: Shared package for Ubuntu provision.
 publish_to: 'none'
 
 environment:
-  sdk: '^3.0.6'
-  flutter: '^3.10.6'
+  sdk: '3.0.6'
+  flutter: '3.10.6'
 
 dependencies:
   args: ^2.2.0

--- a/packages/ubuntu_utils/pubspec.yaml
+++ b/packages/ubuntu_utils/pubspec.yaml
@@ -3,8 +3,8 @@ description: Shared library for Ubuntu wizards.
 publish_to: 'none'
 
 environment:
-  sdk: '^3.0.6'
-  flutter: '^3.10.6'
+  sdk: '3.0.6'
+  flutter: '3.10.6'
 
 dependencies:
   args: ^2.2.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -3,8 +3,8 @@ description: Shared library for Ubuntu wizards.
 publish_to: 'none'
 
 environment:
-  sdk: '^3.0.6'
-  flutter: '^3.10.6'
+  sdk: '3.0.6'
+  flutter: '3.10.6'
 
 dependencies:
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,5 +330,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=3.0.6 <4.0.0"
+  dart: "3.0.6"
   flutter: ">=3.10.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: ubuntu_desktop_provision
 
 environment:
-  sdk: '^3.0.6'
-  flutter: '^3.10.6'
+  sdk: '3.0.6'
+  flutter: '3.10.6'
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
Since the Flutter version 3.10.6 should be used until the Ubuntu LTS version is released I suggest that we pin the version until then.