### PR TITLE
feat(init): disable back buttons on certain pages

### DIFF
--- a/packages/ubuntu_init/lib/src/init_step.dart
+++ b/packages/ubuntu_init/lib/src/init_step.dart
@@ -11,14 +11,15 @@ enum InitStep {
   keyboard(KeyboardPage.new),
   network(NetworkPage.new),
   identity(IdentityPage.new),
-  ubuntuPro(UbuntuProPage.new),
-  privacy(PrivacyPage.new),
-  timezone(TimezonePage.new),
-  telemetry(TelemetryPage.new);
+  ubuntuPro(UbuntuProPage.new, hasPrevious: false),
+  privacy(PrivacyPage.new, hasPrevious: false),
+  timezone(TimezonePage.new, hasPrevious: false),
+  telemetry(TelemetryPage.new, hasPrevious: false);
 
-  const InitStep(this.pageFactory);
+  const InitStep(this.pageFactory, {this.hasPrevious = true});
 
   final ProvisioningPage Function() pageFactory;
+  final bool hasPrevious;
 
   WizardRoute? toRoute(BuildContext context, WidgetRef ref) {
     final pageConfig = ref.watch(pageConfigProvider);
@@ -26,7 +27,10 @@ enum InitStep {
     final page = pageFactory();
     return WizardRoute(
       builder: (_) => page,
-      userData: WizardRouteData(step: includedIndex),
+      userData: WizardRouteData(
+        step: includedIndex,
+        hasPrevious: hasPrevious,
+      ),
       onLoad: (_) => page.load(context, ref),
     );
   }

--- a/packages/ubuntu_init/lib/src/init_wizard.dart
+++ b/packages/ubuntu_init/lib/src/init_wizard.dart
@@ -41,6 +41,7 @@ class InitWizard extends ConsumerWidget {
           builder: (_) => const TelemetryPage(),
           userData: WizardRouteData(
             step: InitStep.telemetry.index,
+            hasPrevious: false,
           ),
           onLoad: (_) => const TelemetryPage().load(context, ref),
           onNext: (_) async {


### PR DESCRIPTION
As some actions in the init wizard are done immediately and aren't trivially reversible, some of the wizard steps shouldn't allow the user to navigate back. I think the simplest solution is to explicitly set this as an individual property for each page in the wizard.

Close #305
UDENG-2061