### PR TITLE
feat(snap): disable default user creation

### DIFF
--- a/snap/local/postinst.d/99_disable_user_creation
+++ b/snap/local/postinst.d/99_disable_user_creation
@@ -1,0 +1,4 @@
+#!/bin/sh
+TARGET=/target
+
+echo "users: []" > $TARGET/etc/cloud/cloud.cfg.d/99-disable-user-creation.cfg


### PR DESCRIPTION
Overrides the default `users` config setting in the cloud-init config on the target system so that no default user is created.

Ref: #252
UDENG-1913