### PR TITLE
fix(init): load images from config file

### DIFF
--- a/packages/ubuntu_init/lib/src/init_wizard.dart
+++ b/packages/ubuntu_init/lib/src/init_wizard.dart
@@ -30,8 +30,10 @@ class InitWizard extends ConsumerWidget {
       routes: {
         Routes.initial: WizardRoute(
           builder: (_) => const SizedBox.shrink(),
-          onReplace: (_) =>
-              ref.read(initModelProvider).init().then((_) => null),
+          onReplace: (_) async {
+            await ref.read(pageImagesProvider).preCache(context);
+            return ref.read(initModelProvider).init().then((_) => null);
+          },
         ),
         ...routes,
         Routes.theme: WizardRoute(


### PR DESCRIPTION
I noticed the images weren't correctly loading in the init wizard:
![image](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/8aa2a9e0-e68b-4694-9b59-ac8a154c1c50)
