### PR TITLE
feat(ci): build snap on init-snap branch

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - bootstrap-snap
+      - init-snap
   pull_request:
     branches:
       - bootstrap-snap
+      - init-snap
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Same as for the `bootstrap-snap` branch