### PR TITLE
feat(ci): use different codecov flags for UI and provd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
     - run: melos coverage
     - uses: codecov/codecov-action@v3
       with:
+        flags: UI
         token: ${{secrets.CODECOV_TOKEN}}
 
   go-sanity:
@@ -193,3 +194,4 @@ jobs:
         with:
           file: /tmp/coverage.out
           flags: provd
+          token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
Adds separate codecov flags for the Go backend and the Flutter UI so that we can track the coverage independently