### PR TITLE
feat: add snapcraft.yaml to build ubuntu-desktop-installer snap from ubuntu_bootstrap

### DIFF
--- a/scripts/inject-snap
+++ b/scripts/inject-snap
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# inject-snap - install a snap into a live iso
+# inject-snap source_iso destination_iso file.snap
+
+set -eux
+
+src=$1
+dst=$2
+snap=$3
+
+LIVEFS_EDITOR="${LIVEFS_EDITOR-$(readlink -f "$(dirname $(dirname ${0}))/livefs-editor")}"
+[ -d "$LIVEFS_EDITOR" ] || git clone https://github.com/mwhudson/livefs-editor $LIVEFS_EDITOR
+
+sudo PYTHONPATH=$LIVEFS_EDITOR \
+    python3 -m livefs_edit $src $dst --inject-snap $snap

--- a/scripts/subiquity_integration
+++ b/scripts/subiquity_integration
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# consistency checks between ubuntu-desktop-installer and subiquity
+
+import unittest
+import yaml
+
+
+class Tests(unittest.TestCase):
+    def test_depends(self):
+        with open('snap/snapcraft.yaml', 'r') as udi_snapcraft:
+            udi_data = yaml.safe_load(udi_snapcraft)
+
+        with open('packages/subiquity_client/subiquity/snapcraft.yaml', 'r') \
+                as subiquity_snapcraft:
+            subiquity_data = yaml.safe_load(subiquity_snapcraft)
+
+        for part in ('probert', 'curtin'):
+            self.assertEqual(udi_data['parts'][part]['source-commit'],
+                             subiquity_data['parts'][part]['source-commit'],
+                             f'comparison of {part}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/update-subiquity-deps
+++ b/scripts/update-subiquity-deps
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from ruamel.yaml import YAML
+
+yaml = YAML()
+yaml.default_flow_style = False
+yaml.pure = True
+yaml.indent(mapping=2, sequence=2, offset=2)
+
+with open('snap/snapcraft.yaml', 'r') as fp:
+    udi_data = yaml.load(fp)
+
+with open('packages/subiquity_client/subiquity/snapcraft.yaml', 'r') as fp:
+    subiquity_data = yaml.load(fp)
+
+for part in ('probert', 'curtin'):
+    udi_data['parts'][part]['source-commit'] = \
+        subiquity_data['parts'][part]['source-commit']
+
+with open('snap/snapcraft.yaml', 'w') as fp:
+    yaml.dump(udi_data, fp)

--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+source "$SNAP_USER_DATA/.last_revision" 2>/dev/null || true
+if [ "$SNAP_DESKTOP_LAST_REVISION" = "$SNAP_REVISION" ]; then
+  needs_update=false
+else
+  needs_update=true
+fi
+
+if [ "$SNAP_ARCH" = "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" = "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" = "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+elif [ "$SNAP_ARCH" = "ppc64el" ]; then
+  ARCH="powerpc64le-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+# Set cache folder to local path
+export XDG_CACHE_HOME="$SNAP_USER_COMMON/.cache"
+[ -d "$XDG_CACHE_HOME" ] ||  mkdir -p "$XDG_CACHE_HOME"
+
+# Workaround for flickering corners and other graphical glitches with GTK's
+# OpenGL backend for X11. See:
+# - https://github.com/canonical/ubuntu-desktop-installer/issues/1397
+# - https://gitlab.gnome.org/GNOME/gtk/-/issues/5600
+export GDK_RENDERING=image
+
+export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
+export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
+if [ "$needs_update" = true ] || [ ! -f "$GDK_PIXBUF_MODULE_FILE" ]; then
+  rm -f "$GDK_PIXBUF_MODULE_FILE"
+  if [ -f "$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" ]; then
+    $SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > "$GDK_PIXBUF_MODULE_FILE"
+  fi
+fi
+
+[ "$needs_update" = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > "$SNAP_USER_DATA/.last_revision"
+
+# Disable storage automounting (/usr/lib/udisks2/udisks2-inhibit)
+sudo mkdir -p /run/udev/rules.d
+sudo sh -c 'echo "SUBSYSTEM==\"block\", ENV{UDISKS_IGNORE}=\"1\"" > /run/udev/rules.d/90-udisks-inhibit.rules'
+trap "sudo rm -f /run/udev/rules.d/90-udisks-inhibit.rules; sudo udevadm control --reload; sudo udevadm trigger --subsystem-match=block" EXIT HUP INT QUIT ILL ABRT FPE KILL SEGV PIPE ALRM TERM BUS
+sudo udevadm control --reload
+sudo udevadm trigger --subsystem-match=block
+
+"$@"

--- a/snap/local/postinst.d/10_configure_auto_login
+++ b/snap/local/postinst.d/10_configure_auto_login
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -e
+
+installer_conf=/tmp/ubuntu_desktop_installer.conf
+
+if ! source $installer_conf 2>/dev/null || [ -z "$AutoLoginUser" ]; then
+    exit
+fi
+
+USER=$AutoLoginUser
+ROOT=/target
+chroot=chroot
+BACKUP=
+
+# Adapted from https://git.launchpad.net/ubiquity/tree/d-i/source/user-setup/user-setup-apply
+
+if [ -d "$ROOT/etc/gdm3" ]; then
+    # Configure GDM autologin
+    GDMCustomFile=$ROOT/etc/gdm3/custom.conf
+    if [ -e "$GDMCustomFile" ] && [ "$BACKUP" ]; then
+        cp "$GDMCustomFile" "${GDMCustomFile}$BACKUP"
+    fi
+    AutologinParameters="AutomaticLoginEnable=true\n\
+AutomaticLogin=$USER\n"
+
+    # Prevent from updating if parameters already present (persistent usb key)
+    if ! `grep -qs "AutomaticLogin=$USER" $GDMCustomFile` ; then
+        if [ -e "$GDMCustomFile" ]; then
+            sed -i '/\(Automatic\)Login/d' $GDMCustomFile
+        fi
+        if ! `grep -qs '\[daemon\]' $GDMCustomFile` ; then
+            echo '[daemon]' >> $GDMCustomFile
+        fi
+        sed -i "s/\[daemon\]/\[daemon\]\n$AutologinParameters/" $GDMCustomFile
+    fi
+fi
+
+if $chroot $ROOT [ -f /etc/kde4/kdm/kdmrc ]; then
+    # Configure KDM autologin
+    $chroot $ROOT sed -i$BACKUP -r \
+        -e "s/^#?AutoLoginEnable=.*\$/AutoLoginEnable=true/" \
+        -e "s/^#?AutoLoginUser=.*\$/AutoLoginUser=$USER/" \
+        -e "s/^#?AutoReLogin=.*\$/AutoReLogin=true/" \
+        /etc/kde4/kdm/kdmrc
+fi
+
+if $chroot $ROOT [ -f /etc/lxdm/lxdm.conf ]; then
+        # Configure LXDM autologin with LXDE session
+    $chroot $ROOT sed -i$BACKUP -r \
+            -e "s/^# autologin=dgod/autologin=$USER/" \
+            -e "s/^# session/session/" \
+            /etc/lxdm/lxdm.conf
+fi
+
+if $chroot $ROOT [ -f /etc/xdg/lubuntu/lxdm/lxdm.conf ]; then
+        # Configure LXDM autologin with Lubuntu session
+    $chroot $ROOT sed -i$BACKUP -r \
+            -e "s/^# autologin=dgod/autologin=$USER/" \
+            -e "s/^# session/session/" \
+            -e "s/startlxde/startlubuntu/" \
+            /etc/xdg/lubuntu/lxdm/lxdm.conf
+fi
+
+if $chroot $ROOT [ -f /usr/bin/sddm ]; then
+    # Configure SDDM autologin with an appropiate session
+    $chroot $ROOT /bin/sh -c "cat > /etc/sddm.conf" << EOF
+[Autologin]
+User=$USER
+Session=PLACEHOLDER
+EOF
+    if $chroot $ROOT [ -f /usr/share/xsessions/plasma.desktop ]; then
+        sed -i 's/PLACEHOLDER/plasma.desktop/' $ROOT/etc/sddm.conf
+    elif $chroot $ROOT [ -f /usr/share/xsessions/Lubuntu.desktop ]; then
+        sed -i 's/PLACEHOLDER/Lubuntu.desktop/' $ROOT/etc/sddm.conf
+    elif $chroot $ROOT [ -f /usr/share/xsessions/lxqt.desktop ]; then
+        sed -i 's/PLACEHOLDER/lxqt.desktop/' $ROOT/etc/sddm.conf
+    else #fallback if some other DE/WM is used
+        SDDMSESSION=$(ls /usr/share/xsessions | head -1)
+        sed -i "s/PLACEHOLDER/$SDDMSESSION/" $ROOT/etc/sddm.conf
+    fi
+fi
+if $chroot $ROOT [ -d /etc/lightdm ]; then
+    # Configure LightDM autologin
+    LightDMCustomFile=$ROOT/etc/lightdm/lightdm.conf
+    AutologinParameters="autologin-guest=false\n\
+autologin-user=$USER\n\
+autologin-user-timeout=0"
+    if ! grep -qs '^autologin-user' $LightDMCustomFile; then
+        if ! grep -qs '^\[Seat:\*\]' $LightDMCustomFile; then
+            echo '[Seat:*]' >> $LightDMCustomFile
+        fi
+        sed -i "s/\[Seat:\*\]/\[Seat:\*\]\n$AutologinParameters/" $LightDMCustomFile
+    #oem config scenario
+    else
+        sed -i "s/^\(\(str  *\)\?autologin-user\)=.*$/\1=$USER/g;" $ROOT/etc/lightdm/lightdm.conf
+    fi
+fi

--- a/snap/local/postinst.d/10_copy_bluetooth_config
+++ b/snap/local/postinst.d/10_copy_bluetooth_config
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+target=/target
+source_bluetooth=/var/lib/bluetooth
+target_bluetooth=$target/$source_bluetooth
+
+if [ -d $source_bluetooth ]; then
+    rm -rf $target_bluetooth
+    cp -a $source_bluetooth $target_bluetooth
+fi

--- a/snap/local/postinst.d/10_copy_network_config
+++ b/snap/local/postinst.d/10_copy_network_config
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+target=/target
+source_nm=/etc/NetworkManager/system-connections
+target_nm=$target/$source_nm
+
+if [ -d $source_nm ] && [ -d $target_nm ]; then
+    cp -anr $source_nm/. $target_nm
+fi
+
+source_netplan=/etc/netplan
+target_netplan=$target/$source_netplan
+
+if [ -d $source_netplan ] && [ -d $target_netplan ]; then
+    cp -anr $source_netplan/90-NM-* $target_netplan
+fi

--- a/snap/local/postinst.d/10_flash_kernel
+++ b/snap/local/postinst.d/10_flash_kernel
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+# Currently curtin doesn't call flash-kernel after installing kernel
+# and generating initrd, but we need it on arm64
+# and we need to update-grub after flash-kernel installed dtb
+if [ -e /target/usr/sbin/flash-kernel ]; then
+	FK_FORCE=yes $SNAP/bin/subiquity/bin/subiquity-cmd curtin in-target -t /target -- flash-kernel
+fi
+if [ -e /target/usr/sbin/update-grub ]; then
+	$SNAP/bin/subiquity/bin/subiquity-cmd curtin in-target -t /target -- update-grub
+fi

--- a/snap/local/postinst.d/10_override_desktop_settings
+++ b/snap/local/postinst.d/10_override_desktop_settings
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+user=ubuntu
+target=/target
+source_schemas=/usr/share/glib-2.0/schemas
+target_schemas=$target/$source_schemas
+
+if [ ! -d $source_schemas ] || [ ! -d $target_schemas ] || ! id $user >/dev/null 2>&1; then
+    exit
+fi
+
+dconf_dump() {
+    target_schema=$target_schemas/20_ubuntu-desktop-installer-$1.gschema.override
+    sudo -u $user dconf dump /org/gnome/desktop/$1/ > $target_schema
+    # - [foo] -> [org.gnome.desktop.$1.foo:ubuntu]
+    sed -i -E "s/^\[([^/]*)\]/\[org.gnome.desktop.$1.\1:ubuntu\]/g" $target_schema
+    # - [/] -> [org.gnome.desktop.$1:ubuntu]
+    sed -i -E "s/^\[\/\]$/\[org.gnome.desktop.$1:ubuntu\]/g" $target_schema
+    [ -s $target_schema ] || rm $target_schema
+}
+
+dconf_dump a11y
+dconf_dump interface
+dconf_dump peripherals
+dconf_dump wm
+
+glib-compile-schemas $target_schemas

--- a/snap/local/postinst.d/50_zfs_cache
+++ b/snap/local/postinst.d/50_zfs_cache
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Provide a workaround so that ubuntu-desktop-installer does not
+# recreate LP: #1993318
+
+TARGET=/target
+
+for pool in $(zpool list -H | cut -f1); do
+    zpool set cachefile= "${pool}"
+    if [ ! -d "/etc/zfs/zfs-list.cache" ] ; then
+        mkdir -p "/etc/zfs/zfs-list.cache"
+    fi
+    if [ ! -d "${TARGET}/etc/zfs/zfs-list.cache" ] ; then
+        mkdir -p "${TARGET}/etc/zfs/zfs-list.cache"
+    fi
+    # Force cache generation
+    : >"/etc/zfs/zfs-list.cache/${pool}"
+    # Execute zfs-list-cacher with a manual fake event
+    env -i \
+        ZEVENT_POOL=${pool} \
+        ZED_ZEDLET_DIR=/etc/zfs/zed.d \
+        ZEVENT_SUBCLASS=history_event \
+        ZFS=zfs \
+        ZEVENT_HISTORY_INTERNAL_NAME=create \
+        /etc/zfs/zed.d/history_event-zfs-list-cacher.sh
+    # ZFS list doesn't honor target prefix for chroots for
+    # the mountpoint property
+    # https://github.com/openzfs/zfs/issues/1078
+    # Drop leading /target from all mountpoint fields
+    sed -E "s|\t${TARGET}/?|\t/|g" "/etc/zfs/zfs-list.cache/${pool}" \
+        > "${TARGET}/etc/zfs/zfs-list.cache/${pool}"
+    # Ensure installer system doesn't generate mount units
+    rm -f "/etc/zfs/zfs-list.cache/${pool}"
+done
+
+

--- a/snap/local/postinst.d/99_telemetry_done
+++ b/snap/local/postinst.d/99_telemetry_done
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+telemetry=/var/log/installer/telemetry
+
+if [ ! -f $telemetry ]; then
+    exit
+fi
+
+current_time=$(date +%s)
+created_at=$(stat --format %W $telemetry)
+duration=$(($current_time - $created_at))
+
+# {
+#   ...
+#   "Stages": {
+#     "0": "welcome",
+#     ...
+#     "1234": "done" // <==
+#   }
+# }
+
+jq ".Stages.\"$duration\"=\"done\"" $telemetry > $telemetry.tmp
+mv $telemetry.tmp $telemetry

--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# store current script directories
+SCRIPT_DIR=`dirname $0`
+
+# configure python environment
+export PYTHONIOENCODING=utf-8
+PYTHONPATH=$SNAP/usr/lib/python3/site-packages:$PYTHONPATH
+PYTHONPATH=$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+PYTHONPATH=$SNAP/lib/python3.10/site-packages:$PYTHONPATH
+export PYTHONPATH
+export PYTHON=$SNAP/usr/bin/python3.10
+
+# ensure curtin points at PYTHON
+export PY3OR2_PYTHON=$PYTHON
+
+# set the PATH so subiquity finds curtin
+# sbin for bundled tools such as ntfsresize
+export PATH=$SNAP/bin:$SNAP/sbin:$PATH
+
+# allow subiquity to run setxkbmap
+export DISPLAY=:0
+
+# base directory for subiquity to locate resources
+export SUBIQUITY_ROOT=$SNAP/bin/subiquity
+
+# run subiquity server
+cd $SCRIPT_DIR/subiquity
+
+args=(--use-os-prober --storage-version=2 --postinst-hooks-dir=$SNAP/etc/subiquity/postinst.d)
+$PYTHON -m subiquity.cmd.server "${args[@]}"

--- a/snap/local/ubuntu-desktop-installer.desktop
+++ b/snap/local/ubuntu-desktop-installer.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+# Do not translate the word "RELEASE".  It is used as a marker by casper.
+Name=Install RELEASE
+Comment=Install this system permanently to your hard disk
+Keywords=ubiquity;
+#use sh because pkexec is broken under xfce/lxce http://pad.lv/1193526
+Exec=ubuntu-desktop-installer
+Icon=ubiquity
+Terminal=false
+Categories=GTK;System;Settings;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,10 +170,7 @@ parts:
       cp snap/local/ubuntu-desktop-installer.desktop $CRAFT_PART_INSTALL/usr/share/applications/
       dart pub global activate melos
       dart pub global run melos bootstrap
-      # https://github.com/canonical/ubuntu-desktop-installer/issues/1146
-      (cd packages/ubuntu_wizard && flutter pub get)
       cd packages/ubuntu_bootstrap
-      flutter pub get
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,267 @@
+name: ubuntu-desktop-installer
+version: git
+summary: Ubuntu Desktop Installer
+description: |
+  This project is a modern implementation of the Ubuntu Desktop installer,
+  using subiquity as a backend and Flutter for the UI.
+grade: stable
+confinement: classic
+base: core22
+issues: https://bugs.launchpad.net/ubuntu-desktop-installer/+filebug
+contact: https://bugs.launchpad.net/ubuntu-desktop-installer/+filebug
+
+apps:
+  subiquity-server:
+    command: bin/subiquity-server
+    daemon: simple
+    restart-condition: always
+    environment:
+      PATH_ORIG: $PATH
+      PYTHONPATH_ORIG: $PYTHONPATH
+      LD_LIBRARY_PATH_ORIG: $LD_LIBRARY_PATH
+
+  subiquity-loadkeys:
+    command: bin/subiquity/bin/subiquity-loadkeys
+
+  ubuntu-desktop-installer:
+    command: bin/ubuntu_bootstrap
+    command-chain: [bin/launcher]
+    desktop: usr/share/applications/ubuntu-desktop-installer.desktop
+    environment:
+      PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri
+      GIO_MODULE_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gio/modules
+      LIVE_RUN: 1
+      LOG_LEVEL: debug
+      SNAP_PYTHON: python3
+
+  probert:
+    command: bin/probert
+
+  os-prober:
+    command: usr/bin/os-prober
+
+parts:
+  curtin:
+    plugin: nil
+    source: https://git.launchpad.net/curtin
+    source-type: git
+    source-commit: 7c18bf6a24297ed465a341a1f53875b61c878d6b
+    override-pull: |
+      craftctl default
+      PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
+      sed -e "s,@@PACKAGED_VERSION@@,$PACKAGED_VERSION,g" -i curtin/version.py
+    override-build: &pyinstall |
+      # We install without dependencies because all dependencies come from
+      # archive packages.
+      # XXX: On core22, running `pip3 install --prefix xxx` does not do the
+      # right thing. The package ends up installed in xxx/local and the modules
+      # get installed to dist-packages instead of site-packages.
+      # See https://discuss.python.org/t/18240
+      # As a workaround, we use a fake user install to get the package
+      # installed in the expected place.
+      PYTHONUSERBASE="$CRAFT_PART_INSTALL" pip3 install --user --no-dependencies .
+    build-packages:
+      - python3-pip
+    organize:
+      lib/python*/site-packages/usr/lib/curtin: usr/lib/
+
+  probert:
+    plugin: nil
+    source: https://github.com/canonical/probert.git
+    source-type: git
+    source-commit: ae758355b610e389099abdb2397bb41ad49409ec
+    override-build: *pyinstall
+    build-packages:
+      - build-essential
+      - libnl-3-dev
+      - libnl-genl-3-dev
+      - libnl-route-3-dev
+      - pkg-config
+      - python3-dev
+      - python3-pip
+    build-attributes: [enable-patchelf]
+    stage:
+      - "*"
+      - -bin/python3*
+
+  subiquitydeps:
+    plugin: nil
+    build-attributes: [enable-patchelf]
+    stage-packages:
+      # This list includes the dependencies for curtin and probert as well,
+      # there doesn't seem to be any real benefit to listing them separately.
+      - cloud-init
+      - dctrl-tools
+      - iso-codes
+      - libpython3-stdlib
+      - libpython3.10-minimal
+      - libpython3.10-stdlib
+      - libsystemd0
+      - lsb-release
+      - ntfs-3g
+      - python3-aiohttp
+      - python3-apport
+      - python3-attr
+      - python3-bson
+      - python3-debian
+      - python3-jsonschema
+      - python3-minimal
+      - python3-oauthlib
+      - python3-pkg-resources
+      - python3-pyroute2
+      - python3-pyrsistent
+      - python3-pyudev
+      - python3-requests
+      - python3-requests-unixsocket
+      - python3-systemd
+      - python3-urwid
+      - python3-yaml
+      - python3-yarl
+      - python3.10-minimal
+      - ssh-import-id
+      - ubuntu-advantage-tools
+      # WSL specifics:
+      - language-selector-common
+      - locales
+    prime:
+      - -lib/systemd/system/*
+
+  flutter-git:
+    source: .
+    override-pull: |
+      craftctl default
+      FLUTTER_VERSION=$(sed -n "s/^flutter \([0-9.]\+\).*/\1/p" .tool-versions)
+      git clone -b $FLUTTER_VERSION --depth 1 https://github.com/flutter/flutter.git
+    plugin: nil
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      mkdir -p $CRAFT_PART_INSTALL/usr/libexec
+      cp -r $CRAFT_PART_SRC/flutter $CRAFT_PART_INSTALL/usr/libexec/flutter
+      ln -s $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $CRAFT_PART_INSTALL/usr/bin/flutter
+      ln -s $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/dart $CRAFT_PART_INSTALL/usr/bin/dart
+      $CRAFT_PART_INSTALL/usr/bin/flutter doctor
+    build-packages:
+      - clang
+      - cmake
+      - curl
+      - libgtk-3-dev
+      - ninja-build
+      - unzip
+      - xz-utils
+      - zip
+    override-prime: ""
+
+  ubuntu-bootstrap:
+    after: [flutter-git]
+    source: .
+    source-type: git
+    plugin: nil
+    build-attributes: [enable-patchelf]
+    override-build: |
+      set -eux
+      mkdir -p $CRAFT_PART_INSTALL/bin/lib
+      cp snap/local/launcher $CRAFT_PART_INSTALL/bin/
+      cp snap/local/subiquity-server $CRAFT_PART_INSTALL/bin/
+      cp -r packages/subiquity_client/subiquity $CRAFT_PART_INSTALL/bin/
+      mkdir -p $CRAFT_PART_INSTALL/etc/subiquity
+      cp -r snap/local/postinst.d $CRAFT_PART_INSTALL/etc/subiquity
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/applications
+      cp snap/local/ubuntu-desktop-installer.desktop $CRAFT_PART_INSTALL/usr/share/applications/
+      dart pub global activate melos
+      dart pub global run melos bootstrap
+      # https://github.com/canonical/ubuntu-desktop-installer/issues/1146
+      (cd packages/ubuntu_wizard && flutter pub get)
+      cd packages/ubuntu_bootstrap
+      flutter pub get
+      flutter build linux --release -v
+      cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
+
+  libraries:
+    plugin: nil
+    build-attributes: [enable-patchelf]
+    stage-packages:
+      - libatk1.0-0
+      - libcairo-gobject2
+      - libcairo2
+      - libegl-mesa0
+      - libegl1
+      - libgl1
+      - libglib2.0-0
+      - libglib2.0-dev
+      - libgtk-3-0
+      - libpango-1.0-0
+      - libpangocairo-1.0-0
+      - libpng16-16
+      - libwayland-egl1
+      - libx11-6
+      - libdatrie1
+      - libdrm2
+      - libgbm1
+      - libglapi-mesa
+      - libgraphite2-3
+      - libxshmfence1
+      - libpciaccess0
+      - libvulkan1
+      - shared-mime-info
+      - libglib2.0-bin
+      - libibus-1.0-5
+    prime:
+      - usr/lib/*/libEGL*.so.*
+      - usr/lib/*/libGL*.so.*
+      - usr/lib/*/libX*.so.*
+      - usr/lib/*/liba*.so.*
+      - usr/lib/*/libcairo*.so.*
+      - usr/lib/*/libe*.so.*
+      - usr/lib/*/libf*.so.*
+      - usr/lib/*/libg*.so.*
+      - usr/lib/*/libharfbuzz*.so.*
+      - usr/lib/*/libibus*.so.*
+      - usr/lib/*/libpango*.so.*
+      - usr/lib/*/libpixman*.so.*
+      - usr/lib/*/libpng*.so.*
+      - usr/lib/*/libthai*.so.*
+      - usr/lib/*/libwayland*.so.*
+      - usr/lib/*/libxcb*.so.*
+      - usr/lib/*/libxkb*.so.*
+      - usr/lib/*/libdatrie*.so.*
+      - usr/lib/*/libdrm*.so.*
+      - usr/lib/*/libgbm*.so.*
+      - usr/lib/*/libglapi*.so.*
+      - usr/lib/*/libgraphite2*.so.*
+      - usr/lib/*/libxshmfence*.so.*
+      - usr/lib/*/libpciaccess*.so.*
+      - usr/lib/*/libsensors*.so.*
+      - usr/lib/*/libvulkan*.so.*
+      - usr/share/glvnd/egl_vendor.d
+      - usr/lib/*/gdk-pixbuf-2.0
+      - usr/lib/*/
+      - usr/bin/update-mime-database
+      - usr/bin/g*
+      - usr/share/mime
+      - -usr/lib/*/pkgconfig
+      - -usr/lib/pkgconfig
+      - -usr/share/pkgconfig
+
+  dri-no-patchelf:
+    after: [libraries]
+    plugin: nil
+    stage-packages:
+      - libgl1-mesa-dri
+    build-attributes:
+      - no-patchelf # Otherwise snapcraft may strip the build ID and cause the driver to crash
+    stage:
+      - usr/lib/${CRAFT_ARCH_TRIPLET}/dri
+      - usr/share/drirc.d
+
+  os-prober:
+    plugin: nil
+    stage-packages: [os-prober]
+    build-attributes: [enable-patchelf]
+    override-stage: |
+      craftctl default
+      for file in $(grep -lr /usr | grep 'usr/[^/]*/[^/]*-probe[sr]'); do
+        sed -i 's, \(/usr\), $SNAP\1,' $file
+      done
+      sed -i 's/mkdir "$tmpmnt"/mkdir -p "$tmpmnt"/' \
+          usr/lib/os-probes/50mounted-tests


### PR DESCRIPTION
Adds the `snapcraft.yaml` from ubuntu-desktop-installer including post-installation scripts and everything else that's needed to build a working snap directly from `ubuntu_bootstrap`.

Note that this PR targets the `bootstrap-snap` branch, which is supposed to track `main` while carrying along everything that's needed to build and maintain the ubuntu-desktop-installer snap. I'll open a separate PR that adds a github action to build a snap in the CI whenever we push to this branch.

P.S. [here](https://github.com/d-loose/ubuntu-desktop-provision/actions/runs/6890839054/job/18744678019)'s a test build I ran using this setup.

UDENG-1750
Fix: #196 