### PR TITLE
feat(ci): add snap workflow for the installer/ubuntu-desktop-bootstrap

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,22 @@
+name: Build Ubuntu Bootstrap Snap
+
+on:
+  push:
+    branches:
+      - bootstrap-snap
+  workflow_dispatch:
+
+jobs:
+  snap:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v3
+      if: github.event_name == 'workflow_dispatch'
+      with:
+        name: 'snap'
+        path: ${{steps.snapcraft.outputs.snap}}


### PR DESCRIPTION
Adds a workflow that builds a snap from the `bootstrap-snap` branch whenever we push to it. Also includes `workflow_dispatch` to manually trigger snap builds.
I'd merge this one first and rebase #193 onto it once we're happy with it.