### PR TITLE
chore: remove generated files from coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,9 +1,4 @@
 comment: false
-ignore:
-  - "**/*.freezed.dart"
-  - "**/*.g.dart"
-  - "**/*.mocks.dart"
-  - "**/l10n/*.dart"
 
 coverage:
   precision: 2

--- a/melos.yaml
+++ b/melos.yaml
@@ -86,16 +86,23 @@ scripts:
   # cleanup generated files from coverage
   coverage:cleanup: >
     melos exec --file-exists=coverage/lcov.info -- \
-      lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info
+      lcov --remove coverage/lcov.info \
+        '**/*.freezed.dart' \
+        '**/*.g.dart' \
+        '**/*.mocks.dart' \
+        '**/l10n/*.dart' \
+        '**/*.pb*.dart' \
+        -o coverage/lcov.info
 
   # format all packages
   format: >
     melos exec -c 1 -- \
       "find $MELOS_PACKAGE_PATH -name '*.dart' \
-          ! -name '*.g.dart' \
           ! -name '*.freezed.dart' \
-          ! -name '*.pb*.dart' \
+          ! -name '*.g.dart' \
+          ! -name '*.mocks.dart' \
           ! -path '*/l10n/*' \
+          ! -name '*.pb*.dart' \
           ! -path '*/.*/*' \
           | xargs dart format --set-exit-if-changed"
 


### PR DESCRIPTION
* Removes generated protobuf files from coverage in `melos coverage:cleanup`
* Removes unneeded `ignore` rule in codecov.yaml
* Removes generated files from `melos format` for consistency