### PR TITLE
Add correct end page for the Core Desktop installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ The configuration file has the following structure:
 # Options:
 # - standard (default): the common provision flow for Ubuntu Desktop and Flavours
 # - oem: enables the eula page and disables the user creation page during bootstrap
-mode: standard | oem
+# - core-desktop: disables exiting the installer at the end (because there is no
+#   live session), and only allows to reboot
+mode: standard | oem | core-desktop
 
 # (Optional) When set, the light and dark theme is inherited from ubuntu-flutter-plugins and the distro name is set.
 #

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -492,6 +492,13 @@
       "system": {}
     }
   },
+  "rebootToConfigure": "**{system}** has been copied to the disk",
+  "@rebootToConfigure": {
+    "type": "text",
+    "placeholders": {
+      "system": {}
+    }
+  },
   "restartInto": "Restart into {system}",
   "@restartInto": {
     "type": "text",
@@ -506,6 +513,8 @@
       "RELEASE": {}
     }
   },
+  "rebootToConfigureWarning": "You have to restart the computer to continue the installation process.",
+  "@rebootToConfigureWarning": {},
   "shutdown": "Shut Down",
   "@shutdown": {},
   "restartNow": "Restart now",

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -1101,6 +1101,12 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'**{system}** is installed and ready to use'**
   String readyToUse(Object system);
 
+  /// No description provided for @rebootToConfigure.
+  ///
+  /// In en, this message translates to:
+  /// **'**{system}** has been copied to the disk'**
+  String rebootToConfigure(Object system);
+
   /// No description provided for @restartInto.
   ///
   /// In en, this message translates to:
