### PR TITLE
feat: add snapcraft.yaml for ubuntu-desktop-init

### DIFF
--- a/snap/local/ubuntu-desktop-init.desktop
+++ b/snap/local/ubuntu-desktop-init.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Ubuntu Desktop Init
+# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Icon=preferences-system
+Exec=ubuntu-desktop-init
+Terminal=false
+Type=Application
+StartupNotify=true
+Categories=GNOME;GTK;System;
+OnlyShowIn=GNOME;Unity;
+NoDisplay=true
+X-GNOME-HiddenUnderSystemd=true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,82 @@
+name: ubuntu-desktop-init
+version: git
+summary: Ubuntu Desktop Init
+description: |
+  Ubuntu Desktop Init description.
+grade: stable
+confinement: strict
+base: core22
+issues: https://github.com/canonical/ubuntu-desktop-provision/issues
+contact: https://github.com/canonical/ubuntu-desktop-provision/issues
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+apps:
+  ubuntu-desktop-init:
+    command: bin/ubuntu_init
+    extensions: [gnome]
+    desktop: usr/share/applications/ubuntu-desktop-init.desktop
+    environment:
+      LOG_LEVEL: debug
+    plugs:
+      - hardware-observe
+      - log-observe
+      - system-observe
+
+parts:
+  flutter-git:
+    source: .
+    override-pull: |
+      craftctl default
+      FLUTTER_VERSION=$(sed -n "s/^flutter \([0-9.]\+\).*/\1/p" .tool-versions)
+      git clone -b $FLUTTER_VERSION --depth 1 https://github.com/flutter/flutter.git
+    plugin: nil
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      mkdir -p $CRAFT_PART_INSTALL/usr/libexec
+      cp -r $CRAFT_PART_SRC/flutter $CRAFT_PART_INSTALL/usr/libexec/flutter
+      ln -s $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $CRAFT_PART_INSTALL/usr/bin/flutter
+      ln -s $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/dart $CRAFT_PART_INSTALL/usr/bin/dart
+      $CRAFT_PART_INSTALL/usr/bin/flutter doctor
+    build-packages:
+      - clang
+      - cmake
+      - curl
+      - libgtk-3-dev
+      - ninja-build
+      - unzip
+      - xz-utils
+      - zip
+    override-prime: ""
+
+  ubuntu-desktop-init:
+    after: [flutter-git]
+    source: .
+    source-type: git
+    plugin: nil
+    override-build: |
+      set -eux
+      mkdir -p $CRAFT_PART_INSTALL/bin/lib
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/applications
+      cp snap/local/ubuntu-desktop-init.desktop $CRAFT_PART_INSTALL/usr/share/applications/
+      dart pub global activate melos
+      dart pub global run melos bootstrap
+      cd packages/ubuntu_init
+      flutter build linux --release -v
+      cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
+    stage-packages:
+      - libsysmetrics1
+      - pciutils
+      - util-linux
+
+lint:
+  ignore:
+    - library:
+        - usr/lib/**/libsysmetrics.so.1
+
+slots:
+  dbus-name:
+    interface: dbus
+    bus: session
+    name: com.canonical.ubuntu_init


### PR DESCRIPTION
Adds a snap for ubuntu-desktop-init based on https://github.com/canonical/ubuntu-welcome/.

I've removed the custom launcher that's being used as a workaround to put a `.config/ubuntu-welcome-done` file into the user's home directory in ubuntu-welcome. We can add something like this back in later if needed, but we'd need to modify ubuntu-init accordingly first.