### PR TITLE
fix(ci): fixing dependency type

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -42,4 +42,4 @@ updates:
       prefix: "deps(subiquity)"
     allow:
       - dependency-name: packages/subiquity_client/subiquity
-        dependency-type: direct:production
+        dependency-type: direct


### PR DESCRIPTION
Looking at the options for the [allow](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) clause, production makes the most sense to me as the dependencies to keep monitored, seeing as we aren't directly working on `subiquity` in this monorepo.