### PR TITLE
feat: add theme variant service

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -112,7 +112,6 @@ Future<void> runInstallerApp(
     }
     return TelemetryService(path);
   });
-  tryRegisterService<ThemeService>(GtkThemeService.new);
   tryRegisterService(UdevService.new);
   tryRegisterService(UrlLauncher.new);
 

--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -78,7 +78,7 @@ Future<void> runInstallerApp(
   // conditional registration if not already registered by flavors or tests
   tryRegisterServiceInstance<ArgResults>(options);
   tryRegisterService<ConfigService>(
-    () => ConfigService(scope: 'bootstrap', path: options['config'] as String?),
+    () => ConfigService(path: options['config'] as String?),
   );
   tryRegisterService<DesktopService>(() => GnomeService());
   tryRegisterServiceFactory<GSettings, String>((schema) => GSettings(schema));

--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -7,6 +7,7 @@ import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
@@ -33,6 +34,10 @@ Future<void> runInitApp(
 
     await registerInitServices(args);
 
+    final themeVariantService = getService<ThemeVariantService>();
+    await themeVariantService.load();
+    final themeVariant = themeVariantService.themeVariant;
+
     runApp(ProviderScope(
       child: Consumer(
         builder: (context, ref, child) {
@@ -43,9 +48,10 @@ Future<void> runInitApp(
           }
           return WizardApp(
             flavor: flavor,
-            theme: theme,
-            darkTheme: darkTheme,
-            onGenerateTitle: onGenerateTitle,
+            theme: theme ?? themeVariant?.theme,
+            darkTheme: darkTheme ?? themeVariant?.darkTheme,
+            onGenerateTitle:
+                onGenerateTitle ?? (_) => themeVariant?.windowTitle ?? '',
             locale: ref.watch(localeProvider),
             localizationsDelegates: [
               ...?localizationsDelegates,

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -48,6 +48,8 @@ Future<void> registerInitServices(List<String> args) {
   tryRegisterService<SessionService>(XdgSessionService.new);
   tryRegisterService<Sysmetrics>(Sysmetrics.new);
   tryRegisterService<ThemeService>(GtkThemeService.new);
+  tryRegisterService<ThemeVariantService>(
+      () => ThemeVariantService(config: tryGetService<ConfigService>()));
   tryRegisterService<TimezoneService>(XdgTimezoneService.new);
   tryRegisterService<UdevService>(UdevService.new);
   tryRegisterService(UrlLauncher.new);

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -37,7 +37,7 @@ Future<void> registerInitServices(List<String> args) {
 
   tryRegisterService<ActiveDirectoryService>(RealmdActiveDirectoryService.new);
   tryRegisterService<ConfigService>(
-      () => ConfigService(scope: 'init', path: options!['config'] as String?));
+      () => ConfigService(path: options!['config'] as String?));
   tryRegisterServiceFactory<GSettings, String>((schema) => GSettings(schema));
   tryRegisterService<IdentityService>(XdgIdentityService.new);
   tryRegisterService<KeyboardService>(XdgKeyboardService.new);

--- a/packages/ubuntu_provision/lib/services.dart
+++ b/packages/ubuntu_provision/lib/services.dart
@@ -12,5 +12,6 @@ export 'src/services/session_service.dart';
 export 'src/services/sound_service.dart';
 export 'src/services/telemetry_service.dart';
 export 'src/services/theme_service.dart';
+export 'src/services/theme_variant_service.dart';
 export 'src/services/timezone_service.dart';
 export 'src/services/udev_service.dart';

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:yaru/yaru.dart';
+
+import '../../services.dart';
+
+final _log = Logger('theme_variant');
+
+class ThemeVariant {
+  const ThemeVariant({
+    this.theme,
+    this.darkTheme,
+    this.windowTitle,
+  });
+
+  final ThemeData? theme;
+  final ThemeData? darkTheme;
+  final String? windowTitle;
+}
+
+class ThemeVariantService {
+  ThemeVariantService({ConfigService? config}) : _config = config;
+
+  final ConfigService? _config;
+  ThemeVariant? themeVariant;
+
+  Future<(ThemeData?, ThemeData?)> _loadTheme() async {
+    final accentColor = await _config?.getColor('accent-color');
+    if (accentColor == null) {
+      return (null, null);
+    }
+
+    final elevatedButtonColor =
+        await _config?.getColor('elevated-button-color');
+    final elevatedButtonTextColor =
+        await _config?.getColor('elevated-button-text-color');
+
+    final theme = createYaruLightTheme(
+      primaryColor: accentColor,
+      elevatedButtonColor: elevatedButtonColor,
+      elevatedButtonTextColor: elevatedButtonTextColor,
+    );
+    final darkTheme = createYaruDarkTheme(
+      primaryColor: accentColor,
+      elevatedButtonColor: elevatedButtonColor,
+      elevatedButtonTextColor: elevatedButtonTextColor,
+    );
+    return (theme, darkTheme);
+  }
+
+  Future<void> load() async {
+    final (theme, darkTheme) = await _loadTheme();
+    final windowTitle = await _config?.get<String>('window-title');
+
+    themeVariant = ThemeVariant(
+      theme: theme,
+      darkTheme: darkTheme,
+      windowTitle: windowTitle,
+    );
+  }
+}
+
+extension on ConfigService {
+  Future<Color?> getColor(String name) async {
+    final colorString = (await get<String>(name))?.replaceFirst(r'#', '');
+    if (colorString == null) {
+      return null;
+    }
+    final color = int.tryParse(colorString, radix: 16);
+    if (color == null) {
+      _log.error('could not parse color \'$colorString\' for $name');
+      return null;
+    }
+    return Color(color).withOpacity(1);
+  }
+}

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -1,0 +1,222 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'theme_variant_service.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ThemeConfig _$ThemeConfigFromJson(Map<String, dynamic> json) {
+  return _ThemeConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ThemeConfig {
+  String? get accentColor => throw _privateConstructorUsedError;
+  String? get elevatedButtonColor => throw _privateConstructorUsedError;
+  String? get elevatedButtonTextColor => throw _privateConstructorUsedError;
+  String? get windowTitle => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ThemeConfigCopyWith<ThemeConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ThemeConfigCopyWith<$Res> {
+  factory $ThemeConfigCopyWith(
+          ThemeConfig value, $Res Function(ThemeConfig) then) =
+      _$ThemeConfigCopyWithImpl<$Res, ThemeConfig>;
+  @useResult
+  $Res call(
+      {String? accentColor,
+      String? elevatedButtonColor,
+      String? elevatedButtonTextColor,
+      String? windowTitle});
+}
+
+/// @nodoc
+class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
+    implements $ThemeConfigCopyWith<$Res> {
+  _$ThemeConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? accentColor = freezed,
+    Object? elevatedButtonColor = freezed,
+    Object? elevatedButtonTextColor = freezed,
+    Object? windowTitle = freezed,
+  }) {
+    return _then(_value.copyWith(
+      accentColor: freezed == accentColor
+          ? _value.accentColor
+          : accentColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      elevatedButtonColor: freezed == elevatedButtonColor
+          ? _value.elevatedButtonColor
+          : elevatedButtonColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      elevatedButtonTextColor: freezed == elevatedButtonTextColor
+          ? _value.elevatedButtonTextColor
+          : elevatedButtonTextColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      windowTitle: freezed == windowTitle
+          ? _value.windowTitle
+          : windowTitle // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ThemeConfigImplCopyWith<$Res>
+    implements $ThemeConfigCopyWith<$Res> {
+  factory _$$ThemeConfigImplCopyWith(
+          _$ThemeConfigImpl value, $Res Function(_$ThemeConfigImpl) then) =
+      __$$ThemeConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? accentColor,
+      String? elevatedButtonColor,
+      String? elevatedButtonTextColor,
+      String? windowTitle});
+}
+
+/// @nodoc
+class __$$ThemeConfigImplCopyWithImpl<$Res>
+    extends _$ThemeConfigCopyWithImpl<$Res, _$ThemeConfigImpl>
+    implements _$$ThemeConfigImplCopyWith<$Res> {
+  __$$ThemeConfigImplCopyWithImpl(
+      _$ThemeConfigImpl _value, $Res Function(_$ThemeConfigImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? accentColor = freezed,
+    Object? elevatedButtonColor = freezed,
+    Object? elevatedButtonTextColor = freezed,
+    Object? windowTitle = freezed,
+  }) {
+    return _then(_$ThemeConfigImpl(
+      accentColor: freezed == accentColor
+          ? _value.accentColor
+          : accentColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      elevatedButtonColor: freezed == elevatedButtonColor
+          ? _value.elevatedButtonColor
+          : elevatedButtonColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      elevatedButtonTextColor: freezed == elevatedButtonTextColor
+          ? _value.elevatedButtonTextColor
+          : elevatedButtonTextColor // ignore: cast_nullable_to_non_nullable
+              as String?,
+      windowTitle: freezed == windowTitle
+          ? _value.windowTitle
+          : windowTitle // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.kebab, explicitToJson: true)
+class _$ThemeConfigImpl implements _ThemeConfig {
+  const _$ThemeConfigImpl(
+      {this.accentColor,
+      this.elevatedButtonColor,
+      this.elevatedButtonTextColor,
+      this.windowTitle});
+
+  factory _$ThemeConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ThemeConfigImplFromJson(json);
+
+  @override
+  final String? accentColor;
+  @override
+  final String? elevatedButtonColor;
+  @override
+  final String? elevatedButtonTextColor;
+  @override
+  final String? windowTitle;
+
+  @override
+  String toString() {
+    return 'ThemeConfig(accentColor: $accentColor, elevatedButtonColor: $elevatedButtonColor, elevatedButtonTextColor: $elevatedButtonTextColor, windowTitle: $windowTitle)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ThemeConfigImpl &&
+            (identical(other.accentColor, accentColor) ||
+                other.accentColor == accentColor) &&
+            (identical(other.elevatedButtonColor, elevatedButtonColor) ||
+                other.elevatedButtonColor == elevatedButtonColor) &&
+            (identical(
+                    other.elevatedButtonTextColor, elevatedButtonTextColor) ||
+                other.elevatedButtonTextColor == elevatedButtonTextColor) &&
+            (identical(other.windowTitle, windowTitle) ||
+                other.windowTitle == windowTitle));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, accentColor, elevatedButtonColor,
+      elevatedButtonTextColor, windowTitle);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
+      __$$ThemeConfigImplCopyWithImpl<_$ThemeConfigImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ThemeConfigImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ThemeConfig implements ThemeConfig {
+  const factory _ThemeConfig(
+      {final String? accentColor,
+      final String? elevatedButtonColor,
+      final String? elevatedButtonTextColor,
+      final String? windowTitle}) = _$ThemeConfigImpl;
+
+  factory _ThemeConfig.fromJson(Map<String, dynamic> json) =
+      _$ThemeConfigImpl.fromJson;
+
+  @override
+  String? get accentColor;
+  @override
+  String? get elevatedButtonColor;
+  @override
+  String? get elevatedButtonTextColor;
+  @override
+  String? get windowTitle;
+  @override
+  @JsonKey(ignore: true)
+  _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.g.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theme_variant_service.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ThemeConfigImpl _$$ThemeConfigImplFromJson(Map<String, dynamic> json) =>
+    _$ThemeConfigImpl(
+      accentColor: json['accent-color'] as String?,
+      elevatedButtonColor: json['elevated-button-color'] as String?,
+      elevatedButtonTextColor: json['elevated-button-text-color'] as String?,
+      windowTitle: json['window-title'] as String?,
+    );
+
+Map<String, dynamic> _$$ThemeConfigImplToJson(_$ThemeConfigImpl instance) =>
+    <String, dynamic>{
+      'accent-color': instance.accentColor,
+      'elevated-button-color': instance.elevatedButtonColor,
+      'elevated-button-text-color': instance.elevatedButtonTextColor,
+      'window-title': instance.windowTitle,
+    };

--- a/packages/ubuntu_provision/lib/theme_variant.dart
+++ b/packages/ubuntu_provision/lib/theme_variant.dart
@@ -1,0 +1,1 @@
+export 'src/services/theme_variant_service.dart';

--- a/packages/ubuntu_provision/lib/ubuntu_provision.dart
+++ b/packages/ubuntu_provision/lib/ubuntu_provision.dart
@@ -9,5 +9,6 @@ export 'locale.dart';
 export 'network.dart';
 export 'services.dart';
 export 'theme.dart';
+export 'theme_variant.dart';
 export 'timezone.dart';
 export 'widgets.dart';

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -18,8 +18,10 @@ dependencies:
     sdk: flutter
   flutter_html: ^3.0.0-beta.1
   flutter_riverpod: ^2.4.5
+  freezed_annotation: ^2.4.1
   form_field_validator: ^1.1.0
   gsettings: ^0.2.8
+  json_annotation: ^4.8.1
   meta: ^1.9.1
   nm: ^0.5.0
   path: ^1.8.3
@@ -54,6 +56,8 @@ dev_dependencies:
   fake_async: ^1.3.1
   flutter_test:
     sdk: flutter
+  freezed: ^2.4.5
+  json_serializable: ^6.7.1
   mockito: 5.4.2
   ubuntu_lints: ^0.1.0
   ubuntu_test: ^0.1.0-0

--- a/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
+++ b/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:ubuntu_provision/theme_variant.dart';
+import 'package:yaml/yaml.dart';
 
 import '../test_utils.dart';
 
@@ -48,8 +49,8 @@ void main() {
 
 MockConfigService createMockConfigService({Map<String, dynamic>? config}) {
   final mock = MockConfigService();
-  when(mock.get<String>(any)).thenAnswer((i) =>
-      Future.value(config?[i.positionalArguments.first] as String? ?? null));
+  when(mock.get('theme'))
+      .thenAnswer((_) async => YamlMap.wrap(config?.cast() ?? {}));
   return mock;
 }
 

--- a/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
+++ b/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:ubuntu_provision/theme_variant.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('ThemeVariantService', () {
+    test('getThemeVariant', () async {
+      final config = {
+        'accent-color': '#ff0000',
+        'elevated-button-color': '#00ff00',
+        'elevated-button-text-color': '#0000ff',
+        'window-title': 'Window Title',
+      };
+      final service =
+          ThemeVariantService(config: createMockConfigService(config: config));
+      await service.load();
+      final themeVariant = service.themeVariant;
+      expect(themeVariant, isNotNull);
+      expect(
+          themeVariant!.theme?.primaryColor, equals(const Color(0xffff0000)));
+      expect(themeVariant.theme?.elevatedButtonColor,
+          equals(const Color(0xff00ff00)));
+      expect(themeVariant.theme?.elevatedButtonTextColor,
+          equals(const Color(0xff0000ff)));
+      expect(themeVariant.darkTheme?.primaryColor,
+          equals(const Color(0xffff0000)));
+      expect(themeVariant.darkTheme?.elevatedButtonColor,
+          equals(const Color(0xff00ff00)));
+      expect(themeVariant.darkTheme?.elevatedButtonTextColor,
+          equals(const Color(0xff0000ff)));
+      expect(themeVariant.windowTitle, 'Window Title');
+    });
+
+    test('getThemeVariant with missing config', () async {
+      final service = ThemeVariantService(config: createMockConfigService());
+      await service.load();
+      final variant = service.themeVariant;
+      expect(variant, isNotNull);
+      expect(variant!.theme, null);
+      expect(variant.darkTheme, null);
+      expect(variant.windowTitle, null);
+    });
+  });
+}
+
+MockConfigService createMockConfigService({Map<String, dynamic>? config}) {
+  final mock = MockConfigService();
+  when(mock.get<String>(any)).thenAnswer((i) =>
+      Future.value(config?[i.positionalArguments.first] as String? ?? null));
+  return mock;
+}
+
+extension on ThemeData {
+  Color? get elevatedButtonColor =>
+      elevatedButtonTheme.style?.backgroundColor?.resolve({});
+  Color? get elevatedButtonTextColor =>
+      elevatedButtonTheme.style?.foregroundColor?.resolve({});
+}


### PR DESCRIPTION
Adds a `ThemeVariantService` to ubuntu-provision that loads some configuration options from the `ConfigService` and creates a `ThemeVariant`, which contains customized yaru themes and a window title.
Example configuration:
```yaml
bootstrap:
  accent-color: '#0000ff'
  elevated-button-color: '#ff0000'
  elevated-button-text-color: '#00ff00'
  window-title: 'My custom window title'
```
(the color parameters are already supported by yaru.dart without any further customization needed).

I'm sure we'll want to adjust details like config file location, scope, etc later on.

Ref #205
UDENG-1762 