@@ -1112,6 +1118,12 @@ abstract class UbuntuBootstrapLocalizations {
   /// In en, this message translates to:
   /// **'You can continue testing {RELEASE} now, but until you restart the computer, any changes you make or documents you save will not be preserved.'**
   String restartWarning(Object RELEASE);
+
+  /// No description provided for @rebootToConfigureWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'You have to restart the computer to continue the installation process.'**
+  String get rebootToConfigureWarning;
 
   /// No description provided for @shutdown.
   ///

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Atura';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restartovat do $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Nyní můžete pokračovat ve zkoušení $RELEASE, ale dokud počítač nerestartujete, veškeré provedené změny nebo vytvořené dokumenty nebudou zachovány.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Vypnout';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Genstart i $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Du kan fortsat afprøve $RELEASE nu, men indtil du genstarter computeren, vil ingen ændringer du foretager, eller dokumenter du gemmer, blive bevaret.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Luk Ned';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Neustart unter $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Sie können $RELEASE jetzt weiter ausprobieren, aber alle Änderungen, die Sie bis zu einem Neustart des Systems durchführen, werden nicht gespeichert.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Herunterfahren';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restartigi al $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Vi povas daŭre elprovi $RELEASE, sed kiam la komputilo restartos, forĵetiĝos ĉiuj ŝanĝoj farotaj de vi kaj dokumentoj konservotaj de vi.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Malŝalti';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Reiniciar en $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Puede continuar probando $RELEASE ahora, pero hasta que reinicie el equipo, los cambios que realice o los documentos que guarde no se conservarán.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Apagar';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'آغاز دوباره به $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'اکنون می‌توانید به آزمودن $RELEASE ادامه دهید؛ ولی تا زمانی که رایانه را دوباره آغاز کنید، هر تغییری یا سندی که ایجاد کنید حفظ نخواهد شد.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'خاموش کردن';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Käynnistä uudelleen käyttöjärjestelmään \"$system\"';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Voit jatkaa julkaisun $RELEASE testaamista nyt, mutta mitkään tekemäsi muutokset tai tallentamasi asiakirjat eivät säily, ennen kuin käynnistät tietokoneen uudelleen.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Sammuta';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Redémarrer sous $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Vous pouvez maintenant continuer à tester $RELEASE, mais tant que vous n’aurez pas redémarré votre ordinateur, les changements effectués ou les documents créés ne seront pas préservés.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Éteindre';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'הפעלה מחדש אל $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'אפשר להמשיך לבחון את $RELEASE כעת אבל רק עד הפעלת המחשב מחדש, השינויים שייערכו למסמכים לא יישמרו.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'כיבוי';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Újraindítás és $system használata';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Most folytathatja a(z) $RELEASE kipróbálását, de amíg nem indítja újra a számítógépet, addig semmilyen elvégzett változtatás vagy elmentett dokumentum nem lesz megtartva.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Leállítás';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Mulai ulang ke $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Matikan';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return '再起動して $system を使い始める';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'このまま $RELEASE の試用を続けることもできますが、コンピューターを再起動するまでは、なにか変更を行ったり文書を保存してもデータは残りません。';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'シャットダウン';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return '$system (으)로 다시 시작';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return '$RELEASE을(를) 계속 사용할 수 있습니다. 하지만 컴퓨터를 다시 시작하지 않으면 바뀐 내용이나 저장한 문서를 잃게 됩니다.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => '시스템 종료';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Paleisti iš naujo į $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Galite toliau bandyti $RELEASE, tačiau, kol nepaleisite kompiuterio iš naujo, tol jokie atlikti pakeitimai bei sukurti ar atsiųsti dokumentai (failai) nebus išsaugoti.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Išjungti';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return '$system-ലേക്ക് റീസ്റ്റാർട്ട് ചെയ്യുക';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'ഷട്ട് ഡൗൺ';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Start om igjen til $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Du kan fortsette å teste $RELEASE, men før du starter datamaskinen på ny vil ingen endringer du gjør eller dokumenter du lagrer bevares.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Slå av';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Reaviar jos $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Podètz téner d’ensajar $RELEASE ara, mas fins que reavietz l’ordenador, tota modificacion o document que creatz serà pas servat.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Atudar';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Uruchom ponownie do $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Możesz teraz kontynuować testowanie wersji $RELEASE, ale dopóki nie uruchomisz ponownie komputera, wszelkie wprowadzone zmiany lub zapisane dokumenty nie zostaną zachowane.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Zamknij';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Reiniciar no $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Pode continuar a testar o $RELEASE agora, mas até reiniciar o computador, quaisquer alterações que faça ou documentos que guarde não serão preservados.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Desligar';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Перезагрузка в $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Можете продолжить тестирование $RELEASE, но при перезагрузке компьютера все внесённые вами изменения или сохранённые документы будут потеряны.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Отключить';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return '$system වෙත යළි අරඹන්න';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'ඔබට දැන් දිගටම $RELEASE අත්හදා බැලීමට හැකිය, නමුත් පරිගණකය යළි ආරම්භ කරන තුරු ඔබ සුරකින ලේඛන හෝ සිදුකරන වෙනස්කම් රැඳෙන්නේ නැත.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'වසා දමන්න';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Reštartovať do $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Teraz môžete pokračovať v skúšaní $RELEASE, ale pokiaľ počítač nereštartujete, všetky vykonané zmeny alebo vytvorené dokumenty nebudú zachované.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Vypnúť';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Ndalo punën';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Starta om till $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Du kan fortsätta att testa $RELEASE nu, men tills du startar om datorn kommer alla ändringar du gör eller dokument du sparar inte att bevaras.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Stäng av';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return '$system ile yeniden başlat';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'Şimdi $RELEASE test etmeye devam edebilirsiniz, ancak bilgisayarı yeniden başlatana kadar yaptığınız değişiklikler ya da kaydettiğiniz belgeler korunmayacaktır.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Kapat';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Перезавантажитися в $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Вимкнути';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return 'Restart into $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return 'You can continue testing $RELEASE now, but until you restart the computer, any changes you make or documents you save will not be preserved.';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => 'Shut Down';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -513,6 +513,11 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String rebootToConfigure(Object system) {
+    return '**$system** has been copied to the disk';
+  }
+
+  @override
   String restartInto(Object system) {
     return '重启进入 $system';
   }
