### PR TITLE
feat(ci): remove duplicate flutter-coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,32 +53,6 @@ jobs:
       env:
         SUBIQUITY_REPLAY_TIMESCALE: 100
 
-  flutter-coverage:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        package:
-          - ubuntu_bootstrap
-          - ubuntu_init
-          - ubuntu_provision
-          - ubuntu_utils
-          - ubuntu_wizard
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - uses: asdf-vm/actions/install@v2
-    - uses: bluefireteam/melos-action@v2
-    - run: flutter test --coverage
-      working-directory: packages/${{matrix.package}}
-    - run: sudo apt update && sudo apt install lcov
-    - run: lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info
-      working-directory: packages/${{matrix.package}}
-    - uses: codecov/codecov-action@v3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-
   flutter-format:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
flutter-tests runs `melos coverage`, so the flutter-coverage job is now redundant.

It was originally introduced in https://github.com/canonical/ubuntu-desktop-provision/pull/34, but I don't think there's a huge benefit of running those tests in parallel at the moment and the re-integration of subiquity_client makes this slightly more complicated again.