### PR TITLE
ci(dependabot): update to support go subproject

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,10 +31,15 @@ updates:
     commit-message:
       prefix: "deps(go-tools)"
 
-  ## Git Submodules
+  ## Subiquity dependencies
   - package-ecosystem: gitsubmodule
     directory: /
     schedule:
         interval: "daily"
         time: "02:00"
     target-branch: "main"
+    commit-message:
+      prefix: "deps(subiquity)"
+    allow:
+      - dependency-name: packages/subiquity_client/subiquity
+        dependency-type: direct:production

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,37 @@
 version: 2
 updates:
+  # Infrastructure
+  ## GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+        interval: "daily"
+        time: "02:00"
+    target-branch: "main"
+    commit-message:
+      prefix: "deps(ci)"
+
+  # Codebase
+  ## Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/provd"
+    schedule:
+        interval: "daily"
+        time: "02:00"
+    target-branch: "main"
+    commit-message:
+      prefix: "deps(go)"
+
+  - package-ecosystem: "gomod"
+    directory: "/provd/tools"
+    schedule:
+        interval: "daily"
+        time: "02:00"
+    target-branch: "main"
+    commit-message:
+      prefix: "deps(go-tools)"
+
+  ## Git Submodules
   - package-ecosystem: gitsubmodule
     directory: /
     schedule:


### PR DESCRIPTION
Adding clauses to the `dependabot.yaml` to support checking go & gh-action deps

Closes #208 