### PR TITLE
feat: add PageConfigService

### DIFF
--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -11,8 +11,8 @@ class InstallerService {
 
   final SubiquityClient _client;
   final PageConfigService? _pageConfig;
-  List<String>? _excludedPages;
-  List<String>? _subiquityPages;
+  Set<String>? _excludedPages;
+  Set<String>? _subiquityPages;
 
   Future<void> init() async {
     await _client.setVariant(Variant.DESKTOP);
@@ -36,11 +36,8 @@ class InstallerService {
 
   Future<void> load() async {
     await monitorStatus().firstWhere((s) => s?.isLoading == false);
-    _subiquityPages = await _client.getInteractiveSections();
-    _excludedPages = _pageConfig?.pages.entries
-        .whereNot((e) => e.value.visible)
-        .map((e) => e.key)
-        .toList();
+    _subiquityPages = (await _client.getInteractiveSections())?.toSet();
+    _excludedPages = _pageConfig?.excludedPages;
 
     if ((_subiquityPages?.isNotEmpty ?? false) &&
         (_excludedPages?.isNotEmpty ?? false)) {

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -39,13 +39,12 @@ class InstallerService {
     _subiquityPages = (await _client.getInteractiveSections())?.toSet();
     _excludedPages = _pageConfig?.excludedPages;
 
-    if ((_subiquityPages?.isNotEmpty ?? false) &&
-        (_excludedPages?.isNotEmpty ?? false)) {
-      final requiredExcludedPages =
-          _excludedPages!.intersection(_subiquityPages!);
+    final requiredExcludedPages =
+        _excludedPages?.intersection(_subiquityPages ?? {});
+    if (requiredExcludedPages?.isNotEmpty ?? false) {
       _log.info(
           '$requiredExcludedPages are required by subiquity and cannot be excluded!');
-      _excludedPages!.removeAll(requiredExcludedPages);
+      _excludedPages!.removeAll(requiredExcludedPages!);
     }
   }
 

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -1,15 +1,18 @@
 import 'package:dartx/dartx.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/services.dart';
 
-class InstallerService {
-  InstallerService(this._client, {ConfigService? config, List<String>? pages})
-      : _config = config,
-        _pages = pages?.map((r) => r.removePrefix('/')).toList();
+final _log = Logger('installer_service');
 
-  List<String>? _pages;
+class InstallerService {
+  InstallerService(this._client, {PageConfigService? pageConfig})
+      : _pageConfig = pageConfig;
+
   final SubiquityClient _client;
-  final ConfigService? _config;
+  final PageConfigService? _pageConfig;
+  List<String>? _excludedPages;
+  List<String>? _subiquityPages;
 
   Future<void> init() async {
     await _client.setVariant(Variant.DESKTOP);
@@ -33,8 +36,20 @@ class InstallerService {
 
   Future<void> load() async {
     await monitorStatus().firstWhere((s) => s?.isLoading == false);
-    _pages ??=
-        await _client.getInteractiveSections() ?? await _config?.getPages();
+    _subiquityPages = await _client.getInteractiveSections();
+    _excludedPages = _pageConfig?.pages.entries
+        .whereNot((e) => e.value.visible)
+        .map((e) => e.key)
+        .toList();
+
+    if ((_subiquityPages?.isNotEmpty ?? false) &&
+        (_excludedPages?.isNotEmpty ?? false)) {
+      final requiredExcludedPages =
+          _excludedPages!.where(_subiquityPages!.contains);
+      _log.info(
+          '$requiredExcludedPages are required by subiquity and cannot be excluded!');
+      _excludedPages!.removeWhere(requiredExcludedPages.contains);
+    }
   }
 
   Future<void> start() => _client.confirm('/dev/tty1');
@@ -42,7 +57,10 @@ class InstallerService {
   Stream<ApplicationStatus?> monitorStatus() => _client.monitorStatus();
 
   bool hasRoute(String route) {
-    return _pages?.contains(route.removePrefix('/')) ?? true;
+    if (_subiquityPages?.isNotEmpty ?? false) {
+      return _subiquityPages!.contains(route.removePrefix('/'));
+    }
+    return !(_excludedPages?.contains(route.removePrefix('/')) ?? false);
   }
 }
 
@@ -54,13 +72,4 @@ extension ApplicationStatusX on ApplicationStatus {
   bool get isInstalling =>
       state.index >= ApplicationState.RUNNING.index &&
       state.index < ApplicationState.DONE.index;
-}
-
-extension on ConfigService {
-  Future<List<String>?> getPages() async {
-    final value = await get('pages');
-    return (value is List ? value.cast<String>() : value?.toString().split(','))
-        ?.map((p) => p.trim())
-        .toList();
-  }
 }

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -42,10 +42,10 @@ class InstallerService {
     if ((_subiquityPages?.isNotEmpty ?? false) &&
         (_excludedPages?.isNotEmpty ?? false)) {
       final requiredExcludedPages =
-          _excludedPages!.where(_subiquityPages!.contains);
+          _excludedPages!.intersection(_subiquityPages!);
       _log.info(
           '$requiredExcludedPages are required by subiquity and cannot be excluded!');
-      _excludedPages!.removeWhere(requiredExcludedPages.contains);
+      _excludedPages!.removeAll(requiredExcludedPages);
     }
   }
 

--- a/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
@@ -148,32 +148,15 @@ void main() {
     when(client.monitorStatus()).thenAnswer(
         (_) => Stream.value(fakeApplicationStatus(ApplicationState.WAITING)));
 
-    final config = MockConfigService();
-    when(config.get('pages')).thenAnswer((_) async => ['a', 'b']);
+    final pageConfig = MockPageConfigService();
+    when(pageConfig.excludedPages).thenReturn({'c'});
 
-    final service = InstallerService(client, config: config);
+    final service = InstallerService(client, pageConfig: pageConfig);
     await service.load();
 
     expect(service.hasRoute('a'), isTrue);
     expect(service.hasRoute('b'), isTrue);
     expect(service.hasRoute('c'), isFalse);
-  });
-
-  test('configured page string', () async {
-    final client = MockSubiquityClient();
-    when(client.getInteractiveSections()).thenAnswer((_) async => null);
-    when(client.monitorStatus()).thenAnswer(
-        (_) => Stream.value(fakeApplicationStatus(ApplicationState.WAITING)));
-
-    final config = MockConfigService();
-    when(config.get('pages')).thenAnswer((_) async => 'c, e');
-
-    final service = InstallerService(client, config: config);
-    await service.load();
-
-    expect(service.hasRoute('c'), isTrue);
-    expect(service.hasRoute('d'), isFalse);
-    expect(service.hasRoute('e'), isTrue);
   });
 
   test('start installation', () async {

--- a/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
+++ b/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
@@ -75,35 +75,4 @@ void main() {
 
     await expectLater(windowClosed, completes);
   });
-
-  testWidgets('pages', (tester) async {
-    await tester.runApp(() => runInitApp(['--pages=locale,keyboard,identity']));
-
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-    await expectLocale('en_US.UTF-8');
-
-    await tester.testKeyboardPage(layout: 'English (US)');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-    await expectKeyboard(const KeyboardSetting(layout: 'us'));
-
-    final windowClosed = YaruTestWindow.waitForClosed();
-
-    const identity = Identity(
-      realname: 'User',
-      username: 'user',
-      hostname: 'ubuntu',
-    );
-    await tester.testIdentityPage(
-      identity: identity,
-      password: 'password',
-    );
-    await tester.tapNext(); // TODO: tapDone()
-    await tester.pumpAndSettle();
-    await expectIdentity(identity);
-
-    await expectLater(windowClosed, completes);
-  });
 }

--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -14,7 +14,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 Future<void> runInitApp(
   List<String> args, {
-  List<String>? pages,
   String package = 'ubuntu_init',
   UbuntuFlavor? flavor,
   ThemeData? theme,
@@ -38,6 +37,8 @@ Future<void> runInitApp(
     await themeVariantService.load();
     final themeVariant = themeVariantService.themeVariant;
 
+    await getService<PageConfigService>().load();
+
     runApp(ProviderScope(
       child: Consumer(
         builder: (context, ref, child) {
@@ -60,7 +61,7 @@ Future<void> runInitApp(
             supportedLocales: supportedLocales,
             home: DefaultAssetBundle(
               bundle: ProxyAssetBundle(rootBundle, package: package),
-              child: InitWizard(pages: pages, onDone: onDone),
+              child: InitWizard(onDone: onDone),
             ),
           );
         },

--- a/packages/ubuntu_init/lib/src/init_model.dart
+++ b/packages/ubuntu_init/lib/src/init_model.dart
@@ -8,40 +8,23 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 
 final initModelProvider = Provider(
   (_) => InitModel(
-    config: tryGetService<ConfigService>(),
+    pageConfig: tryGetService<PageConfigService>(),
     args: tryGetService<ArgResults>(),
   ),
 );
 
 class InitModel {
-  InitModel({ConfigService? config, ArgResults? args})
-      : _config = config,
-        _args = args;
+  InitModel({PageConfigService? pageConfig, ArgResults? args})
+      : _pageConfig = pageConfig;
 
-  final ConfigService? _config;
-  final ArgResults? _args;
-  Set<String>? _pages;
+  final PageConfigService? _pageConfig;
+  Set<String>? _excludedPages;
 
   Future<void> init() async {
-    _pages ??= (await _config?.getPages() ?? _args?.getPages())
-        ?.map((r) => r.removePrefix('/'))
-        .toSet();
+    _excludedPages = _pageConfig?.excludedPages;
   }
 
   bool hasRoute(String route) {
-    return _pages?.contains(route.removePrefix('/')) ?? true;
+    return !(_excludedPages?.contains(route.removePrefix('/')) ?? false);
   }
-}
-
-extension on ConfigService {
-  Future<List<String>?> getPages() async {
-    final value = await get('pages');
-    return (value is List ? value.cast<String>() : value?.toString().split(','))
-        ?.map((p) => p.trim())
-        .toList();
-  }
-}
-
-extension on ArgResults {
-  List<String>? getPages() => (this['pages'] as String?)?.split(',');
 }

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -43,6 +43,8 @@ Future<void> registerInitServices(List<String> args) {
   tryRegisterService<KeyboardService>(XdgKeyboardService.new);
   tryRegisterService<LocaleService>(XdgLocaleService.new);
   tryRegisterService<NetworkService>(NetworkService.new);
+  tryRegisterService<PageConfigService>(
+      () => PageConfigService(config: tryGetService<ConfigService>()));
   tryRegisterService<PrivacyService>(GnomePrivacyService.new);
   tryRegisterService<ProductService>(ProductService.new);
   tryRegisterService<SessionService>(XdgSessionService.new);

--- a/packages/ubuntu_init/lib/src/init_wizard.dart
+++ b/packages/ubuntu_init/lib/src/init_wizard.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
@@ -36,17 +35,10 @@ class InitRoutes {
 class InitWizard extends ConsumerWidget {
   InitWizard({
     super.key,
-    List<String>? pages,
     FutureOr<void> Function()? onDone,
-  })  : _pages = pages?.map((r) => r.removePrefix('/')).toSet(),
-        _onDone = onDone;
+  }) : _onDone = onDone;
 
-  final Set<String>? _pages;
   final FutureOr<void> Function()? _onDone;
-
-  bool _hasRoute(String route) {
-    return _pages?.contains(route.removePrefix('/')) ?? true;
-  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -126,7 +118,7 @@ class InitWizard extends ConsumerWidget {
       userData: WizardData(totalSteps: InitStep.values.length),
       predicate: (route) => switch (route) {
         InitRoutes.initial => true,
-        _ => _hasRoute(route) && ref.read(initModelProvider).hasRoute(route),
+        _ => ref.read(initModelProvider).hasRoute(route),
       },
     );
   }

--- a/packages/ubuntu_init/test/init_model_test.dart
+++ b/packages/ubuntu_init/test/init_model_test.dart
@@ -7,26 +7,13 @@ import 'package:ubuntu_provision/services.dart';
 
 import 'init_model_test.mocks.dart';
 
-@GenerateMocks([ArgResults, ConfigService])
+@GenerateMocks([ArgResults, PageConfigService])
 void main() {
-  test('init', () async {
-    final config = MockConfigService();
-    when(config.get('pages')).thenAnswer((_) async => null);
-
-    final args = MockArgResults();
-    when(args['pages']).thenReturn(null);
-
-    final model = InitModel(config: config, args: args);
-    await model.init();
-    verify(config.get('pages')).called(1);
-    verify(args['pages']).called(1);
-  });
-
   test('configured page array', () async {
-    final config = MockConfigService();
-    when(config.get('pages')).thenAnswer((_) async => ['a', '/b']);
+    final config = MockPageConfigService();
+    when(config.excludedPages).thenReturn({'c'});
 
-    final model = InitModel(config: config);
+    final model = InitModel(pageConfig: config);
     await model.init();
 
     expect(model.hasRoute('a'), isTrue);
@@ -37,17 +24,5 @@ void main() {
 
     expect(model.hasRoute('c'), isFalse);
     expect(model.hasRoute('/c'), isFalse);
-  });
-
-  test('configured page string', () async {
-    final config = MockConfigService();
-    when(config.get('pages')).thenAnswer((_) async => 'c, e');
-
-    final model = InitModel(config: config);
-    await model.init();
-
-    expect(model.hasRoute('c'), isTrue);
-    expect(model.hasRoute('d'), isFalse);
-    expect(model.hasRoute('e'), isTrue);
   });
 }

--- a/packages/ubuntu_init/test/init_model_test.mocks.dart
+++ b/packages/ubuntu_init/test/init_model_test.mocks.dart
@@ -7,7 +7,7 @@ import 'dart:async' as _i4;
 
 import 'package:args/src/arg_results.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:ubuntu_provision/src/services/config_service.dart' as _i3;
+import 'package:ubuntu_provision/services.dart' as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -64,34 +64,33 @@ class MockArgResults extends _i1.Mock implements _i2.ArgResults {
       ) as bool);
 }
 
-/// A class which mocks [ConfigService].
+/// A class which mocks [PageConfigService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockConfigService extends _i1.Mock implements _i3.ConfigService {
-  MockConfigService() {
+class MockPageConfigService extends _i1.Mock implements _i3.PageConfigService {
+  MockPageConfigService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<T?> get<T>(
-    String? key, {
-    String? scope,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #get,
-          [key],
-          {#scope: scope},
-        ),
-        returnValue: _i4.Future<T?>.value(),
-      ) as _i4.Future<T?>);
+  Map<String, _i3.PageConfigEntry> get pages => (super.noSuchMethod(
+        Invocation.getter(#pages),
+        returnValue: <String, _i3.PageConfigEntry>{},
+      ) as Map<String, _i3.PageConfigEntry>);
 
   @override
-  _i4.Future<Map<String, dynamic>?> load() => (super.noSuchMethod(
+  Set<String> get excludedPages => (super.noSuchMethod(
+        Invocation.getter(#excludedPages),
+        returnValue: <String>{},
+      ) as Set<String>);
+
+  @override
+  _i4.Future<void> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i4.Future<Map<String, dynamic>?>.value(),
-      ) as _i4.Future<Map<String, dynamic>?>);
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
 }

--- a/packages/ubuntu_provision/build.yaml
+++ b/packages/ubuntu_provision/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          explicit_to_json: true
+          field_rename: kebab

--- a/packages/ubuntu_provision/lib/services.dart
+++ b/packages/ubuntu_provision/lib/services.dart
@@ -6,6 +6,7 @@ export 'src/services/journal_service.dart';
 export 'src/services/keyboard_service.dart';
 export 'src/services/locale_service.dart';
 export 'src/services/network_service.dart';
+export 'src/services/page_config_service.dart';
 export 'src/services/power_service.dart';
 export 'src/services/product_service.dart';
 export 'src/services/session_service.dart';

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.dart
@@ -1,0 +1,85 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../services.dart';
+
+part 'page_config_service.freezed.dart';
+part 'page_config_service.g.dart';
+
+final _log = Logger('page');
+
+@freezed
+class PageConfigEntry with _$PageConfigEntry {
+  const factory PageConfigEntry({
+    String? image,
+    String? title,
+    @Default(true) bool visible,
+  }) = _PageConfigEntry;
+  factory PageConfigEntry.fromJson(Map<String, dynamic> json) =>
+      _$PageConfigEntryFromJson(json);
+}
+
+@freezed
+class PageConfig with _$PageConfig {
+  const factory PageConfig({
+    @Default({}) @PageConfigEntryConverter() Map<String, PageConfigEntry> pages,
+  }) = _PageConfig;
+  factory PageConfig.fromJson(Map<String, dynamic> json) =>
+      _$PageConfigFromJson(json);
+}
+
+class PageConfigEntryConverter
+    extends JsonConverter<Map<String, PageConfigEntry>, Map<String, dynamic>> {
+  const PageConfigEntryConverter();
+
+  @override
+  Map<String, PageConfigEntry> fromJson(Map<String, dynamic> objects) {
+    final pages = <String, PageConfigEntry>{};
+    for (final entry in objects.entries) {
+      if (entry.value is bool) {
+        pages[entry.key] = PageConfigEntry(visible: entry.value as bool);
+      } else if (entry.value is Map<String, dynamic>) {
+        pages[entry.key] =
+            PageConfigEntry.fromJson(entry.value as Map<String, dynamic>);
+      } else if (entry.value is YamlMap) {
+        pages[entry.key] =
+            PageConfigEntry.fromJson((entry.value as YamlMap).cast());
+      } else {
+        _log.error(
+            'Invalid page config entry for ${entry.key}: ${entry.value}');
+        continue;
+      }
+    }
+    return pages;
+  }
+
+  @override
+  Map<String, dynamic> toJson(Map<String, PageConfigEntry> pages) {
+    final objects = <String, dynamic>{};
+    for (final entry in pages.entries) {
+      if (entry.value.image != null || entry.value.title != null) {
+        objects[entry.key] = entry.value.toJson();
+      } else {
+        objects[entry.key] = (entry.value.visible);
+      }
+    }
+    return objects;
+  }
+}
+
+class PageConfigService {
+  PageConfigService({ConfigService? config}) : _config = config;
+
+  final ConfigService? _config;
+  final Map<String, PageConfigEntry> pages = {};
+
+  Future<void> load() async {
+    final pageConfig = PageConfig.fromJson({
+      'pages': Map<String, dynamic>.from(
+        (await _config!.get<YamlMap>('pages'))?.value.cast() ?? {},
+      )
+    });
+    pages.addAll(pageConfig.pages);
+  }
+}

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:yaml/yaml.dart';
@@ -73,6 +74,9 @@ class PageConfigService {
 
   final ConfigService? _config;
   final Map<String, PageConfigEntry> pages = {};
+
+  Set<String> get excludedPages =>
+      pages.entries.whereNot((e) => e.value.visible).map((e) => e.key).toSet();
 
   Future<void> load() async {
     final pageConfig = PageConfig.fromJson({

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
@@ -1,0 +1,339 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'page_config_service.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+PageConfigEntry _$PageConfigEntryFromJson(Map<String, dynamic> json) {
+  return _PageConfigEntry.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PageConfigEntry {
+  String? get image => throw _privateConstructorUsedError;
+  String? get title => throw _privateConstructorUsedError;
+  bool get visible => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PageConfigEntryCopyWith<PageConfigEntry> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PageConfigEntryCopyWith<$Res> {
+  factory $PageConfigEntryCopyWith(
+          PageConfigEntry value, $Res Function(PageConfigEntry) then) =
+      _$PageConfigEntryCopyWithImpl<$Res, PageConfigEntry>;
+  @useResult
+  $Res call({String? image, String? title, bool visible});
+}
+
+/// @nodoc
+class _$PageConfigEntryCopyWithImpl<$Res, $Val extends PageConfigEntry>
+    implements $PageConfigEntryCopyWith<$Res> {
+  _$PageConfigEntryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? image = freezed,
+    Object? title = freezed,
+    Object? visible = null,
+  }) {
+    return _then(_value.copyWith(
+      image: freezed == image
+          ? _value.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      visible: null == visible
+          ? _value.visible
+          : visible // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PageConfigEntryImplCopyWith<$Res>
+    implements $PageConfigEntryCopyWith<$Res> {
+  factory _$$PageConfigEntryImplCopyWith(_$PageConfigEntryImpl value,
+          $Res Function(_$PageConfigEntryImpl) then) =
+      __$$PageConfigEntryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? image, String? title, bool visible});
+}
+
+/// @nodoc
+class __$$PageConfigEntryImplCopyWithImpl<$Res>
+    extends _$PageConfigEntryCopyWithImpl<$Res, _$PageConfigEntryImpl>
+    implements _$$PageConfigEntryImplCopyWith<$Res> {
+  __$$PageConfigEntryImplCopyWithImpl(
+      _$PageConfigEntryImpl _value, $Res Function(_$PageConfigEntryImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? image = freezed,
+    Object? title = freezed,
+    Object? visible = null,
+  }) {
+    return _then(_$PageConfigEntryImpl(
+      image: freezed == image
+          ? _value.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      visible: null == visible
+          ? _value.visible
+          : visible // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageConfigEntryImpl implements _PageConfigEntry {
+  const _$PageConfigEntryImpl({this.image, this.title, this.visible = true});
+
+  factory _$PageConfigEntryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PageConfigEntryImplFromJson(json);
+
+  @override
+  final String? image;
+  @override
+  final String? title;
+  @override
+  @JsonKey()
+  final bool visible;
+
+  @override
+  String toString() {
+    return 'PageConfigEntry(image: $image, title: $title, visible: $visible)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageConfigEntryImpl &&
+            (identical(other.image, image) || other.image == image) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.visible, visible) || other.visible == visible));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, image, title, visible);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
+      __$$PageConfigEntryImplCopyWithImpl<_$PageConfigEntryImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageConfigEntryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PageConfigEntry implements PageConfigEntry {
+  const factory _PageConfigEntry(
+      {final String? image,
+      final String? title,
+      final bool visible}) = _$PageConfigEntryImpl;
+
+  factory _PageConfigEntry.fromJson(Map<String, dynamic> json) =
+      _$PageConfigEntryImpl.fromJson;
+
+  @override
+  String? get image;
+  @override
+  String? get title;
+  @override
+  bool get visible;
+  @override
+  @JsonKey(ignore: true)
+  _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+PageConfig _$PageConfigFromJson(Map<String, dynamic> json) {
+  return _PageConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PageConfig {
+  @PageConfigEntryConverter()
+  Map<String, PageConfigEntry> get pages => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PageConfigCopyWith<PageConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PageConfigCopyWith<$Res> {
+  factory $PageConfigCopyWith(
+          PageConfig value, $Res Function(PageConfig) then) =
+      _$PageConfigCopyWithImpl<$Res, PageConfig>;
+  @useResult
+  $Res call({@PageConfigEntryConverter() Map<String, PageConfigEntry> pages});
+}
+
+/// @nodoc
+class _$PageConfigCopyWithImpl<$Res, $Val extends PageConfig>
+    implements $PageConfigCopyWith<$Res> {
+  _$PageConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pages = null,
+  }) {
+    return _then(_value.copyWith(
+      pages: null == pages
+          ? _value.pages
+          : pages // ignore: cast_nullable_to_non_nullable
+              as Map<String, PageConfigEntry>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PageConfigImplCopyWith<$Res>
+    implements $PageConfigCopyWith<$Res> {
+  factory _$$PageConfigImplCopyWith(
+          _$PageConfigImpl value, $Res Function(_$PageConfigImpl) then) =
+      __$$PageConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@PageConfigEntryConverter() Map<String, PageConfigEntry> pages});
+}
+
+/// @nodoc
+class __$$PageConfigImplCopyWithImpl<$Res>
+    extends _$PageConfigCopyWithImpl<$Res, _$PageConfigImpl>
+    implements _$$PageConfigImplCopyWith<$Res> {
+  __$$PageConfigImplCopyWithImpl(
+      _$PageConfigImpl _value, $Res Function(_$PageConfigImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pages = null,
+  }) {
+    return _then(_$PageConfigImpl(
+      pages: null == pages
+          ? _value._pages
+          : pages // ignore: cast_nullable_to_non_nullable
+              as Map<String, PageConfigEntry>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PageConfigImpl implements _PageConfig {
+  const _$PageConfigImpl(
+      {@PageConfigEntryConverter()
+      final Map<String, PageConfigEntry> pages = const {}})
+      : _pages = pages;
+
+  factory _$PageConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PageConfigImplFromJson(json);
+
+  final Map<String, PageConfigEntry> _pages;
+  @override
+  @JsonKey()
+  @PageConfigEntryConverter()
+  Map<String, PageConfigEntry> get pages {
+    if (_pages is EqualUnmodifiableMapView) return _pages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_pages);
+  }
+
+  @override
+  String toString() {
+    return 'PageConfig(pages: $pages)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageConfigImpl &&
+            const DeepCollectionEquality().equals(other._pages, _pages));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_pages));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
+      __$$PageConfigImplCopyWithImpl<_$PageConfigImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PageConfigImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PageConfig implements PageConfig {
+  const factory _PageConfig(
+      {@PageConfigEntryConverter()
+      final Map<String, PageConfigEntry> pages}) = _$PageConfigImpl;
+
+  factory _PageConfig.fromJson(Map<String, dynamic> json) =
+      _$PageConfigImpl.fromJson;
+
+  @override
+  @PageConfigEntryConverter()
+  Map<String, PageConfigEntry> get pages;
+  @override
+  @JsonKey(ignore: true)
+  _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.g.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'page_config_service.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PageConfigEntryImpl _$$PageConfigEntryImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PageConfigEntryImpl(
+      image: json['image'] as String?,
+      title: json['title'] as String?,
+      visible: json['visible'] as bool? ?? true,
+    );
+
+Map<String, dynamic> _$$PageConfigEntryImplToJson(
+        _$PageConfigEntryImpl instance) =>
+    <String, dynamic>{
+      'image': instance.image,
+      'title': instance.title,
+      'visible': instance.visible,
+    };
+
+_$PageConfigImpl _$$PageConfigImplFromJson(Map<String, dynamic> json) =>
+    _$PageConfigImpl(
+      pages: json['pages'] == null
+          ? const {}
+          : const PageConfigEntryConverter()
+              .fromJson(json['pages'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$PageConfigImplToJson(_$PageConfigImpl instance) =>
+    <String, dynamic>{
+      'pages': const PageConfigEntryConverter().toJson(instance.pages),
+    };

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.dart
@@ -13,8 +13,6 @@ final _log = Logger('theme_variant');
 
 @freezed
 class ThemeConfig with _$ThemeConfig {
-  // ignore: invalid_annotation_target
-  @JsonSerializable(fieldRename: FieldRename.kebab, explicitToJson: true)
   const factory ThemeConfig({
     String? accentColor,
     String? elevatedButtonColor,

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -136,8 +136,7 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
-@JsonSerializable(fieldRename: FieldRename.kebab, explicitToJson: true)
+@JsonSerializable()
 class _$ThemeConfigImpl implements _ThemeConfig {
   const _$ThemeConfigImpl(
       {this.accentColor,

--- a/packages/ubuntu_provision/test/services/page_service_test.dart
+++ b/packages/ubuntu_provision/test/services/page_service_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:ubuntu_provision/src/services/page_config_service.dart';
+import 'package:yaml/yaml.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  test('pages', () async {
+    final config = {
+      'keyboard': false,
+      'network': {
+        'image': '/foo/bar/network.png',
+        'title': 'Network Page Title',
+      },
+    };
+    final service =
+        PageConfigService(config: createMockConfigService(config: config));
+    await service.load();
+    final pages = service.pages;
+    expect(pages, isNotNull);
+    expect(pages['keyboard']?.visible, isFalse);
+    expect(pages['network']?.visible, isTrue);
+    expect(pages['network']?.image, equals('/foo/bar/network.png'));
+    expect(pages['network']?.title, equals('Network Page Title'));
+  });
+
+  test('pages without config', () async {
+    final service = PageConfigService(config: createMockConfigService());
+    await service.load();
+    final pages = service.pages;
+    expect(pages, isNotNull);
+    expect(pages, isEmpty);
+  });
+}
+
+MockConfigService createMockConfigService({Map<String, dynamic>? config}) {
+  final mock = MockConfigService();
+  when(mock.get('pages'))
+      .thenAnswer((_) async => YamlMap.wrap(config?.cast() ?? {}));
+  return mock;
+}

--- a/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
+++ b/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
@@ -7,43 +7,40 @@ import 'package:yaml/yaml.dart';
 import '../test_utils.dart';
 
 void main() {
-  group('ThemeVariantService', () {
-    test('getThemeVariant', () async {
-      final config = {
-        'accent-color': '#ff0000',
-        'elevated-button-color': '#00ff00',
-        'elevated-button-text-color': '#0000ff',
-        'window-title': 'Window Title',
-      };
-      final service =
-          ThemeVariantService(config: createMockConfigService(config: config));
-      await service.load();
-      final themeVariant = service.themeVariant;
-      expect(themeVariant, isNotNull);
-      expect(
-          themeVariant!.theme?.primaryColor, equals(const Color(0xffff0000)));
-      expect(themeVariant.theme?.elevatedButtonColor,
-          equals(const Color(0xff00ff00)));
-      expect(themeVariant.theme?.elevatedButtonTextColor,
-          equals(const Color(0xff0000ff)));
-      expect(themeVariant.darkTheme?.primaryColor,
-          equals(const Color(0xffff0000)));
-      expect(themeVariant.darkTheme?.elevatedButtonColor,
-          equals(const Color(0xff00ff00)));
-      expect(themeVariant.darkTheme?.elevatedButtonTextColor,
-          equals(const Color(0xff0000ff)));
-      expect(themeVariant.windowTitle, 'Window Title');
-    });
+  test('getThemeVariant', () async {
+    final config = {
+      'accent-color': '#ff0000',
+      'elevated-button-color': '#00ff00',
+      'elevated-button-text-color': '#0000ff',
+      'window-title': 'Window Title',
+    };
+    final service =
+        ThemeVariantService(config: createMockConfigService(config: config));
+    await service.load();
+    final themeVariant = service.themeVariant;
+    expect(themeVariant, isNotNull);
+    expect(themeVariant!.theme?.primaryColor, equals(const Color(0xffff0000)));
+    expect(themeVariant.theme?.elevatedButtonColor,
+        equals(const Color(0xff00ff00)));
+    expect(themeVariant.theme?.elevatedButtonTextColor,
+        equals(const Color(0xff0000ff)));
+    expect(
+        themeVariant.darkTheme?.primaryColor, equals(const Color(0xffff0000)));
+    expect(themeVariant.darkTheme?.elevatedButtonColor,
+        equals(const Color(0xff00ff00)));
+    expect(themeVariant.darkTheme?.elevatedButtonTextColor,
+        equals(const Color(0xff0000ff)));
+    expect(themeVariant.windowTitle, 'Window Title');
+  });
 
-    test('getThemeVariant with missing config', () async {
-      final service = ThemeVariantService(config: createMockConfigService());
-      await service.load();
-      final variant = service.themeVariant;
-      expect(variant, isNotNull);
-      expect(variant!.theme, null);
-      expect(variant.darkTheme, null);
-      expect(variant.windowTitle, null);
-    });
+  test('getThemeVariant with missing config', () async {
+    final service = ThemeVariantService(config: createMockConfigService());
+    await service.load();
+    final variant = service.themeVariant;
+    expect(variant, isNotNull);
+    expect(variant!.theme, null);
+    expect(variant.darkTheme, null);
+    expect(variant.windowTitle, null);
   });
 }
 

--- a/packages/ubuntu_provision/test/test_utils.dart
+++ b/packages/ubuntu_provision/test/test_utils.dart
@@ -60,6 +60,7 @@ extension UbuntuProvisionTester on WidgetTester {
   KeyboardService,
   LocaleService,
   NetworkService,
+  PageConfigService,
   PowerService,
   ProductService,
   SessionService,

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -3,36 +3,19 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i9;
-import 'dart:ui' as _i26;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i11;
 
-import 'package:dbus/dbus.dart' as _i20;
+import 'package:dbus/dbus.dart' as _i10;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i9;
 import 'package:nm/nm.dart' as _i4;
 import 'package:subiquity_client/subiquity_client.dart' as _i2;
-import 'package:timezone_map/src/location.dart' as _i14;
-import 'package:timezone_map/src/service.dart' as _i12;
-import 'package:timezone_map/src/source.dart' as _i13;
-import 'package:ubuntu_provision/src/services/active_directory_service.dart'
-    as _i8;
-import 'package:ubuntu_provision/src/services/config_service.dart' as _i10;
-import 'package:ubuntu_provision/src/services/desktop_service.dart' as _i11;
-import 'package:ubuntu_provision/src/services/identity_service.dart' as _i3;
-import 'package:ubuntu_provision/src/services/journal_service.dart' as _i15;
-import 'package:ubuntu_provision/src/services/keyboard_service.dart' as _i16;
-import 'package:ubuntu_provision/src/services/locale_service.dart' as _i17;
-import 'package:ubuntu_provision/src/services/network_service.dart' as _i19;
-import 'package:ubuntu_provision/src/services/power_service.dart' as _i21;
-import 'package:ubuntu_provision/src/services/product_service.dart' as _i6;
-import 'package:ubuntu_provision/src/services/session_service.dart' as _i22;
-import 'package:ubuntu_provision/src/services/sound_service.dart' as _i23;
-import 'package:ubuntu_provision/src/services/telemetry_service.dart' as _i24;
-import 'package:ubuntu_provision/src/services/theme_service.dart' as _i25;
-import 'package:ubuntu_provision/src/services/timezone_service.dart' as _i27;
-import 'package:ubuntu_provision/src/services/udev_service.dart' as _i7;
-import 'package:ubuntu_utils/src/url_launcher.dart' as _i28;
-import 'package:upower/upower.dart' as _i5;
+import 'package:timezone_map/src/location.dart' as _i8;
+import 'package:timezone_map/src/service.dart' as _i6;
+import 'package:timezone_map/src/source.dart' as _i7;
+import 'package:ubuntu_provision/services.dart' as _i3;
+import 'package:ubuntu_utils/src/url_launcher.dart' as _i12;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -122,7 +105,7 @@ class _FakeNetworkManagerActiveConnection_6 extends _i1.SmartFake
 }
 
 class _FakeUPowerKbdBacklight_7 extends _i1.SmartFake
-    implements _i5.UPowerKbdBacklight {
+    implements _i3.UPowerKbdBacklight {
   _FakeUPowerKbdBacklight_7(
     Object parent,
     Invocation parentInvocation,
@@ -132,7 +115,7 @@ class _FakeUPowerKbdBacklight_7 extends _i1.SmartFake
         );
 }
 
-class _FakeUPowerDevice_8 extends _i1.SmartFake implements _i5.UPowerDevice {
+class _FakeUPowerDevice_8 extends _i1.SmartFake implements _i3.UPowerDevice {
   _FakeUPowerDevice_8(
     Object parent,
     Invocation parentInvocation,
@@ -142,7 +125,7 @@ class _FakeUPowerDevice_8 extends _i1.SmartFake implements _i5.UPowerDevice {
         );
 }
 
-class _FakeProductInfo_9 extends _i1.SmartFake implements _i6.ProductInfo {
+class _FakeProductInfo_9 extends _i1.SmartFake implements _i3.ProductInfo {
   _FakeProductInfo_9(
     Object parent,
     Invocation parentInvocation,
@@ -153,7 +136,7 @@ class _FakeProductInfo_9 extends _i1.SmartFake implements _i6.ProductInfo {
 }
 
 class _FakeUdevDeviceInfo_10 extends _i1.SmartFake
-    implements _i7.UdevDeviceInfo {
+    implements _i3.UdevDeviceInfo {
   _FakeUdevDeviceInfo_10(
     Object parent,
     Invocation parentInvocation,
@@ -167,133 +150,133 @@ class _FakeUdevDeviceInfo_10 extends _i1.SmartFake
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockActiveDirectoryService extends _i1.Mock
-    implements _i8.ActiveDirectoryService {
+    implements _i3.ActiveDirectoryService {
   MockActiveDirectoryService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<bool> hasSupport() => (super.noSuchMethod(
+  _i5.Future<bool> hasSupport() => (super.noSuchMethod(
         Invocation.method(
           #hasSupport,
           [],
         ),
-        returnValue: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i9.Future<bool> isUsed() => (super.noSuchMethod(
+  _i5.Future<bool> isUsed() => (super.noSuchMethod(
         Invocation.method(
           #isUsed,
           [],
         ),
-        returnValue: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i9.Future<void> setUsed(bool? used) => (super.noSuchMethod(
+  _i5.Future<void> setUsed(bool? used) => (super.noSuchMethod(
         Invocation.method(
           #setUsed,
           [used],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<_i2.AdConnectionInfo> getConnectionInfo() => (super.noSuchMethod(
+  _i5.Future<_i2.AdConnectionInfo> getConnectionInfo() => (super.noSuchMethod(
         Invocation.method(
           #getConnectionInfo,
           [],
         ),
         returnValue:
-            _i9.Future<_i2.AdConnectionInfo>.value(_FakeAdConnectionInfo_0(
+            _i5.Future<_i2.AdConnectionInfo>.value(_FakeAdConnectionInfo_0(
           this,
           Invocation.method(
             #getConnectionInfo,
             [],
           ),
         )),
-      ) as _i9.Future<_i2.AdConnectionInfo>);
+      ) as _i5.Future<_i2.AdConnectionInfo>);
 
   @override
-  _i9.Future<void> setConnectionInfo(_i2.AdConnectionInfo? info) =>
+  _i5.Future<void> setConnectionInfo(_i2.AdConnectionInfo? info) =>
       (super.noSuchMethod(
         Invocation.method(
           #setConnectionInfo,
           [info],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<List<_i2.AdDomainNameValidation>> checkDomainName(
+  _i5.Future<List<_i2.AdDomainNameValidation>> checkDomainName(
           String? domain) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkDomainName,
           [domain],
         ),
-        returnValue: _i9.Future<List<_i2.AdDomainNameValidation>>.value(
+        returnValue: _i5.Future<List<_i2.AdDomainNameValidation>>.value(
             <_i2.AdDomainNameValidation>[]),
-      ) as _i9.Future<List<_i2.AdDomainNameValidation>>);
+      ) as _i5.Future<List<_i2.AdDomainNameValidation>>);
 
   @override
-  _i9.Future<_i2.AdAdminNameValidation> checkAdminName(String? admin) =>
+  _i5.Future<_i2.AdAdminNameValidation> checkAdminName(String? admin) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkAdminName,
           [admin],
         ),
-        returnValue: _i9.Future<_i2.AdAdminNameValidation>.value(
+        returnValue: _i5.Future<_i2.AdAdminNameValidation>.value(
             _i2.AdAdminNameValidation.OK),
-      ) as _i9.Future<_i2.AdAdminNameValidation>);
+      ) as _i5.Future<_i2.AdAdminNameValidation>);
 
   @override
-  _i9.Future<_i2.AdPasswordValidation> checkPassword(String? password) =>
+  _i5.Future<_i2.AdPasswordValidation> checkPassword(String? password) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkPassword,
           [password],
         ),
-        returnValue: _i9.Future<_i2.AdPasswordValidation>.value(
+        returnValue: _i5.Future<_i2.AdPasswordValidation>.value(
             _i2.AdPasswordValidation.OK),
-      ) as _i9.Future<_i2.AdPasswordValidation>);
+      ) as _i5.Future<_i2.AdPasswordValidation>);
 
   @override
-  _i9.Future<_i2.AdDomainNameValidation> pingDomainController(String? domain) =>
+  _i5.Future<_i2.AdDomainNameValidation> pingDomainController(String? domain) =>
       (super.noSuchMethod(
         Invocation.method(
           #pingDomainController,
           [domain],
         ),
-        returnValue: _i9.Future<_i2.AdDomainNameValidation>.value(
+        returnValue: _i5.Future<_i2.AdDomainNameValidation>.value(
             _i2.AdDomainNameValidation.OK),
-      ) as _i9.Future<_i2.AdDomainNameValidation>);
+      ) as _i5.Future<_i2.AdDomainNameValidation>);
 
   @override
-  _i9.Future<_i2.AdJoinResult> getJoinResult({bool? wait = true}) =>
+  _i5.Future<_i2.AdJoinResult> getJoinResult({bool? wait = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinResult,
           [],
           {#wait: wait},
         ),
-        returnValue: _i9.Future<_i2.AdJoinResult>.value(_i2.AdJoinResult.OK),
-      ) as _i9.Future<_i2.AdJoinResult>);
+        returnValue: _i5.Future<_i2.AdJoinResult>.value(_i2.AdJoinResult.OK),
+      ) as _i5.Future<_i2.AdJoinResult>);
 }
 
 /// A class which mocks [ConfigService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockConfigService extends _i1.Mock implements _i10.ConfigService {
+class MockConfigService extends _i1.Mock implements _i3.ConfigService {
   MockConfigService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<T?> get<T>(
+  _i5.Future<T?> get<T>(
     String? key, {
     String? scope,
   }) =>
@@ -303,58 +286,58 @@ class MockConfigService extends _i1.Mock implements _i10.ConfigService {
           [key],
           {#scope: scope},
         ),
-        returnValue: _i9.Future<T?>.value(),
-      ) as _i9.Future<T?>);
+        returnValue: _i5.Future<T?>.value(),
+      ) as _i5.Future<T?>);
 
   @override
-  _i9.Future<Map<String, dynamic>?> load() => (super.noSuchMethod(
+  _i5.Future<Map<String, dynamic>?> load() => (super.noSuchMethod(
         Invocation.method(
           #load,
           [],
         ),
-        returnValue: _i9.Future<Map<String, dynamic>?>.value(),
-      ) as _i9.Future<Map<String, dynamic>?>);
+        returnValue: _i5.Future<Map<String, dynamic>?>.value(),
+      ) as _i5.Future<Map<String, dynamic>?>);
 }
 
 /// A class which mocks [DesktopService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDesktopService extends _i1.Mock implements _i11.DesktopService {
+class MockDesktopService extends _i1.Mock implements _i3.DesktopService {
   MockDesktopService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<void> inhibit() => (super.noSuchMethod(
+  _i5.Future<void> inhibit() => (super.noSuchMethod(
         Invocation.method(
           #inhibit,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> close() => (super.noSuchMethod(
+  _i5.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [GeoService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGeoService extends _i1.Mock implements _i12.GeoService {
+class MockGeoService extends _i1.Mock implements _i6.GeoService {
   MockGeoService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  void addSource(_i13.GeoSource? source) => super.noSuchMethod(
+  void addSource(_i7.GeoSource? source) => super.noSuchMethod(
         Invocation.method(
           #addSource,
           [source],
@@ -363,7 +346,7 @@ class MockGeoService extends _i1.Mock implements _i12.GeoService {
       );
 
   @override
-  void removeSource(_i13.GeoSource? source) => super.noSuchMethod(
+  void removeSource(_i7.GeoSource? source) => super.noSuchMethod(
         Invocation.method(
           #removeSource,
           [source],
@@ -372,67 +355,67 @@ class MockGeoService extends _i1.Mock implements _i12.GeoService {
       );
 
   @override
-  _i9.Future<void> init() => (super.noSuchMethod(
+  _i5.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<_i14.GeoLocation?> lookupLocation() => (super.noSuchMethod(
+  _i5.Future<_i8.GeoLocation?> lookupLocation() => (super.noSuchMethod(
         Invocation.method(
           #lookupLocation,
           [],
         ),
-        returnValue: _i9.Future<_i14.GeoLocation?>.value(),
-      ) as _i9.Future<_i14.GeoLocation?>);
+        returnValue: _i5.Future<_i8.GeoLocation?>.value(),
+      ) as _i5.Future<_i8.GeoLocation?>);
 
   @override
-  _i9.Future<Iterable<_i14.GeoLocation>> searchLocation(String? location) =>
+  _i5.Future<Iterable<_i8.GeoLocation>> searchLocation(String? location) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchLocation,
           [location],
         ),
         returnValue:
-            _i9.Future<Iterable<_i14.GeoLocation>>.value(<_i14.GeoLocation>[]),
-      ) as _i9.Future<Iterable<_i14.GeoLocation>>);
+            _i5.Future<Iterable<_i8.GeoLocation>>.value(<_i8.GeoLocation>[]),
+      ) as _i5.Future<Iterable<_i8.GeoLocation>>);
 
   @override
-  _i9.Future<Iterable<_i14.GeoLocation>> searchCoordinates(
-          _i14.LatLng? coordinates) =>
+  _i5.Future<Iterable<_i8.GeoLocation>> searchCoordinates(
+          _i8.LatLng? coordinates) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchCoordinates,
           [coordinates],
         ),
         returnValue:
-            _i9.Future<Iterable<_i14.GeoLocation>>.value(<_i14.GeoLocation>[]),
-      ) as _i9.Future<Iterable<_i14.GeoLocation>>);
+            _i5.Future<Iterable<_i8.GeoLocation>>.value(<_i8.GeoLocation>[]),
+      ) as _i5.Future<Iterable<_i8.GeoLocation>>);
 
   @override
-  _i9.Future<Iterable<_i14.GeoLocation>> searchTimezone(String? timezone) =>
+  _i5.Future<Iterable<_i8.GeoLocation>> searchTimezone(String? timezone) =>
       (super.noSuchMethod(
         Invocation.method(
           #searchTimezone,
           [timezone],
         ),
         returnValue:
-            _i9.Future<Iterable<_i14.GeoLocation>>.value(<_i14.GeoLocation>[]),
-      ) as _i9.Future<Iterable<_i14.GeoLocation>>);
+            _i5.Future<Iterable<_i8.GeoLocation>>.value(<_i8.GeoLocation>[]),
+      ) as _i5.Future<Iterable<_i8.GeoLocation>>);
 
   @override
-  _i9.Future<void> cancelSearch() => (super.noSuchMethod(
+  _i5.Future<void> cancelSearch() => (super.noSuchMethod(
         Invocation.method(
           #cancelSearch,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [IdentityService].
@@ -444,54 +427,54 @@ class MockIdentityService extends _i1.Mock implements _i3.IdentityService {
   }
 
   @override
-  _i9.Future<_i3.Identity> getIdentity() => (super.noSuchMethod(
+  _i5.Future<_i3.Identity> getIdentity() => (super.noSuchMethod(
         Invocation.method(
           #getIdentity,
           [],
         ),
-        returnValue: _i9.Future<_i3.Identity>.value(_FakeIdentity_1(
+        returnValue: _i5.Future<_i3.Identity>.value(_FakeIdentity_1(
           this,
           Invocation.method(
             #getIdentity,
             [],
           ),
         )),
-      ) as _i9.Future<_i3.Identity>);
+      ) as _i5.Future<_i3.Identity>);
 
   @override
-  _i9.Future<void> setIdentity(_i3.Identity? identity) => (super.noSuchMethod(
+  _i5.Future<void> setIdentity(_i3.Identity? identity) => (super.noSuchMethod(
         Invocation.method(
           #setIdentity,
           [identity],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<_i2.UsernameValidation> validateUsername(String? username) =>
+  _i5.Future<_i2.UsernameValidation> validateUsername(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
         returnValue:
-            _i9.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
-      ) as _i9.Future<_i2.UsernameValidation>);
+            _i5.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
+      ) as _i5.Future<_i2.UsernameValidation>);
 }
 
 /// A class which mocks [JournalService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockJournalService extends _i1.Mock implements _i15.JournalService {
+class MockJournalService extends _i1.Mock implements _i3.JournalService {
   MockJournalService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Stream<String> start(
+  _i5.Stream<String> start(
     List<String>? ids, {
-    _i15.JournalOutput? output = _i15.JournalOutput.short,
+    _i3.JournalOutput? output = _i3.JournalOutput.short,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -499,14 +482,14 @@ class MockJournalService extends _i1.Mock implements _i15.JournalService {
           [ids],
           {#output: output},
         ),
-        returnValue: _i9.Stream<String>.empty(),
-      ) as _i9.Stream<String>);
+        returnValue: _i5.Stream<String>.empty(),
+      ) as _i5.Stream<String>);
 }
 
 /// A class which mocks [KeyboardService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockKeyboardService extends _i1.Mock implements _i16.KeyboardService {
+class MockKeyboardService extends _i1.Mock implements _i3.KeyboardService {
   MockKeyboardService() {
     _i1.throwOnMissingStub(this);
   }
@@ -518,33 +501,33 @@ class MockKeyboardService extends _i1.Mock implements _i16.KeyboardService {
       ) as bool);
 
   @override
-  _i9.Future<_i2.KeyboardSetup> getKeyboard() => (super.noSuchMethod(
+  _i5.Future<_i2.KeyboardSetup> getKeyboard() => (super.noSuchMethod(
         Invocation.method(
           #getKeyboard,
           [],
         ),
-        returnValue: _i9.Future<_i2.KeyboardSetup>.value(_FakeKeyboardSetup_2(
+        returnValue: _i5.Future<_i2.KeyboardSetup>.value(_FakeKeyboardSetup_2(
           this,
           Invocation.method(
             #getKeyboard,
             [],
           ),
         )),
-      ) as _i9.Future<_i2.KeyboardSetup>);
+      ) as _i5.Future<_i2.KeyboardSetup>);
 
   @override
-  _i9.Future<void> setKeyboard(_i2.KeyboardSetting? setting) =>
+  _i5.Future<void> setKeyboard(_i2.KeyboardSetting? setting) =>
       (super.noSuchMethod(
         Invocation.method(
           #setKeyboard,
           [setting],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> setInputSource(
+  _i5.Future<void> setInputSource(
     _i2.KeyboardSetting? setting, {
     String? user,
   }) =>
@@ -554,65 +537,65 @@ class MockKeyboardService extends _i1.Mock implements _i16.KeyboardService {
           [setting],
           {#user: user},
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<_i2.AnyStep> getKeyboardStep([String? step = r'0']) =>
+  _i5.Future<_i2.AnyStep> getKeyboardStep([String? step = r'0']) =>
       (super.noSuchMethod(
         Invocation.method(
           #getKeyboardStep,
           [step],
         ),
-        returnValue: _i9.Future<_i2.AnyStep>.value(_FakeAnyStep_3(
+        returnValue: _i5.Future<_i2.AnyStep>.value(_FakeAnyStep_3(
           this,
           Invocation.method(
             #getKeyboardStep,
             [step],
           ),
         )),
-      ) as _i9.Future<_i2.AnyStep>);
+      ) as _i5.Future<_i2.AnyStep>);
 }
 
 /// A class which mocks [LocaleService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLocaleService extends _i1.Mock implements _i17.LocaleService {
+class MockLocaleService extends _i1.Mock implements _i3.LocaleService {
   MockLocaleService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<String> getLocale() => (super.noSuchMethod(
+  _i5.Future<String> getLocale() => (super.noSuchMethod(
         Invocation.method(
           #getLocale,
           [],
         ),
-        returnValue: _i9.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #getLocale,
             [],
           ),
         )),
-      ) as _i9.Future<String>);
+      ) as _i5.Future<String>);
 
   @override
-  _i9.Future<void> setLocale(String? locale) => (super.noSuchMethod(
+  _i5.Future<void> setLocale(String? locale) => (super.noSuchMethod(
         Invocation.method(
           #setLocale,
           [locale],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [NetworkService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
+class MockNetworkService extends _i1.Mock implements _i3.NetworkService {
   MockNetworkService() {
     _i1.throwOnMissingStub(this);
   }
@@ -642,36 +625,36 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
       ) as List<_i4.NetworkManagerDevice>);
 
   @override
-  _i9.Stream<_i4.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
+  _i5.Stream<_i4.NetworkManagerDevice> get deviceAdded => (super.noSuchMethod(
         Invocation.getter(#deviceAdded),
-        returnValue: _i9.Stream<_i4.NetworkManagerDevice>.empty(),
-      ) as _i9.Stream<_i4.NetworkManagerDevice>);
+        returnValue: _i5.Stream<_i4.NetworkManagerDevice>.empty(),
+      ) as _i5.Stream<_i4.NetworkManagerDevice>);
 
   @override
-  _i9.Stream<_i4.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
+  _i5.Stream<_i4.NetworkManagerDevice> get deviceRemoved => (super.noSuchMethod(
         Invocation.getter(#deviceRemoved),
-        returnValue: _i9.Stream<_i4.NetworkManagerDevice>.empty(),
-      ) as _i9.Stream<_i4.NetworkManagerDevice>);
+        returnValue: _i5.Stream<_i4.NetworkManagerDevice>.empty(),
+      ) as _i5.Stream<_i4.NetworkManagerDevice>);
 
   @override
-  _i9.Stream<_i4.NetworkManagerActiveConnection> get activeConnectionAdded =>
+  _i5.Stream<_i4.NetworkManagerActiveConnection> get activeConnectionAdded =>
       (super.noSuchMethod(
         Invocation.getter(#activeConnectionAdded),
-        returnValue: _i9.Stream<_i4.NetworkManagerActiveConnection>.empty(),
-      ) as _i9.Stream<_i4.NetworkManagerActiveConnection>);
+        returnValue: _i5.Stream<_i4.NetworkManagerActiveConnection>.empty(),
+      ) as _i5.Stream<_i4.NetworkManagerActiveConnection>);
 
   @override
-  _i9.Stream<_i4.NetworkManagerActiveConnection> get activeConnectionRemoved =>
+  _i5.Stream<_i4.NetworkManagerActiveConnection> get activeConnectionRemoved =>
       (super.noSuchMethod(
         Invocation.getter(#activeConnectionRemoved),
-        returnValue: _i9.Stream<_i4.NetworkManagerActiveConnection>.empty(),
-      ) as _i9.Stream<_i4.NetworkManagerActiveConnection>);
+        returnValue: _i5.Stream<_i4.NetworkManagerActiveConnection>.empty(),
+      ) as _i5.Stream<_i4.NetworkManagerActiveConnection>);
 
   @override
-  _i9.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+  _i5.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
         Invocation.getter(#propertiesChanged),
-        returnValue: _i9.Stream<List<String>>.empty(),
-      ) as _i9.Stream<List<String>>);
+        returnValue: _i5.Stream<List<String>>.empty(),
+      ) as _i5.Stream<List<String>>);
 
   @override
   List<_i4.NetworkManagerDevice> get devices => (super.noSuchMethod(
@@ -725,7 +708,7 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
   @override
   String get primaryConnectionType => (super.noSuchMethod(
         Invocation.getter(#primaryConnectionType),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#primaryConnectionType),
         ),
@@ -746,7 +729,7 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
   @override
   String get version => (super.noSuchMethod(
         Invocation.getter(#version),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#version),
         ),
@@ -773,7 +756,7 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
   @override
   String get connectivityCheckUri => (super.noSuchMethod(
         Invocation.getter(#connectivityCheckUri),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#connectivityCheckUri),
         ),
@@ -804,7 +787,7 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
       ) as _i4.NetworkManagerDnsManager);
 
   @override
-  Map<String, Map<String, _i20.DBusValue>> getWifiSettings(
+  Map<String, Map<String, _i10.DBusValue>> getWifiSettings(
           {required String? ssid}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -812,63 +795,63 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
           [],
           {#ssid: ssid},
         ),
-        returnValue: <String, Map<String, _i20.DBusValue>>{},
-      ) as Map<String, Map<String, _i20.DBusValue>>);
+        returnValue: <String, Map<String, _i10.DBusValue>>{},
+      ) as Map<String, Map<String, _i10.DBusValue>>);
 
   @override
-  _i9.Future<void> markConfigured() => (super.noSuchMethod(
+  _i5.Future<void> markConfigured() => (super.noSuchMethod(
         Invocation.method(
           #markConfigured,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> connect() => (super.noSuchMethod(
+  _i5.Future<void> connect() => (super.noSuchMethod(
         Invocation.method(
           #connect,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
+  _i5.Future<void> setWirelessEnabled(bool? value) => (super.noSuchMethod(
         Invocation.method(
           #setWirelessEnabled,
           [value],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
+  _i5.Future<void> setWwanEnabled(bool? value) => (super.noSuchMethod(
         Invocation.method(
           #setWwanEnabled,
           [value],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> setConnectivityCheckEnabled(bool? value) =>
+  _i5.Future<void> setConnectivityCheckEnabled(bool? value) =>
       (super.noSuchMethod(
         Invocation.method(
           #setConnectivityCheckEnabled,
           [value],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<_i4.NetworkManagerActiveConnection> addAndActivateConnection({
-    Map<String, Map<String, _i20.DBusValue>>? connection = const {},
+  _i5.Future<_i4.NetworkManagerActiveConnection> addAndActivateConnection({
+    Map<String, Map<String, _i10.DBusValue>>? connection = const {},
     required _i4.NetworkManagerDevice? device,
     _i4.NetworkManagerAccessPoint? accessPoint,
   }) =>
@@ -882,7 +865,7 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
             #accessPoint: accessPoint,
           },
         ),
-        returnValue: _i9.Future<_i4.NetworkManagerActiveConnection>.value(
+        returnValue: _i5.Future<_i4.NetworkManagerActiveConnection>.value(
             _FakeNetworkManagerActiveConnection_6(
           this,
           Invocation.method(
@@ -895,10 +878,10 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
             },
           ),
         )),
-      ) as _i9.Future<_i4.NetworkManagerActiveConnection>);
+      ) as _i5.Future<_i4.NetworkManagerActiveConnection>);
 
   @override
-  _i9.Future<_i4.NetworkManagerActiveConnection> activateConnection({
+  _i5.Future<_i4.NetworkManagerActiveConnection> activateConnection({
     required _i4.NetworkManagerDevice? device,
     _i4.NetworkManagerSettingsConnection? connection,
     _i4.NetworkManagerAccessPoint? accessPoint,
@@ -913,7 +896,7 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
             #accessPoint: accessPoint,
           },
         ),
-        returnValue: _i9.Future<_i4.NetworkManagerActiveConnection>.value(
+        returnValue: _i5.Future<_i4.NetworkManagerActiveConnection>.value(
             _FakeNetworkManagerActiveConnection_6(
           this,
           Invocation.method(
@@ -926,50 +909,81 @@ class MockNetworkService extends _i1.Mock implements _i19.NetworkService {
             },
           ),
         )),
-      ) as _i9.Future<_i4.NetworkManagerActiveConnection>);
+      ) as _i5.Future<_i4.NetworkManagerActiveConnection>);
 
   @override
-  _i9.Future<void> deactivateConnection(
+  _i5.Future<void> deactivateConnection(
           _i4.NetworkManagerActiveConnection? connection) =>
       (super.noSuchMethod(
         Invocation.method(
           #deactivateConnection,
           [connection],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> close() => (super.noSuchMethod(
+  _i5.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+}
+
+/// A class which mocks [PageConfigService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPageConfigService extends _i1.Mock implements _i3.PageConfigService {
+  MockPageConfigService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  Map<String, _i3.PageConfigEntry> get pages => (super.noSuchMethod(
+        Invocation.getter(#pages),
+        returnValue: <String, _i3.PageConfigEntry>{},
+      ) as Map<String, _i3.PageConfigEntry>);
+
+  @override
+  Set<String> get excludedPages => (super.noSuchMethod(
+        Invocation.getter(#excludedPages),
+        returnValue: <String>{},
+      ) as Set<String>);
+
+  @override
+  _i5.Future<void> load() => (super.noSuchMethod(
+        Invocation.method(
+          #load,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [PowerService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPowerService extends _i1.Mock implements _i21.PowerService {
+class MockPowerService extends _i1.Mock implements _i3.PowerService {
   MockPowerService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.UPowerKbdBacklight get kbdBacklight => (super.noSuchMethod(
+  _i3.UPowerKbdBacklight get kbdBacklight => (super.noSuchMethod(
         Invocation.getter(#kbdBacklight),
         returnValue: _FakeUPowerKbdBacklight_7(
           this,
           Invocation.getter(#kbdBacklight),
         ),
-      ) as _i5.UPowerKbdBacklight);
+      ) as _i3.UPowerKbdBacklight);
 
   @override
-  set kbdBacklight(_i5.UPowerKbdBacklight? _kbdBacklight) => super.noSuchMethod(
+  set kbdBacklight(_i3.UPowerKbdBacklight? _kbdBacklight) => super.noSuchMethod(
         Invocation.setter(
           #kbdBacklight,
           _kbdBacklight,
@@ -980,7 +994,7 @@ class MockPowerService extends _i1.Mock implements _i21.PowerService {
   @override
   String get daemonVersion => (super.noSuchMethod(
         Invocation.getter(#daemonVersion),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#daemonVersion),
         ),
@@ -1005,84 +1019,84 @@ class MockPowerService extends _i1.Mock implements _i21.PowerService {
       ) as bool);
 
   @override
-  List<_i5.UPowerDevice> get devices => (super.noSuchMethod(
+  List<_i3.UPowerDevice> get devices => (super.noSuchMethod(
         Invocation.getter(#devices),
-        returnValue: <_i5.UPowerDevice>[],
-      ) as List<_i5.UPowerDevice>);
+        returnValue: <_i3.UPowerDevice>[],
+      ) as List<_i3.UPowerDevice>);
 
   @override
-  _i5.UPowerDevice get displayDevice => (super.noSuchMethod(
+  _i3.UPowerDevice get displayDevice => (super.noSuchMethod(
         Invocation.getter(#displayDevice),
         returnValue: _FakeUPowerDevice_8(
           this,
           Invocation.getter(#displayDevice),
         ),
-      ) as _i5.UPowerDevice);
+      ) as _i3.UPowerDevice);
 
   @override
-  _i9.Stream<_i5.UPowerDevice> get deviceAdded => (super.noSuchMethod(
+  _i5.Stream<_i3.UPowerDevice> get deviceAdded => (super.noSuchMethod(
         Invocation.getter(#deviceAdded),
-        returnValue: _i9.Stream<_i5.UPowerDevice>.empty(),
-      ) as _i9.Stream<_i5.UPowerDevice>);
+        returnValue: _i5.Stream<_i3.UPowerDevice>.empty(),
+      ) as _i5.Stream<_i3.UPowerDevice>);
 
   @override
-  _i9.Stream<_i5.UPowerDevice> get deviceRemoved => (super.noSuchMethod(
+  _i5.Stream<_i3.UPowerDevice> get deviceRemoved => (super.noSuchMethod(
         Invocation.getter(#deviceRemoved),
-        returnValue: _i9.Stream<_i5.UPowerDevice>.empty(),
-      ) as _i9.Stream<_i5.UPowerDevice>);
+        returnValue: _i5.Stream<_i3.UPowerDevice>.empty(),
+      ) as _i5.Stream<_i3.UPowerDevice>);
 
   @override
-  _i9.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
+  _i5.Stream<List<String>> get propertiesChanged => (super.noSuchMethod(
         Invocation.getter(#propertiesChanged),
-        returnValue: _i9.Stream<List<String>>.empty(),
-      ) as _i9.Stream<List<String>>);
+        returnValue: _i5.Stream<List<String>>.empty(),
+      ) as _i5.Stream<List<String>>);
 
   @override
-  _i9.Future<void> connect() => (super.noSuchMethod(
+  _i5.Future<void> connect() => (super.noSuchMethod(
         Invocation.method(
           #connect,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<String> getCriticalAction() => (super.noSuchMethod(
+  _i5.Future<String> getCriticalAction() => (super.noSuchMethod(
         Invocation.method(
           #getCriticalAction,
           [],
         ),
-        returnValue: _i9.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #getCriticalAction,
             [],
           ),
         )),
-      ) as _i9.Future<String>);
+      ) as _i5.Future<String>);
 
   @override
-  _i9.Future<void> close() => (super.noSuchMethod(
+  _i5.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [ProductService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProductService extends _i1.Mock implements _i6.ProductService {
+class MockProductService extends _i1.Mock implements _i3.ProductService {
   MockProductService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.ProductInfo getProductInfo() => (super.noSuchMethod(
+  _i3.ProductInfo getProductInfo() => (super.noSuchMethod(
         Invocation.method(
           #getProductInfo,
           [],
@@ -1094,7 +1108,7 @@ class MockProductService extends _i1.Mock implements _i6.ProductService {
             [],
           ),
         ),
-      ) as _i6.ProductInfo);
+      ) as _i3.ProductInfo);
 
   @override
   String getReleaseNotesURL(String? languageCode) => (super.noSuchMethod(
@@ -1102,7 +1116,7 @@ class MockProductService extends _i1.Mock implements _i6.ProductService {
           #getReleaseNotesURL,
           [languageCode],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.method(
             #getReleaseNotesURL,
@@ -1115,57 +1129,57 @@ class MockProductService extends _i1.Mock implements _i6.ProductService {
 /// A class which mocks [SessionService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSessionService extends _i1.Mock implements _i22.SessionService {
+class MockSessionService extends _i1.Mock implements _i3.SessionService {
   MockSessionService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
+  _i5.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
         Invocation.method(
           #reboot,
           [],
           {#immediate: immediate},
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
+  _i5.Future<void> shutdown({bool? immediate = false}) => (super.noSuchMethod(
         Invocation.method(
           #shutdown,
           [],
           {#immediate: immediate},
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [SoundService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSoundService extends _i1.Mock implements _i23.SoundService {
+class MockSoundService extends _i1.Mock implements _i3.SoundService {
   MockSoundService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<void> play(String? id) => (super.noSuchMethod(
+  _i5.Future<void> play(String? id) => (super.noSuchMethod(
         Invocation.method(
           #play,
           [id],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [TelemetryService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTelemetryService extends _i1.Mock implements _i24.TelemetryService {
+class MockTelemetryService extends _i1.Mock implements _i3.TelemetryService {
   MockTelemetryService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1173,35 +1187,35 @@ class MockTelemetryService extends _i1.Mock implements _i24.TelemetryService {
   @override
   String get path => (super.noSuchMethod(
         Invocation.getter(#path),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#path),
         ),
       ) as String);
 
   @override
-  _i9.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
+  _i5.Future<void> init([Map<String, dynamic>? metrics = const {}]) =>
       (super.noSuchMethod(
         Invocation.method(
           #init,
           [metrics],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> addStage(String? name) => (super.noSuchMethod(
+  _i5.Future<void> addStage(String? name) => (super.noSuchMethod(
         Invocation.method(
           #addStage,
           [name],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> addMetric(
+  _i5.Future<void> addMetric(
     String? key,
     dynamic value,
   ) =>
@@ -1213,118 +1227,118 @@ class MockTelemetryService extends _i1.Mock implements _i24.TelemetryService {
             value,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> addMetrics(Map<String, dynamic>? entries) =>
+  _i5.Future<void> addMetrics(Map<String, dynamic>? entries) =>
       (super.noSuchMethod(
         Invocation.method(
           #addMetrics,
           [entries],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [ThemeService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockThemeService extends _i1.Mock implements _i25.ThemeService {
+class MockThemeService extends _i1.Mock implements _i3.ThemeService {
   MockThemeService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<_i26.Brightness> getBrightness() => (super.noSuchMethod(
+  _i5.Future<_i11.Brightness> getBrightness() => (super.noSuchMethod(
         Invocation.method(
           #getBrightness,
           [],
         ),
-        returnValue: _i9.Future<_i26.Brightness>.value(_i26.Brightness.dark),
-      ) as _i9.Future<_i26.Brightness>);
+        returnValue: _i5.Future<_i11.Brightness>.value(_i11.Brightness.dark),
+      ) as _i5.Future<_i11.Brightness>);
 
   @override
-  _i9.Future<void> setBrightness(_i26.Brightness? brightness) =>
+  _i5.Future<void> setBrightness(_i11.Brightness? brightness) =>
       (super.noSuchMethod(
         Invocation.method(
           #setBrightness,
           [brightness],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<String?> getAccent() => (super.noSuchMethod(
+  _i5.Future<String?> getAccent() => (super.noSuchMethod(
         Invocation.method(
           #getAccent,
           [],
         ),
-        returnValue: _i9.Future<String?>.value(),
-      ) as _i9.Future<String?>);
+        returnValue: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
 
   @override
-  _i9.Future<void> setAccent(String? accent) => (super.noSuchMethod(
+  _i5.Future<void> setAccent(String? accent) => (super.noSuchMethod(
         Invocation.method(
           #setAccent,
           [accent],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i9.Future<void> close() => (super.noSuchMethod(
+  _i5.Future<void> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [TimezoneService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTimezoneService extends _i1.Mock implements _i27.TimezoneService {
+class MockTimezoneService extends _i1.Mock implements _i3.TimezoneService {
   MockTimezoneService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<String> getTimezone() => (super.noSuchMethod(
+  _i5.Future<String> getTimezone() => (super.noSuchMethod(
         Invocation.method(
           #getTimezone,
           [],
         ),
-        returnValue: _i9.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #getTimezone,
             [],
           ),
         )),
-      ) as _i9.Future<String>);
+      ) as _i5.Future<String>);
 
   @override
-  _i9.Future<void> setTimezone(String? timezone) => (super.noSuchMethod(
+  _i5.Future<void> setTimezone(String? timezone) => (super.noSuchMethod(
         Invocation.method(
           #setTimezone,
           [timezone],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [UdevDeviceInfo].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUdevDeviceInfo extends _i1.Mock implements _i7.UdevDeviceInfo {
+class MockUdevDeviceInfo extends _i1.Mock implements _i3.UdevDeviceInfo {
   MockUdevDeviceInfo() {
     _i1.throwOnMissingStub(this);
   }
@@ -1332,7 +1346,7 @@ class MockUdevDeviceInfo extends _i1.Mock implements _i7.UdevDeviceInfo {
   @override
   String get fullName => (super.noSuchMethod(
         Invocation.getter(#fullName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#fullName),
         ),
@@ -1342,13 +1356,13 @@ class MockUdevDeviceInfo extends _i1.Mock implements _i7.UdevDeviceInfo {
 /// A class which mocks [UdevService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUdevService extends _i1.Mock implements _i7.UdevService {
+class MockUdevService extends _i1.Mock implements _i3.UdevService {
   MockUdevService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i7.UdevDeviceInfo bySysname(String? sysname) => (super.noSuchMethod(
+  _i3.UdevDeviceInfo bySysname(String? sysname) => (super.noSuchMethod(
         Invocation.method(
           #bySysname,
           [sysname],
@@ -1360,10 +1374,10 @@ class MockUdevService extends _i1.Mock implements _i7.UdevService {
             [sysname],
           ),
         ),
-      ) as _i7.UdevDeviceInfo);
+      ) as _i3.UdevDeviceInfo);
 
   @override
-  _i7.UdevDeviceInfo bySyspath(String? syspath) => (super.noSuchMethod(
+  _i3.UdevDeviceInfo bySyspath(String? syspath) => (super.noSuchMethod(
         Invocation.method(
           #bySyspath,
           [syspath],
@@ -1375,32 +1389,32 @@ class MockUdevService extends _i1.Mock implements _i7.UdevService {
             [syspath],
           ),
         ),
-      ) as _i7.UdevDeviceInfo);
+      ) as _i3.UdevDeviceInfo);
 }
 
 /// A class which mocks [UrlLauncher].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUrlLauncher extends _i1.Mock implements _i28.UrlLauncher {
+class MockUrlLauncher extends _i1.Mock implements _i12.UrlLauncher {
   MockUrlLauncher() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i9.Future<bool> canLaunchUrl(String? url) => (super.noSuchMethod(
+  _i5.Future<bool> canLaunchUrl(String? url) => (super.noSuchMethod(
         Invocation.method(
           #canLaunchUrl,
           [url],
         ),
-        returnValue: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i9.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
+  _i5.Future<bool> launchUrl(String? url) => (super.noSuchMethod(
         Invocation.method(
           #launchUrl,
           [url],
         ),
-        returnValue: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 }


### PR DESCRIPTION
Follow-up to #239.
Adds a service that parses the 'pages' section of the configuration file following this schema:

```yaml
pages:
  locale: false
  keyboard:
    image: '/path/to/image'
    title: 'My custom window title'
```

This PR only replaces the previous 'pages' configuration that allowed passing a list of pages that should be included in the wizard. As before, by default all available pages are shown by default. What's changed is that the logic is now reversed: you need to exclude a page explicitly in the config file now. If a page is excluded but required by subiquity in autoinstall mode, a warning will be shown and only the pages by subiquity will be included. (We could also exit the wizard with an error, if that's preferred).

As a next step, I plan to add a provider that holds the parsed page config so that individual pages have a way to access the customized image and window title.

P.S. I'll add proper integration tests once we settle on a config schema!

Fix: #205
UDENG-1762