### PR TITLE
fix: catch all errors in init services

### DIFF
--- a/packages/ubuntu_bootstrap/lib/services/refresh_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/refresh_service.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: avoid_catches_without_on_clauses
+// TODO: check if catching `Exception` in check() and refresh() is sufficient
+
 import 'dart:async';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -55,7 +58,7 @@ class RefreshService {
     try {
       _setState(const RefreshState.checking());
       _setStatus(await _client.checkRefresh());
-    } on Exception catch (e) {
+    } catch (e) {
       _setState(RefreshState.error(e));
     }
     return _state;
@@ -69,7 +72,7 @@ class RefreshService {
         if (_state.ready) {
           _setState(const RefreshState.done());
         }
-      } on Exception catch (_) {
+      } catch (_) {
         // subiquity restarted, consider the refresh done
         _setState(const RefreshState.done());
         return false;

--- a/packages/ubuntu_init/lib/src/services/privacy_service.dart
+++ b/packages/ubuntu_init/lib/src/services/privacy_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_catches_without_on_clauses
+
 import 'package:dbus/dbus.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:meta/meta.dart';
@@ -32,7 +34,7 @@ class GnomePrivacyService implements PrivacyService {
   Future<bool> isLocationEnabled() async {
     try {
       return await _locationSettings.get('enabled').then((v) => v.asBoolean());
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error getting location settings: $e');
       return false;
     }
@@ -43,7 +45,7 @@ class GnomePrivacyService implements PrivacyService {
     await setReportingEnabled(true);
     try {
       return await _locationSettings.set('enabled', DBusBoolean(enabled));
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error setting location settings: $e');
       return;
     }
@@ -55,7 +57,7 @@ class GnomePrivacyService implements PrivacyService {
       return await _privacySettings
           .get('report-technical-problems')
           .then((v) => v.asBoolean());
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error getting privacy settings: $e');
       return false;
     }
@@ -66,7 +68,7 @@ class GnomePrivacyService implements PrivacyService {
     try {
       return await _privacySettings.set(
           'report-technical-problems', DBusBoolean(enabled));
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error setting privacy settings: $e');
       return;
     }

--- a/packages/ubuntu_init/lib/src/services/privacy_service.dart
+++ b/packages/ubuntu_init/lib/src/services/privacy_service.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: avoid_catches_without_on_clauses
+// TODO: replace this service with a new one that communicates with provd
 
 import 'package:dbus/dbus.dart';
 import 'package:gsettings/gsettings.dart';

--- a/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_identity_service.dart
@@ -1,3 +1,5 @@
+// TODO: replace this service with a new one that communicates with provd
+
 import 'package:crypt/crypt.dart';
 import 'package:dbus/dbus.dart';
 import 'package:meta/meta.dart';

--- a/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_catches_without_on_clauses
+
 import 'dart:convert';
 
 import 'package:dbus/dbus.dart';
@@ -87,7 +89,7 @@ class XdgKeyboardService implements KeyboardService {
         layouts: await _getLayouts(),
       );
       return keyboardSetup;
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Failed to get keyboard setup', e);
       return const KeyboardSetup(
         setting: KeyboardSetting(layout: ''),
@@ -117,7 +119,7 @@ class XdgKeyboardService implements KeyboardService {
               DBusStruct([const DBusString('xkb'), DBusString(xkbString)])
             ]),
       );
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Failed to set input source', e);
     }
   }
@@ -134,7 +136,7 @@ class XdgKeyboardService implements KeyboardService {
         false,
         false,
       );
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Failed to set keyboard', e);
     }
   }

--- a/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_keyboard_service.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: avoid_catches_without_on_clauses
+// TODO: replace this service with a new one that communicates with provd
 
 import 'dart:convert';
 

--- a/packages/ubuntu_init/lib/src/services/xdg_locale_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_locale_service.dart
@@ -1,3 +1,5 @@
+// TODO: replace this service with a new one that communicates with provd
+
 import 'package:dbus/dbus.dart';
 import 'package:meta/meta.dart';
 import 'package:ubuntu_provision/services.dart';

--- a/packages/ubuntu_init/lib/src/services/xdg_session_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_session_service.dart
@@ -1,3 +1,5 @@
+// TODO: replace this service with a new one that communicates with provd
+
 import 'package:meta/meta.dart';
 import 'package:ubuntu_provision/services.dart';
 import 'package:ubuntu_session/ubuntu_session.dart';

--- a/packages/ubuntu_init/lib/src/services/xdg_timezone_service.dart
+++ b/packages/ubuntu_init/lib/src/services/xdg_timezone_service.dart
@@ -1,3 +1,5 @@
+// TODO: replace this service with a new one that communicates with provd
+
 import 'package:dbus/dbus.dart';
 import 'package:meta/meta.dart';
 import 'package:ubuntu_provision/services.dart';

--- a/packages/ubuntu_provision/lib/src/services/product_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/product_service.dart
@@ -90,8 +90,9 @@ class ProductService {
             .readAsLinesSync()
             .firstWhere((line) => line.trim().isNotEmpty);
         return url.replaceAll(r'${LANG}', languageCode);
-        // ignore: empty_catches
-      } on Exception catch (_) {}
+        // TODO: error handling
+        // ignore: empty_catches, avoid_catches_without_on_clauses
+      } catch (_) {}
     }
     try {
       final lines = _fileSystem
@@ -101,6 +102,7 @@ class ProductService {
       final codeName = last.split(',')[1].replaceAll(RegExp('\\s+'), '');
       assert(codeName.isNotEmpty);
       return 'https://wiki.ubuntu.com/$codeName/ReleaseNotes';
+      // TODO: error handling
       // ignore: avoid_catches_without_on_clauses
     } catch (e) {
       // Those are not actual release notes,

--- a/packages/ubuntu_provision/lib/src/services/theme_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_service.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: avoid_catches_without_on_clauses
+// TODO: replace this service with a new one that communicates with provd
+// TODO: move to ubuntu_init
 
 import 'dart:ui';
 

--- a/packages/ubuntu_provision/lib/src/services/theme_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_catches_without_on_clauses
+
 import 'dart:ui';
 
 import 'package:dbus/dbus.dart';
@@ -40,7 +42,7 @@ class GtkThemeService implements ThemeService {
       final scheme =
           await settings.get('color-scheme').then((v) => v.asString());
       return scheme.hasSuffix('dark') ? Brightness.dark : Brightness.light;
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error getting theme settings: $e');
       return Brightness.light;
     }
@@ -61,7 +63,7 @@ class GtkThemeService implements ThemeService {
           await settings.set('color-scheme', const DBusString('prefer-light'));
           break;
       }
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error setting theme settings: $e');
     }
   }
@@ -71,7 +73,7 @@ class GtkThemeService implements ThemeService {
     try {
       final theme = await settings.get('gtk-theme').then((v) => v.asString());
       return theme.removeSuffix('dark').split('-').elementAtOrNull(1);
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error getting accent color: $e');
       return null;
     }
@@ -87,7 +89,7 @@ class GtkThemeService implements ThemeService {
         if (theme.hasSuffix('dark')) 'dark',
       ].join('-');
       return settings.set('gtk-theme', DBusString(value));
-    } on Exception catch (e) {
+    } catch (e) {
       _log.error('Error setting accent color: $e');
     }
   }


### PR DESCRIPTION
The debug error catching introduced in #258 got messed up in #272. This reverts those changes so that we can run the init wizard using those legacy services without crashing it.
I've added todo notes to the services that we'll need to deprecate and replace with calls to the provd daemon.