### PR TITLE
feat: pin yaru versions

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -59,10 +59,10 @@ command:
       xdg_directories: ^1.0.3
       xdg_locale: ^0.0.1
       yaml: ^3.1.2
-      yaru: ^1.1.0
-      yaru_icons: ^2.2.2
-      yaru_widgets: ^3.2.2
-      yaru_window: ^0.1.3
+      yaru: 1.1.0
+      yaru_icons: 2.2.2
+      yaru_widgets: 3.2.2
+      yaru_window: 0.1.3
 
     dev_dependencies:
       build_runner: ^2.4.6

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -50,9 +50,9 @@ dependencies:
   ubuntu_utils: ^0.1.0
   ubuntu_widgets: ^0.2.0
   ubuntu_wizard: ^0.1.0
-  yaru: ^1.1.0
-  yaru_icons: ^2.2.2
-  yaru_widgets: ^3.2.2
+  yaru: 1.1.0
+  yaru_icons: 2.2.2
+  yaru_widgets: 3.2.2
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -39,9 +39,9 @@ dependencies:
   ubuntu_utils: ^0.1.0
   ubuntu_wizard: ^0.1.0
   xdg_locale: ^0.0.1
-  yaru: ^1.1.0
-  yaru_icons: ^2.2.2
-  yaru_widgets: ^3.2.2
+  yaru: 1.1.0
+  yaru_icons: 2.2.2
+  yaru_widgets: 3.2.2
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -45,10 +45,10 @@ dependencies:
   upower: ^0.7.0
   xdg_directories: ^1.0.3
   yaml: ^3.1.2
-  yaru: ^1.1.0
-  yaru_icons: ^2.2.2
-  yaru_widgets: ^3.2.2
-  yaru_window: ^0.1.3
+  yaru: 1.1.0
+  yaru_icons: 2.2.2
+  yaru_widgets: 3.2.2
+  yaru_window: 0.1.3
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/packages/ubuntu_provision_test/pubspec.yaml
+++ b/packages/ubuntu_provision_test/pubspec.yaml
@@ -23,6 +23,6 @@ dependencies:
   ubuntu_test: ^0.1.0-0
   ubuntu_utils: ^0.1.0
   ubuntu_wizard: ^0.1.0
-  yaru: ^1.1.0
+  yaru: 1.1.0
   yaru_test: ^0.1.3
-  yaru_widgets: ^3.2.2
+  yaru_widgets: 3.2.2

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   ubuntu_localizations: ^0.3.3
   ubuntu_widgets: ^0.2.0
   wizard_router: ^1.0.4
-  yaru: ^1.1.0
-  yaru_widgets: ^3.2.2
+  yaru: 1.1.0
+  yaru_widgets: 3.2.2
 
 dev_dependencies:
   flutter_lints: ^3.0.1


### PR DESCRIPTION
Let's pin the yaru versions for now to fix the [recent test failures](https://github.com/canonical/ubuntu-desktop-provision/actions/runs/6893487495/job/18753168310) caused by yaru 1.2.0.

Yaru folks: in case you're reading this, I'm not blaming you and don't know what the actual bug is since I can't reproduce it locally - but pinning yaru to 1.1.0 seems to solve it. Might be a bug in ubuntu_wizard though.

@spydon are there any other package versions we should pin?