### PR TITLE
Add flavo(u)r data in ProductService

### DIFF
--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -437,7 +437,8 @@ class FakeProductService implements ProductService {
   ProductInfo getProductInfo() => ProductInfo(name: 'Ubuntu', version: '23.04');
 
   @override
-  UbuntuFlavor? getFlavor() => const UbuntuFlavor(id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r');
+  UbuntuFlavor? getFlavor() =>
+      const UbuntuFlavor(id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r');
 
   @override
   String getReleaseNotesURL(String languageCode) =>

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -4,6 +4,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_bootstrap/ubuntu_bootstrap.dart';
+import 'package:ubuntu_flavor/src/ubuntu_flavor.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_provision_test/ubuntu_provision_test.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
@@ -434,6 +435,9 @@ class FakeDesktopService implements DesktopService {
 class FakeProductService implements ProductService {
   @override
   ProductInfo getProductInfo() => ProductInfo(name: 'Ubuntu', version: '23.04');
+
+  @override
+  UbuntuFlavor? getFlavor() => const UbuntuFlavor(id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r');
 
   @override
   String getReleaseNotesURL(String languageCode) =>

--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -98,7 +98,7 @@ Future<void> runInstallerApp(
       () => SubiquityNetworkService(getService<SubiquityClient>()));
   tryRegisterService(() => PostInstallService('/tmp/$baseName.conf'));
   tryRegisterService(PowerService.new);
-  tryRegisterService(ProductService.new);
+  tryRegisterService<ProductService>(() => ProductService(flavor: flavor));
   tryRegisterService(() => RefreshService(getService<SubiquityClient>()));
   tryRegisterService<SessionService>(
       () => SubiquitySessionService(getService<SubiquityClient>()));

--- a/packages/ubuntu_provision/lib/src/services/product_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/product_service.dart
@@ -25,9 +25,10 @@ class ProductService {
 
   final FileSystem _fileSystem;
 
-  ProductService({@visibleForTesting FileSystem? fileSystem, UbuntuFlavor? flavor})
+  ProductService(
+      {@visibleForTesting FileSystem? fileSystem, UbuntuFlavor? flavor})
       : _fileSystem = fileSystem ?? const LocalFileSystem(),
-      _flavor = flavor;
+        _flavor = flavor;
 
   /// Returns the flavor data, if passed during construction
   UbuntuFlavor? getFlavor() {

--- a/packages/ubuntu_provision/lib/src/services/product_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/product_service.dart
@@ -1,6 +1,7 @@
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:meta/meta.dart';
+import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 
 const String isoPath = '/cdrom/.disk/info';
 const String localPath = '/etc/os-release';
@@ -20,11 +21,18 @@ class ProductInfo {
 /// A class which reads current system info
 class ProductService {
   ProductInfo? _cachedProductInfo;
+  final UbuntuFlavor? _flavor;
 
   final FileSystem _fileSystem;
 
-  ProductService([@visibleForTesting FileSystem? fileSystem])
-      : _fileSystem = fileSystem ?? const LocalFileSystem();
+  ProductService({@visibleForTesting FileSystem? fileSystem, UbuntuFlavor? flavor})
+      : _fileSystem = fileSystem ?? const LocalFileSystem(),
+      _flavor = flavor;
+
+  /// Returns the flavor data, if passed during construction
+  UbuntuFlavor? getFlavor() {
+    return _flavor;
+  }
 
   /// Returns system version from CD ISO or hard disk falls back to simple
   /// "Ubuntu" text when cannot find file.

--- a/packages/ubuntu_provision/test/services/product_service_test.dart
+++ b/packages/ubuntu_provision/test/services/product_service_test.dart
@@ -14,7 +14,7 @@ void main() {
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu');
       expect(info.version, '21.04');
@@ -41,7 +41,7 @@ UBUNTU_CODENAME=hirsute
 
           ''');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.version, '21.04');
       expect(info.toString(), 'Ubuntu 21.04');
@@ -49,7 +49,7 @@ UBUNTU_CODENAME=hirsute
 
     test('should return Ubuntu as fallback value', () {
       final fileSystem = MemoryFileSystem();
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu');
       expect(info.version, isNull);
@@ -62,7 +62,7 @@ UBUNTU_CODENAME=hirsute
         f.writeAsString(
             'Ubuntu 20.04.2.0 LTS "Focal Fossa" - Release amd64 (20210209.1)');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu');
       expect(info.version, '20.04.2.0 LTS');
@@ -89,7 +89,7 @@ UBUNTU_CODENAME=focal
 
           ''');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu');
       expect(info.version, '20.04.2 LTS');
@@ -103,7 +103,7 @@ UBUNTU_CODENAME=focal
 PRETTY_NAME="Ubuntu 23.10"
 ''');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu');
       expect(info.version, '23.10');
@@ -116,7 +116,7 @@ PRETTY_NAME="Ubuntu 23.10"
         f.writeAsString(
             'Kubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Kubuntu');
       expect(info.version, '21.04');
@@ -129,7 +129,7 @@ PRETTY_NAME="Ubuntu 23.10"
         f.writeAsString(
             'Ubuntu-MATE 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final info = ProductService(fileSystem).getProductInfo();
+      final info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu-MATE');
       expect(info.version, '21.04');
@@ -142,7 +142,7 @@ PRETTY_NAME="Ubuntu 23.10"
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final service = ProductService(fileSystem);
+      final service = ProductService(fileSystem: fileSystem);
       var info = service.getProductInfo();
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
@@ -163,14 +163,14 @@ PRETTY_NAME="Ubuntu 23.10"
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      var info = ProductService(fileSystem).getProductInfo();
+      var info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       await fileSystem.file(isoPath).create(recursive: true).then((f) {
         f.writeAsString(
             'Ubuntu-MATE 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
 
-      info = ProductService(fileSystem).getProductInfo();
+      info = ProductService(fileSystem: fileSystem).getProductInfo();
 
       expect(info.name, 'Ubuntu-MATE');
       expect(info.version, '21.04');
@@ -186,7 +186,7 @@ PRETTY_NAME="Ubuntu 23.10"
 https://wiki.ubuntu.com/IntrepidReleaseNotes/\${LANG}
     ''');
 
-    final service = ProductService(fs);
+    final service = ProductService(fileSystem: fs);
     final url = service.getReleaseNotesURL('fr');
     expect(url, equals('https://wiki.ubuntu.com/IntrepidReleaseNotes/fr'));
   });
@@ -201,14 +201,14 @@ version,codename,series,created,release,eol,eol-server,eol-esm
 5.04,Hoary Hedgehog,hoary,2004-10-20,2005-04-08,2006-10-31
     ''');
 
-    final service = ProductService(fs);
+    final service = ProductService(fileSystem: fs);
     final url = service.getReleaseNotesURL('en');
     expect(url, equals('https://wiki.ubuntu.com/HoaryHedgehog/ReleaseNotes'));
   });
 
   test('release notes URL fallback', () {
     final fs = MemoryFileSystem.test();
-    final service = ProductService(fs);
+    final service = ProductService(fileSystem: fs);
     final url = service.getReleaseNotesURL('en');
     expect(url, equals('https://ubuntu.com/download/desktop'));
   });

--- a/packages/ubuntu_provision/test/services/product_service_test.dart
+++ b/packages/ubuntu_provision/test/services/product_service_test.dart
@@ -1,6 +1,9 @@
+import 'dart:math';
+
 import 'package:file/memory.dart';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_provision/services.dart';
 
 void main() {
@@ -14,11 +17,19 @@ void main() {
         f.writeAsString(
             'Ubuntu 21.04 "Hirsute Hippo" - Release amd64 (20210420)');
       });
-      final info = ProductService(fileSystem: fileSystem).getProductInfo();
+      final service = ProductService(
+          fileSystem: fileSystem,
+          flavor: const UbuntuFlavor(
+              id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r'));
+      final info = service.getProductInfo();
 
       expect(info.name, 'Ubuntu');
       expect(info.version, '21.04');
       expect(info.toString(), 'Ubuntu 21.04');
+
+      final flavor = service.getFlavor();
+      expect(flavor?.id, 'FakeUbuntu');
+      expect(flavor?.name, 'Ubuntu Fake Flavo(u)r');
     });
 
     test('should return product info from disk when iso file doesnt exists',

--- a/packages/ubuntu_provision/test/services/product_service_test.dart
+++ b/packages/ubuntu_provision/test/services/product_service_test.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:file/memory.dart';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/ubuntu_provision_test/lib/src/fake_init.dart
+++ b/packages/ubuntu_provision_test/lib/src/fake_init.dart
@@ -4,6 +4,7 @@ import 'package:dbus/dbus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:sysmetrics/src/sysmetrics.dart';
+import 'package:ubuntu_flavor/src/ubuntu_flavor.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
@@ -364,6 +365,9 @@ class _FakeSysmetrics implements Sysmetrics {
 class _FakeProductService implements ProductService {
   @override
   ProductInfo getProductInfo() => ProductInfo(name: 'Ubuntu', version: '23.10');
+
+  @override
+  UbuntuFlavor? getFlavor() => const UbuntuFlavor(id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r');
 
   @override
   String getReleaseNotesURL(String languageCode) =>

--- a/packages/ubuntu_provision_test/lib/src/fake_init.dart
+++ b/packages/ubuntu_provision_test/lib/src/fake_init.dart
@@ -367,7 +367,8 @@ class _FakeProductService implements ProductService {
   ProductInfo getProductInfo() => ProductInfo(name: 'Ubuntu', version: '23.10');
 
   @override
-  UbuntuFlavor? getFlavor() => const UbuntuFlavor(id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r');
+  UbuntuFlavor? getFlavor() =>
+      const UbuntuFlavor(id: 'FakeUbuntu', name: 'Ubuntu Fake Flavo(u)r');
 
   @override
   String getReleaseNotesURL(String languageCode) =>


### PR DESCRIPTION
It can be useful to have available the flavor data passed during the call to runInstallerApp (for example, to change the page appearance for specific Ubuntu flavors, like Ubuntu Core Desktop, based on the id field).

This MR makes that data available in the ProductService class, thus allowing to retrieve it anywhere.