### PR TITLE
fix: Support window sized down to 700x560

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/source/source_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/source/source_page.dart
@@ -31,54 +31,58 @@ class SourcePage extends ConsumerWidget with ProvisioningPage {
       name: 'source',
       windowTitle: lang.updatesOtherSoftwarePageTitle,
       title: lang.updatesOtherSoftwarePageDescription,
+      expandContent: true,
       content: Center(
-        child: ListView(
-          shrinkWrap: true,
-          children: [
-            ...model.sources
-                .map((source) => Align(
-                      alignment: AlignmentDirectional.centerStart,
-                      child: Visibility(
-                        child: YaruRadioButton<String>(
-                          title: Text(source.localizeTitle(context)),
-                          subtitle: Text(source.localizeSubtitle(context)),
-                          contentPadding: kWizardPadding,
-                          value: source.id,
-                          groupValue: model.sourceId,
-                          onChanged: model.setSourceId,
+        child: Scrollbar(
+          thumbVisibility: true,
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              ...model.sources
+                  .map((source) => Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: Visibility(
+                          child: YaruRadioButton<String>(
+                            title: Text(source.localizeTitle(context)),
+                            subtitle: Text(source.localizeSubtitle(context)),
+                            contentPadding: kWizardPadding,
+                            value: source.id,
+                            groupValue: model.sourceId,
+                            onChanged: model.setSourceId,
+                          ),
                         ),
-                      ),
-                    ))
-                .withSpacing(kWizardSpacing),
-            Padding(
-              padding: const EdgeInsets.all(kYaruPagePadding),
-              child: Text(lang.otherOptions),
-            ),
-            Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: YaruCheckButton(
-                title: Text(lang.installDriversTitle),
-                subtitle: Text(lang.installDriversSubtitle),
-                contentPadding: kWizardPadding,
-                value: model.installDrivers,
-                onChanged: model.setInstallDrivers,
+                      ))
+                  .withSpacing(kWizardSpacing),
+              Padding(
+                padding: const EdgeInsets.all(kYaruPagePadding),
+                child: Text(lang.otherOptions),
               ),
-            ),
-            const SizedBox(height: kWizardSpacing),
-            Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: Tooltip(
-                message: !model.isOnline ? lang.offlineWarning : '',
+              Align(
+                alignment: AlignmentDirectional.centerStart,
                 child: YaruCheckButton(
-                  title: Text(lang.installCodecsTitle),
-                  subtitle: Text(lang.installCodecsSubtitle),
+                  title: Text(lang.installDriversTitle),
+                  subtitle: Text(lang.installDriversSubtitle),
                   contentPadding: kWizardPadding,
-                  value: model.installCodecs && model.isOnline,
-                  onChanged: model.isOnline ? model.setInstallCodecs : null,
+                  value: model.installDrivers,
+                  onChanged: model.setInstallDrivers,
                 ),
               ),
-            ),
-          ],
+              const SizedBox(height: kWizardSpacing),
+              Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: Tooltip(
+                  message: !model.isOnline ? lang.offlineWarning : '',
+                  child: YaruCheckButton(
+                    title: Text(lang.installCodecsTitle),
+                    subtitle: Text(lang.installCodecsSubtitle),
+                    contentPadding: kWizardPadding,
+                    value: model.installCodecs && model.isOnline,
+                    onChanged: model.isOnline ? model.setInstallCodecs : null,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
       snackBar: model.onBattery

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -112,7 +112,9 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
                       child: Text(lang.installationTypeAdvancedLabel),
                     ),
                     const SizedBox(width: kWizardSpacing),
-                    Text(model.guidedCapability?.localize(lang) ?? ''),
+                    Flexible(
+                      child: Text(model.guidedCapability?.localize(lang) ?? ''),
+                    ),
                   ],
                 ),
               ),

--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -37,40 +37,50 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
       windowTitle: lang.networkPageTitle,
       title: 'Connect to the Internet?', // TODO(Lukas): Add to localization
       expandContent: true,
-      content: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(lang.networkPageHeader),
-          const SizedBox(height: kWizardSpacing),
-          EthernetRadioButton(
-            value: model.connectMode,
-            onChanged: (_) => model.selectConnectMode(ConnectMode.ethernet),
-          ),
-          EthernetView(
-            expanded: model.connectMode == ConnectMode.ethernet,
-            onEnabled: () => model.selectConnectMode(ConnectMode.ethernet),
-          ),
-          WifiRadioButton(
-            value: model.connectMode,
-            onChanged: (_) => model.selectConnectMode(ConnectMode.wifi),
-          ),
-          WifiView(
-            expanded: model.connectMode == ConnectMode.wifi,
-            onEnabled: () => model.selectConnectMode(ConnectMode.wifi),
-            onSelected: (_, __) => model.selectConnectMode(ConnectMode.wifi),
-          ),
-          HiddenWifiRadioButton(
-            value: model.connectMode,
-            onChanged: (_) => model.selectConnectMode(ConnectMode.hiddenWifi),
-          ),
-          HiddenWifiView(
-            expanded: model.connectMode == ConnectMode.hiddenWifi,
-          ),
-          NoConnectView(
-            value: model.connectMode,
-            onChanged: (_) => model.selectConnectMode(ConnectMode.none),
-          ),
-        ],
+      content: Scrollbar(
+        thumbVisibility: true,
+        child: ListView(
+          shrinkWrap: true,
+          children: <Widget>[
+            Text(lang.networkPageHeader),
+            const SizedBox(height: kWizardSpacing),
+            EthernetRadioButton(
+              value: model.connectMode,
+              onChanged: (_) => model.selectConnectMode(ConnectMode.ethernet),
+            ),
+            EthernetView(
+              expanded: model.connectMode == ConnectMode.ethernet,
+              onEnabled: () => model.selectConnectMode(ConnectMode.ethernet),
+            ),
+            WifiRadioButton(
+              value: model.connectMode,
+              onChanged: (_) => model.selectConnectMode(ConnectMode.wifi),
+            ),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: model.connectMode == ConnectMode.wifi ? 100 : 0,
+                maxHeight: 200,
+              ),
+              child: WifiView(
+                expanded: model.connectMode == ConnectMode.wifi,
+                onEnabled: () => model.selectConnectMode(ConnectMode.wifi),
+                onSelected: (_, __) =>
+                    model.selectConnectMode(ConnectMode.wifi),
+              ),
+            ),
+            HiddenWifiRadioButton(
+              value: model.connectMode,
+              onChanged: (_) => model.selectConnectMode(ConnectMode.hiddenWifi),
+            ),
+            HiddenWifiView(
+              expanded: model.connectMode == ConnectMode.hiddenWifi,
+            ),
+            NoConnectView(
+              value: model.connectMode,
+              onChanged: (_) => model.selectConnectMode(ConnectMode.none),
+            ),
+          ],
+        ),
       ),
       bottomBar: WizardBar(
         leading: const PreviousWizardButton(),

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -21,7 +21,7 @@ class HorizontalPage extends ConsumerWidget {
     this.expandContent = false,
     this.padding = const EdgeInsets.symmetric(
       horizontal: defaultContentPadding,
-      vertical: _verticalContentPadding,
+      vertical: _minContentPadding,
     ),
     this.bottomBar,
     this.snackBar,
@@ -68,19 +68,22 @@ class HorizontalPage extends ConsumerWidget {
 
   // TODO(Lukas): Move these to a proper place.
   static const defaultContentPadding = 100.0;
-  static const _verticalContentPadding = 20.0;
+  static const _minContentPadding = 20.0;
   static const _contentSpacing = 60.0;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final icon = ref.watch(pageImagesProvider).get(name, context);
+    final windowSize = MediaQuery.of(context).size;
+    final isSmallWindow = windowSize.width < 960 || windowSize.height < 680;
+    final adjustedPadding =
+        isSmallWindow ? const EdgeInsets.all(_minContentPadding) : padding;
 
     return WizardPage(
       title: YaruWindowTitleBar(title: Text(windowTitle)),
       content: Padding(
-        padding:
-            padding, // TODO(Lukas): Make padding smaller when the size of the window is small.
+        padding: adjustedPadding,
         child: Row(
           children: [
             if (icon != null) ...[
@@ -88,7 +91,9 @@ class HorizontalPage extends ConsumerWidget {
                 flex: 2,
                 child: icon,
               ),
-              const SizedBox(width: _contentSpacing),
+              SizedBox(
+                width: isSmallWindow ? _minContentPadding : _contentSpacing,
+              ),
             ],
             Expanded(
               flex: 5,


### PR DESCRIPTION
With a minimum display size of 800x600 the window needs to be able to be 700x560, since the top bar and the dock has to be accounted for.

With this PR extra horizontal padding and scroll views are introduced to make it work on the minimum size.
The default size is still 960x680 though, and if the screen is smaller than that the window maximizes itself.