### PR TITLE
feat(init): split off welcome wizard

### DIFF
--- a/packages/ubuntu_init/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_init/integration_test/screenshot_test.dart
@@ -18,7 +18,7 @@ Future<void> main() async {
   tearDown(rootBundle.clear);
 
   testWidgets('00.welcome', (tester) async {
-    await tester.runApp(() => runInitApp([], theme: currentTheme));
+    await tester.runApp(() => runInitApp(['--welcome'], theme: currentTheme));
     await tester.pumpAndSettle();
 
     await tester.testWelcomeInitPage(
@@ -28,9 +28,6 @@ Future<void> main() async {
 
   testWidgets('01.locale', (tester) async {
     await tester.runApp(() => runInitApp([], theme: currentTheme));
-    await tester.pumpAndSettle();
-
-    await tester.jumpToPage(Routes.locale);
     await tester.pumpAndSettle();
 
     await tester.testLocalePage(

--- a/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
+++ b/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
@@ -24,10 +24,6 @@ void main() {
 
     await tester.runApp(() => runInitApp([]));
 
-    await tester.testWelcomeInitPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-
     await tester.testLocalePage(language: 'Deutsch');
     await tester.tapNext();
     await tester.pumpAndSettle();
@@ -69,6 +65,17 @@ void main() {
     await expectTimezone('Europe/Berlin');
 
     await tester.testTelemetryPage(enabled: false);
+    await tester.tapDone();
+    await tester.pumpAndSettle();
+    await expectLater(windowClosed, completes);
+  });
+
+  testWidgets('welcome', (tester) async {
+    final windowClosed = YaruTestWindow.waitForClosed();
+
+    await tester.runApp(() => runInitApp(['--welcome']));
+
+    await tester.testWelcomeInitPage();
     await tester.tapDone();
     await tester.pumpAndSettle();
     await expectLater(windowClosed, completes);

--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -43,6 +43,8 @@ Future<void> runInitApp(
     log.debug('Loading page config');
     await getService<PageConfigService>().load();
 
+    final welcome = tryGetService<ArgResults>()?['welcome'] as bool? ?? false;
+
     runApp(ProviderScope(
       child: Consumer(
         builder: (context, ref, child) {
@@ -65,7 +67,9 @@ Future<void> runInitApp(
             supportedLocales: supportedLocales,
             home: DefaultAssetBundle(
               bundle: ProxyAssetBundle(rootBundle, package: package),
-              child: InitWizard(onDone: onDone),
+              child: welcome
+                  ? WelcomeWizard(onDone: onDone)
+                  : InitWizard(onDone: onDone),
             ),
           );
         },

--- a/packages/ubuntu_init/lib/src/init_services.dart
+++ b/packages/ubuntu_init/lib/src/init_services.dart
@@ -33,6 +33,10 @@ Future<void> registerInitServices(List<String> args) {
     options = parseCommandLine(args, onPopulateOptions: (parser) {
       parser.addOption('config', valueHelp: 'path', help: 'Config file path');
       parser.addOption('pages', hide: true);
+      parser.addFlag(
+        'welcome',
+        help: 'Show welcome wizard',
+      );
     });
     registerServiceInstance<ArgResults>(options!);
   }

--- a/packages/ubuntu_init/lib/src/init_step.dart
+++ b/packages/ubuntu_init/lib/src/init_step.dart
@@ -6,7 +6,6 @@ import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
 enum InitStep {
-  welcome(WelcomePage.new),
   locale(LocalePage.new),
   keyboard(KeyboardPage.new),
   network(NetworkPage.new),
@@ -36,6 +35,31 @@ enum InitStep {
   String get name => toString().split('.').last;
 
   static InitStep? fromName(String name) {
+    return values.firstWhereOrNull((e) => e.name == name);
+  }
+}
+
+enum WelcomeStep {
+  welcome(WelcomePage.new);
+
+  const WelcomeStep(this.pageFactory);
+
+  final ProvisioningPage Function() pageFactory;
+
+  WizardRoute toRoute(BuildContext context, WidgetRef ref) {
+    final page = pageFactory();
+    return WizardRoute(
+      builder: (_) => page,
+      userData: WizardRouteData(
+        step: values.indexOf(this),
+      ),
+      onLoad: (_) => page.load(context, ref),
+    );
+  }
+
+  String get name => toString().split('.').last;
+
+  static WelcomeStep? fromName(String name) {
     return values.firstWhereOrNull((e) => e.name == name);
   }
 }


### PR DESCRIPTION
Adds a `--welcome` argument to ubuntu_init that runs a separate desktop welcome wizard (stage 5 of the provisioning flow).

Close #204
UDENG-1760