### PR TITLE
feat: rename ubuntu-desktop-installer snap to ubuntu-desktop-bootstrap

### DIFF
--- a/snap/local/ubuntu-desktop-bootstrap.desktop
+++ b/snap/local/ubuntu-desktop-bootstrap.desktop
@@ -6,7 +6,7 @@ Name=Install RELEASE
 Comment=Install this system permanently to your hard disk
 Keywords=ubiquity;
 #use sh because pkexec is broken under xfce/lxce http://pad.lv/1193526
-Exec=ubuntu-desktop-installer
+Exec=ubuntu-desktop-bootstrap
 Icon=ubiquity
 Terminal=false
 Categories=GTK;System;Settings;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
-name: ubuntu-desktop-installer
+name: ubuntu-desktop-bootstrap
 version: git
-summary: Ubuntu Desktop Installer
+summary: Ubuntu Desktop Bootstrap
 description: |
   This project is a modern implementation of the Ubuntu Desktop installer,
   using subiquity as a backend and Flutter for the UI.
@@ -23,10 +23,10 @@ apps:
   subiquity-loadkeys:
     command: bin/subiquity/bin/subiquity-loadkeys
 
-  ubuntu-desktop-installer:
+  ubuntu-desktop-bootstrap:
     command: bin/ubuntu_bootstrap
     command-chain: [bin/launcher]
-    desktop: usr/share/applications/ubuntu-desktop-installer.desktop
+    desktop: usr/share/applications/ubuntu-desktop-bootstrap.desktop
     environment:
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri
@@ -167,7 +167,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/etc/subiquity
       cp -r snap/local/postinst.d $CRAFT_PART_INSTALL/etc/subiquity
       mkdir -p $CRAFT_PART_INSTALL/usr/share/applications
-      cp snap/local/ubuntu-desktop-installer.desktop $CRAFT_PART_INSTALL/usr/share/applications/
+      cp snap/local/ubuntu-desktop-bootstrap.desktop $CRAFT_PART_INSTALL/usr/share/applications/
       dart pub global activate melos
       dart pub global run melos bootstrap
       cd packages/ubuntu_bootstrap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,8 @@ description: |
 grade: stable
 confinement: classic
 base: core22
-issues: https://bugs.launchpad.net/ubuntu-desktop-installer/+filebug
-contact: https://bugs.launchpad.net/ubuntu-desktop-installer/+filebug
+issues: https://bugs.launchpad.net/ubuntu-desktop-provision/+filebug
+contact: https://bugs.launchpad.net/ubuntu-desktop-provision/+filebug
 
 apps:
   subiquity-server:


### PR DESCRIPTION
This will require some changes to the iso at some point.

For testing, you can still inject the ubuntu-desktop-bootstrap snap into an iso, boot it, quit the installer and remove it, then launch ubuntu-desktop-bootstrap instead. A bit cumbersome, but we should be able to get those things onto the iso soon..