### PR TITLE
feat(ci): run tests only on main and archive/main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
-      - 'ubuntu/**'
-      - 'canary-*'
+      - archive/main
   pull_request:
+    branches:
+      - main
+      - archive/main
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - bootstrap-snap
+  pull_request:
+    branches:
+      - bootstrap-snap
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We don't need to run the Flutter and Go tests on the snap branch - instead just run the snap workflow there.

I'd open a PR that merges `main` into `bootstrap-snap` afterwards.

P.S. I've also removed the obsolete `canary-*` and `ubuntu/**` branches