@@ -521,6 +526,9 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String restartWarning(Object RELEASE) {
     return '您现在可以继续测试 $RELEASE，但在重新启动计算机之前，您所做的任何更改或保存的文档都不会被保留。';
   }
+
+  @override
+  String get rebootToConfigureWarning => 'You have to restart the computer to continue the installation process.';
 
   @override
   String get shutdown => '关机';

--- a/packages/ubuntu_bootstrap/lib/pages/install/install_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/install/install_page.dart
@@ -188,6 +188,9 @@ class _DonePage extends ConsumerWidget {
     final flavor = ref.watch(flavorProvider);
     final lang = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(installModelProvider);
+    final isCoreDesktop =
+        model.provisioningMode == ProvisioningMode.coreDesktop;
+
     return WizardPage(
       headerPadding: EdgeInsets.zero,
       contentPadding: EdgeInsets.zero,
@@ -206,13 +209,17 @@ class _DonePage extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 MarkdownBody(
-                  data: lang.readyToUse(model.productInfo),
+                  data: isCoreDesktop
+                      ? lang.rebootToConfigure(model.productInfo)
+                      : lang.readyToUse(model.productInfo),
                   styleSheet: MarkdownStyleSheet(
                     p: Theme.of(context).textTheme.titleLarge,
                   ),
                 ),
                 const SizedBox(height: kWizardSpacing * 1.5),
-                Text(lang.restartWarning(flavor.displayName)),
+                Text(isCoreDesktop
+                    ? lang.rebootToConfigureWarning
+                    : lang.restartWarning(flavor.displayName)),
                 const SizedBox(height: kWizardSpacing * 1.5),
                 Row(
                   children: [
@@ -226,12 +233,13 @@ class _DonePage extends ConsumerWidget {
                       ),
                     ),
                     const SizedBox(width: kWizardSpacing),
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed: YaruWindow.of(context).close,
-                        child: Text(lang.continueTesting),
+                    if (!isCoreDesktop)
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: YaruWindow.of(context).close,
+                          child: Text(lang.continueTesting),
+                        ),
                       ),
-                    ),
                   ],
                 ),
               ],

--- a/packages/ubuntu_bootstrap/test/install/install_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/install/install_model_test.dart
@@ -22,6 +22,7 @@ void main() async {
       MockJournalService(),
       product,
       MockSessionService(),
+      MockConfigService(),
     );
     expect(model.productInfo.name, 'Ubuntu');
     expect(model.productInfo.version, '24.04 LTS');
