### PR TITLE
feat: update init snap in testing pipeline and log debug information

### DIFF
--- a/snap/local/postinst.d/99_install_ubuntu_init
+++ b/snap/local/postinst.d/99_install_ubuntu_init
@@ -30,4 +30,4 @@ EOF
 ) > $TARGET/etc/systemd/system/install-ubuntu-init.service
 ln -s /etc/systemd/system/install-ubuntu-init.service $TARGET/etc/systemd/system/multi-user.target.wants/
 
-sed -i 's|/usr/libexec/gnome-initial-setup|/snap/ubuntu-desktop-init/current/bin/ubuntu_init|' $TARGET/usr/share/applications/gnome-initial-setup.desktop
+sed -i 's|/usr/libexec/gnome-initial-setup|env LOG_FILE=/tmp/init.log LOG_LEVEL=debug /snap/ubuntu-desktop-init/current/bin/ubuntu_init|' $TARGET/usr/share/applications/gnome-initial-setup.desktop

--- a/snap/local/postinst.d/99_install_ubuntu_init
+++ b/snap/local/postinst.d/99_install_ubuntu_init
@@ -6,8 +6,8 @@ set -eux
 (
 cat << 'EOF'
 #!/bin/bash
-wget "https://github.com/d-loose/provision-testing/raw/main/ubuntu-desktop-init_0%2Bgit.ef84de5_amd64.snap"
-snap install --dangerous --devmode ubuntu-desktop-init_0+git.ef84de5_amd64.snap
+wget "https://github.com/d-loose/provision-testing/raw/main/ubuntu-desktop-init_0+git.0372cca_amd64.snap"
+snap install --dangerous --devmode ubuntu-desktop-init_0+git.0372cca_amd64.snap
 EOF
 ) > $TARGET/usr/bin/install-ubuntu-init
 chmod +x $TARGET/usr/bin/install-ubuntu-init


### PR DESCRIPTION
Includes the latest init-snap in the postinst hook that sets up our testing pipeline and logs debug messages from the init wizard to `/tmp/init.log`