### PR TITLE
fix: Only show wifi device if there are more devices

### DIFF
--- a/packages/ubuntu_init/test/init_model_test.mocks.dart
+++ b/packages/ubuntu_init/test/init_model_test.mocks.dart
@@ -146,15 +146,13 @@ class MockIdentityService extends _i1.Mock implements _i2.IdentityService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<_i2.UsernameValidation> validateUsername(String? username) =>
-      (super.noSuchMethod(
+  _i4.Future<dynamic> validateUsername(String? username) => (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
-        returnValue:
-            _i4.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
-      ) as _i4.Future<_i2.UsernameValidation>);
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
 }
 
 /// A class which mocks [GdmService].

--- a/packages/ubuntu_init/test/init_model_test.mocks.dart
+++ b/packages/ubuntu_init/test/init_model_test.mocks.dart
@@ -146,13 +146,15 @@ class MockIdentityService extends _i1.Mock implements _i2.IdentityService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<dynamic> validateUsername(String? username) => (super.noSuchMethod(
+  _i4.Future<_i2.UsernameValidation> validateUsername(String? username) =>
+      (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
-        returnValue: _i4.Future<dynamic>.value(),
-      ) as _i4.Future<dynamic>);
+        returnValue:
+            _i4.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
+      ) as _i4.Future<_i2.UsernameValidation>);
 }
 
 /// A class which mocks [GdmService].

--- a/packages/ubuntu_provision/test/network/test_network.dart
+++ b/packages/ubuntu_provision/test/network/test_network.dart
@@ -61,6 +61,7 @@ Widget buildNetworkPage({
   when(wifiDevice.scanning).thenReturn(false);
   when(wifiDevice.accessPoints).thenReturn([accessPoint]);
   when(wifiDevice.isActive).thenReturn(false);
+  when(wifiDevice.isActiveAccessPoint(any)).thenReturn(false);
 
   final wifiModel = MockWifiModel();
   when(wifiModel.connectMode).thenReturn(ConnectMode.wifi);


### PR DESCRIPTION
If there is only one wifi network adapter, its name should not show, only the access points.

This PR also adds a loading indicator to the wifi that it is connecting to, so that it isn't only shown on the adapter (which now wouldn't be seen).

Closes #358 