@@ -36,7 +37,10 @@ void main() async {
         .thenAnswer((_) => const Stream.empty());
     final product = MockProductService();
     final session = MockSessionService();
-    final model = InstallModel(client, journal, product, session);
+    final config = MockConfigService();
+    when(config.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+    final model = InstallModel(client, journal, product, session, config);
 
     when(client.getStatus())
         .thenAnswer((_) async => testStatus(ApplicationState.values.first));
@@ -74,7 +78,10 @@ void main() async {
     final product = MockProductService();
 
     final session = MockSessionService();
-    final model = InstallModel(client, journal, product, session);
+    final config = MockConfigService();
+    when(config.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+    final model = InstallModel(client, journal, product, session, config);
 
     expect(model.state, isNull);
     expect(model.isInstalling, isFalse);
@@ -127,7 +134,10 @@ void main() async {
     final product = MockProductService();
 
     final session = MockSessionService();
-    final model = InstallModel(client, journal, product, session);
+    final config = MockConfigService();
+    when(config.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+    final model = InstallModel(client, journal, product, session, config);
 
     expect(model.hasError, isFalse);
 
@@ -142,7 +152,9 @@ void main() async {
       MockJournalService(),
       MockProductService(),
       MockSessionService(),
+      MockConfigService(),
     );
+
     expect(model.isLogVisible, isFalse);
 
     var wasNotified = 0;
@@ -160,13 +172,16 @@ void main() async {
   test('reboot', () async {
     final client = MockSubiquityClient();
     final session = MockSessionService();
+    final config = MockConfigService();
+    when(config.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
     final model = InstallModel(
       client,
       MockJournalService(),
       MockProductService(),
       session,
+      config,
     );
-
     await model.reboot();
     verify(session.reboot()).called(1);
   });
@@ -191,7 +206,10 @@ void main() async {
     final product = MockProductService();
 
     final session = MockSessionService();
-    final model = InstallModel(client, journal, product, session);
+    final config = MockConfigService();
+    when(config.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+    final model = InstallModel(client, journal, product, session, config);
 
     expect(model.event.action, InstallationAction.none);
 

--- a/packages/ubuntu_bootstrap/test/install/install_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/install/install_page_test.dart
@@ -5,6 +5,7 @@ import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/install/install_model.dart';
 import 'package:ubuntu_bootstrap/pages/install/install_page.dart';
 import 'package:ubuntu_bootstrap/pages/install/slide_view.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -161,6 +162,18 @@ void main() {
     verify(model.reboot()).called(1);
 
     await expectLater(windowClosed, completes);
+  });
+
+  testWidgets('core desktop has no continue testing', (tester) async {
+    final model = buildInstallModel(
+        isDone: true, provisioningMode: ProvisioningMode.coreDesktop);
+    await tester.pumpApp((_) => buildPage(model));
+
+    final context = tester.element(find.byType(InstallPage));
+    final l10n = UbuntuBootstrapLocalizations.of(context);
+
+    final continueTestingButton = find.button(l10n.continueTesting);
+    expect(continueTestingButton, findsNothing);
   });
 
   testWidgets('continue testing', (tester) async {

--- a/packages/ubuntu_bootstrap/test/install/test_install.dart
+++ b/packages/ubuntu_bootstrap/test/install/test_install.dart
@@ -22,6 +22,7 @@ InstallModel buildInstallModel({
   bool? isLogVisible,
   bool? isPlaying,
   ProductInfo? productInfo,
+  ProvisioningMode? provisioningMode,
 }) {
   final model = MockInstallModel();
   when(model.state).thenReturn(state);
@@ -34,6 +35,8 @@ InstallModel buildInstallModel({
   when(model.isPlaying).thenReturn(isPlaying ?? false);
   when(model.productInfo)
       .thenReturn(productInfo ?? ProductInfo(name: 'Ubuntu'));
+  when(model.provisioningMode)
+      .thenReturn(provisioningMode ?? ProvisioningMode.standard);
   return model;
 }
 

--- a/packages/ubuntu_bootstrap/test/install/test_install.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/install/test_install.mocks.dart
@@ -108,6 +108,12 @@ class MockInstallModel extends _i1.Mock implements _i3.InstallModel {
       ) as bool);
 
   @override
+  _i2.ProvisioningMode get provisioningMode => (super.noSuchMethod(
+        Invocation.getter(#provisioningMode),
+        returnValue: _i2.ProvisioningMode.standard,
+      ) as _i2.ProvisioningMode);
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,

--- a/packages/ubuntu_bootstrap/test/installer_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_test.dart
@@ -49,6 +49,7 @@ void main() {
 
   testWidgets('fully automated installation', (tester) async {
     registerMockService<SessionService>(MockSessionService());
+    registerMockService<ConfigService>(MockConfigService());
     await tester.pumpWidget(
       tester.buildInstaller(
         state: ApplicationState.RUNNING,

--- a/packages/ubuntu_provision/lib/src/services/config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/config_service.dart
@@ -11,6 +11,24 @@ import 'package:yaml/yaml.dart';
 
 final _log = Logger('config');
 
+enum ProvisioningMode {
+  standard,
+  oem,
+  coreDesktop;
+
+  static ProvisioningMode fromString(String? value) {
+    final lower = value?.toLowerCase();
+    switch (lower) {
+      case 'oem':
+        return ProvisioningMode.oem;
+      case 'core-desktop':
+        return ProvisioningMode.coreDesktop;
+      default:
+        return ProvisioningMode.standard;
+    }
+  }
+}
+
 class ConfigService {
   ConfigService({
     this.scope,
@@ -33,6 +51,10 @@ class ConfigService {
       return _config?[key] as T?;
     }
     return _config?[scopeOverride ?? scope]?[key] as T?;
+  }
+
+  Future<ProvisioningMode> get provisioningMode async {
+    return ProvisioningMode.fromString(await get<String>('mode'));
   }
 
   /// Loads the config file, if none are found on the filesystem by

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.dart
@@ -10,21 +10,6 @@ part 'page_config_service.g.dart';
 final _log = Logger('page');
 const _tryOrInstallName = 'tryOrInstall';
 
-enum ProvisioningMode {
-  standard,
-  oem;
-
-  static ProvisioningMode fromString(String? value) {
-    final lower = value?.toLowerCase();
-    switch (lower) {
-      case 'oem':
-        return ProvisioningMode.oem;
-      default:
-        return ProvisioningMode.standard;
-    }
-  }
-}
-
 class PageConfigService {
   PageConfigService({ConfigService? config, this.includeTryOrInstall = false})
       : _config = config;
@@ -43,7 +28,7 @@ class PageConfigService {
       'pages': await _config!.get<Map<String, dynamic>>('pages') ??
           <String, dynamic>{},
     });
-    mode = ProvisioningMode.fromString(await _config!.get<String>('mode'));
+    mode = await _config!.provisioningMode;
 
     pages.addAll(pageConfig.pages);
 

--- a/packages/ubuntu_provision/test/services/page_config_service_test.dart
+++ b/packages/ubuntu_provision/test/services/page_config_service_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_provision/services.dart';
-import 'package:ubuntu_provision/src/services/page_config_service.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:yaml/yaml.dart';
 
@@ -38,13 +37,16 @@ pages:
 
 MockConfigService createMockConfigService({
   String config = '',
-  ProvisioningMode mode = ProvisioningMode.standard,
+  ProvisioningMode? mode,
 }) {
   final mock = MockConfigService();
   final yaml = loadYaml(config)?['pages'] as YamlMap?;
-  when(mock.get('mode')).thenAnswer((_) async => mode.name);
+  when(mock.get('mode')).thenAnswer(
+      (_) async => mode != null ? mode.name : ProvisioningMode.standard.name);
   when(mock.get('pages')).thenAnswer(
     (_) async => config == '' ? null : yaml?.toMap(),
   );
+  when(mock.provisioningMode)
+      .thenAnswer((_) async => mode ?? ProvisioningMode.standard);
   return mock;
 }

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -724,6 +724,13 @@ class MockConfigService extends _i1.Mock implements _i4.ConfigService {
       ) as _i3.FileSystem);
 
   @override
+  _i13.Future<_i4.ProvisioningMode> get provisioningMode => (super.noSuchMethod(
+        Invocation.getter(#provisioningMode),
+        returnValue: _i13.Future<_i4.ProvisioningMode>.value(
+            _i4.ProvisioningMode.standard),
+      ) as _i13.Future<_i4.ProvisioningMode>);
+
+  @override
   _i13.Future<T?> get<T>(
     String? key, {
     String? scopeOverride,


### PR DESCRIPTION
The current Ubuntu-core-desktop-init program used for the installer shows, at the end, the same page than the live installer: one where the user can choose between “reboot” or “continue testing”. This is invalid for Core Desktop because it’s not a live session, so choosing “continue testing” leaves a graphical session without desktop.

This patch adds a new parameter in whitelabel.yaml, `live-session`, which by default is true. When this parameter is set to false, it will change the last page to one that only allows to reboot, and shows a more fitting message.