### PR TITLE
feat: reintegrate identity, active directory and timezone pages into ubuntu bootstrap

### DIFF
--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -325,7 +325,57 @@ Future<void> main() async {
     await tester.pumpAndSettle();
 
     await tester.testConfirmPage(
-      screenshot: '$currentThemeName/10.confirm',
+      screenshot: '$currentThemeName/09.confirm',
+    );
+  }, variant: themeVariant);
+
+  testWidgets('10.timezone', (tester) async {
+    await tester.runApp(() => runInstallerApp([], theme: currentTheme));
+    await tester.pumpAndSettle();
+
+    await tester.jumpToPage(Routes.timezone);
+    await tester.pumpAndSettle();
+
+    await tester.testTimezonePage(
+      screenshot: '$currentThemeName/10.timezone',
+    );
+  }, variant: themeVariant);
+
+  testWidgets('11.identity', (tester) async {
+    await tester.runApp(() => runInstallerApp([], theme: currentTheme));
+    await tester.pumpAndSettle();
+
+    await tester.jumpToPage(Routes.identity);
+    await tester.pumpAndSettle();
+
+    await tester.testIdentityPage(
+      identity: const Identity(
+        realname: 'Ubuntu User',
+        hostname: 'ubuntu',
+        username: 'user',
+      ),
+      password: 'password',
+      screenshot: '$currentThemeName/11.identity',
+    );
+  }, variant: themeVariant);
+
+  testWidgets('12.active-directory', (tester) async {
+    final client = FakeSubiquityClient();
+    registerServiceInstance<SubiquityClient>(client);
+
+    final service = FakeActiveDirectoryService(client);
+    registerServiceInstance<ActiveDirectoryService>(service);
+
+    await tester.runApp(() => runInstallerApp([], theme: currentTheme));
+    await tester.pumpAndSettle();
+
+    await tester.jumpToPage(Routes.activeDirectory);
+    await tester.pumpAndSettle();
+
+    await tester.testActiveDirectoryPage(
+      adminName: 'admin',
+      password: 'password',
+      screenshot: '$currentThemeName/12.active-directory',
     );
   }, variant: themeVariant);
 
@@ -365,6 +415,13 @@ Future<void> main() async {
       screenshot: '$currentThemeName/16.complete',
     );
   }, variant: themeVariant);
+}
+
+class FakeActiveDirectoryService extends SubiquityActiveDirectoryService {
+  FakeActiveDirectoryService(super.client);
+
+  @override
+  Future<bool> isUsed() async => true;
 }
 
 class FakeDesktopService implements DesktopService {

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -324,6 +324,21 @@ Future<void> main() async {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
+    await tester.testIdentityPage(
+      identity: const Identity(
+        realname: 'Ubuntu User',
+        hostname: 'ubuntu',
+        username: 'user',
+      ),
+      password: 'password',
+    );
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testTimezonePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
     await tester.testConfirmPage(
       screenshot: '$currentThemeName/09.confirm',
     );

--- a/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -73,23 +73,19 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testConfirmPage();
-    await tester.tapConfirm();
+    await tester.testIdentityPage(identity: identity, password: 'password');
+    await tester.tapNext();
     await tester.pumpAndSettle();
+    await expectIdentity(identity);
 
     await tester.testTimezonePage(timezone: timezone);
     await tester.tapNext();
     await tester.pumpAndSettle();
     await expectTimezone(timezone);
 
-    await tester.testIdentityPage(identity: identity, password: 'password');
-    await tester.tapNext();
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
     await tester.pumpAndSettle();
-    await expectIdentity(identity);
-
-    await tester.testThemePage();
-    await tester.tapNext();
-    await tester.pump();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();
@@ -151,22 +147,18 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
-
-    await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-
     await tester.testIdentityPage(identity: identity, password: 'password');
     await tester.tapNext();
     await tester.pumpAndSettle();
     await expectIdentity(identity);
 
-    await tester.testThemePage();
+    await tester.testTimezonePage();
     await tester.tapNext();
-    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
+    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();
@@ -222,22 +214,18 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
-
-    await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-
     await tester.testIdentityPage(identity: identity, password: 'password');
     await tester.tapNext();
     await tester.pumpAndSettle();
     await expectIdentity(identity);
 
-    await tester.testThemePage();
+    await tester.testTimezonePage();
     await tester.tapNext();
-    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
+    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();
@@ -302,22 +290,18 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
-
-    await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-
     await tester.testIdentityPage(identity: identity, password: 'password');
     await tester.tapNext();
     await tester.pumpAndSettle();
     await expectIdentity(identity);
 
-    await tester.testThemePage();
+    await tester.testTimezonePage();
     await tester.tapNext();
-    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
+    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();
@@ -378,14 +362,6 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
-
-    await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-
     await tester.testIdentityPage(
       identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
       password: 'password',
@@ -393,9 +369,13 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testThemePage();
+    await tester.testTimezonePage();
     await tester.tapNext();
-    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
+    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();
@@ -447,14 +427,6 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
-
-    await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-
     await tester.testIdentityPage(
       identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
       password: 'password',
@@ -462,9 +434,13 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
 
-    await tester.testThemePage();
+    await tester.testTimezonePage();
     await tester.tapNext();
-    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
+    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();

--- a/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -33,6 +33,12 @@ void main() {
     const language = 'Français';
     const locale = 'fr_FR.UTF-8';
     const keyboard = KeyboardSetting(layout: 'fr', variant: 'latin9');
+    const timezone = 'Europe/Paris';
+    const identity = Identity(
+      realname: 'User',
+      hostname: 'ubuntu',
+      username: 'user',
+    );
 
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
@@ -71,6 +77,20 @@ void main() {
     await tester.tapConfirm();
     await tester.pumpAndSettle();
 
+    await tester.testTimezonePage(timezone: timezone);
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await expectTimezone(timezone);
+
+    await tester.testIdentityPage(identity: identity, password: 'password');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await expectIdentity(identity);
+
+    await tester.testThemePage();
+    await tester.tapNext();
+    await tester.pump();
+
     await tester.testInstallPage();
     await tester.pumpAndSettle();
 
@@ -79,12 +99,20 @@ void main() {
     await expectLater(windowClosed, completes);
 
     await verifySubiquityConfig(
+      identity: identity,
       keyboard: keyboard,
       locale: locale,
+      timezone: timezone,
     );
   });
 
   testWidgets('LVM Encrypted', (tester) async {
+    const identity = Identity(
+      realname: 'User',
+      hostname: 'ubuntu',
+      username: 'user',
+    );
+
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
@@ -127,6 +155,19 @@ void main() {
     await tester.tapConfirm();
     await tester.pumpAndSettle();
 
+    await tester.testTimezonePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testIdentityPage(identity: identity, password: 'password');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await expectIdentity(identity);
+
+    await tester.testThemePage();
+    await tester.tapNext();
+    await tester.pump();
+
     await tester.testInstallPage();
     await tester.pumpAndSettle();
 
@@ -135,11 +176,18 @@ void main() {
     await expectLater(windowClosed, completes);
 
     await verifySubiquityConfig(
+      identity: identity,
       capability: GuidedCapability.LVM_LUKS,
     );
   });
 
   testWidgets('ZFS unencrypted', (tester) async {
+    const identity = Identity(
+      realname: 'User',
+      hostname: 'ubuntu',
+      username: 'user',
+    );
+
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
@@ -178,6 +226,19 @@ void main() {
     await tester.tapConfirm();
     await tester.pumpAndSettle();
 
+    await tester.testTimezonePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testIdentityPage(identity: identity, password: 'password');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await expectIdentity(identity);
+
+    await tester.testThemePage();
+    await tester.tapNext();
+    await tester.pump();
+
     await tester.testInstallPage();
     await tester.pumpAndSettle();
 
@@ -186,11 +247,18 @@ void main() {
     await expectLater(windowClosed, completes);
 
     await verifySubiquityConfig(
+      identity: identity,
       capability: GuidedCapability.ZFS,
     );
   });
 
   testWidgets('tpm', (tester) async {
+    const identity = Identity(
+      realname: 'User',
+      hostname: 'ubuntu',
+      username: 'user',
+    );
+
     await tester.runApp(() => app.main([
           '--source-catalog=examples/sources/tpm.yaml',
           '--dry-run-config=examples/dry-run-configs/tpm.yaml',
@@ -238,6 +306,19 @@ void main() {
     await tester.tapConfirm();
     await tester.pumpAndSettle();
 
+    await tester.testTimezonePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testIdentityPage(identity: identity, password: 'password');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await expectIdentity(identity);
+
+    await tester.testThemePage();
+    await tester.tapNext();
+    await tester.pump();
+
     await tester.testInstallPage();
     await tester.pumpAndSettle();
 
@@ -246,6 +327,7 @@ void main() {
     await expectLater(windowClosed, completes);
 
     await verifySubiquityConfig(
+      identity: identity,
       capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
     );
   });
@@ -300,6 +382,21 @@ void main() {
     await tester.tapConfirm();
     await tester.pumpAndSettle();
 
+    await tester.testTimezonePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testIdentityPage(
+      identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
+      password: 'password',
+    );
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testThemePage();
+    await tester.tapNext();
+    await tester.pump();
+
     await tester.testInstallPage();
     await tester.pumpAndSettle();
 
@@ -353,6 +450,21 @@ void main() {
     await tester.testConfirmPage();
     await tester.tapConfirm();
     await tester.pumpAndSettle();
+
+    await tester.testTimezonePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testIdentityPage(
+      identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
+      password: 'password',
+    );
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testThemePage();
+    await tester.tapNext();
+    await tester.pump();
 
     await tester.testInstallPage();
     await tester.pumpAndSettle();

--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -86,12 +86,16 @@ Future<void> runInstallerApp(
   final baseName = p.basename(Platform.resolvedExecutable);
 
   // conditional registration if not already registered by flavors or tests
+  tryRegisterService<ActiveDirectoryService>(
+      () => SubiquityActiveDirectoryService(getService<SubiquityClient>()));
   tryRegisterServiceInstance<ArgResults>(options);
   tryRegisterService<ConfigService>(
       () => ConfigService(path: options['config'] as String?));
   tryRegisterService<AccessibilityService>(GnomeAccessibilityService.new);
   if (liveRun) tryRegisterService<DesktopService>(GnomeService.new);
   tryRegisterServiceFactory<GSettings, String>(GSettings.new);
+  tryRegisterService<IdentityService>(() => SubiquityIdentityService(
+      getService<SubiquityClient>(), getService<PostInstallService>()));
   tryRegisterService<InstallerService>(
     () => InstallerService(
       getService<SubiquityClient>(),
@@ -140,6 +144,8 @@ Future<void> runInstallerApp(
   tryRegisterService<ThemeVariantService>(
     () => ThemeVariantService(config: tryGetService<ConfigService>()),
   );
+  tryRegisterService<TimezoneService>(
+      () => SubiquityTimezoneService(getService<SubiquityClient>()));
   tryRegisterService(UdevService.new);
   tryRegisterService(UrlLauncher.new);
 

--- a/packages/ubuntu_bootstrap/lib/installer/installation_step.dart
+++ b/packages/ubuntu_bootstrap/lib/installer/installation_step.dart
@@ -17,6 +17,9 @@ enum InstallationStep {
   notEnoughDiskSpace(NotEnoughDiskSpacePage.new, discreteStep: false),
   secureBoot(SecureBootPage.new),
   storage(StorageWizard.new, discreteStep: false),
+  identity(IdentityPage.new),
+  activeDirectory(ActiveDirectoryPage.new),
+  timezone(TimezonePage.new),
   confirm(ConfirmPage.new);
 
   const InstallationStep(this.pageFactory, {this.discreteStep = true});

--- a/packages/ubuntu_bootstrap/lib/services.dart
+++ b/packages/ubuntu_bootstrap/lib/services.dart
@@ -1,6 +1,6 @@
 export 'package:ubuntu_service/ubuntu_service.dart';
 
-export 'services/active_directory_service.dart' hide log;
+export 'services/active_directory_service.dart';
 export 'services/gnome_accessibility_service.dart';
 export 'services/identity_service.dart';
 export 'services/installer_service.dart';

--- a/packages/ubuntu_bootstrap/lib/services.dart
+++ b/packages/ubuntu_bootstrap/lib/services.dart
@@ -1,6 +1,8 @@
 export 'package:ubuntu_service/ubuntu_service.dart';
 
+export 'services/active_directory_service.dart' hide log;
 export 'services/gnome_accessibility_service.dart';
+export 'services/identity_service.dart';
 export 'services/installer_service.dart';
 export 'services/keyboard_service.dart';
 export 'services/locale_service.dart';
@@ -9,3 +11,4 @@ export 'services/post_install_service.dart';
 export 'services/refresh_service.dart';
 export 'services/session_service.dart';
 export 'services/storage_service.dart';
+export 'services/timezone_service.dart';

--- a/packages/ubuntu_bootstrap/lib/services/active_directory_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/active_directory_service.dart
@@ -1,0 +1,73 @@
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_provision/services.dart';
+
+final log = Logger('ad');
+
+class SubiquityActiveDirectoryService implements ActiveDirectoryService {
+  SubiquityActiveDirectoryService(this._subiquity);
+
+  final SubiquityClient _subiquity;
+  bool? _used;
+
+  @override
+  Future<bool> hasSupport() {
+    return _subiquity.hasActiveDirectorySupport();
+  }
+
+  @override
+  Future<bool> isUsed() async {
+    return _used ?? false;
+  }
+
+  @override
+  Future<void> setUsed(bool used) async {
+    _used = used;
+    if (!used) {
+      // the active directory endpoint is not optional so we need to explicitly
+      // mark it as configured even if not used to avoid subiquity getting stuck
+      // at waiting for it to be configured.
+      _subiquity.markConfigured(['active_directory']);
+    }
+  }
+
+  @override
+  Future<AdConnectionInfo> getConnectionInfo() {
+    return _subiquity.getActiveDirectory();
+  }
+
+  @override
+  Future<void> setConnectionInfo(AdConnectionInfo info) {
+    return _subiquity.setActiveDirectory(info);
+  }
+
+  @override
+  Future<List<AdDomainNameValidation>> checkDomainName(String domain) {
+    return _subiquity.checkActiveDirectoryDomainName(domain);
+  }
+
+  @override
+  Future<AdAdminNameValidation> checkAdminName(String admin) {
+    return _subiquity.checkActiveDirectoryAdminName(admin);
+  }
+
+  @override
+  Future<AdPasswordValidation> checkPassword(String password) {
+    return _subiquity.checkActiveDirectoryPassword(password);
+  }
+
+  @override
+  Future<AdDomainNameValidation> pingDomainController(String domain) {
+    return _subiquity.pingActiveDirectoryDomainController(domain);
+  }
+
+  @override
+  Future<AdJoinResult> getJoinResult({bool wait = true}) async {
+    try {
+      return await _subiquity.getActiveDirectoryJoinResult(wait: wait);
+    } catch (e) {
+      log.error(e);
+      return AdJoinResult.UNKNOWN;
+    }
+  }
+}

--- a/packages/ubuntu_bootstrap/lib/services/active_directory_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/active_directory_service.dart
@@ -2,7 +2,7 @@ import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/services.dart';
 
-final log = Logger('ad');
+final _log = Logger('ad');
 
 class SubiquityActiveDirectoryService implements ActiveDirectoryService {
   SubiquityActiveDirectoryService(this._subiquity);
@@ -27,7 +27,7 @@ class SubiquityActiveDirectoryService implements ActiveDirectoryService {
       // the active directory endpoint is not optional so we need to explicitly
       // mark it as configured even if not used to avoid subiquity getting stuck
       // at waiting for it to be configured.
-      _subiquity.markConfigured(['active_directory']);
+      await _subiquity.markConfigured(['active_directory']);
     }
   }
 
@@ -65,8 +65,9 @@ class SubiquityActiveDirectoryService implements ActiveDirectoryService {
   Future<AdJoinResult> getJoinResult({bool wait = true}) async {
     try {
       return await _subiquity.getActiveDirectoryJoinResult(wait: wait);
+      // ignore: avoid_catches_without_on_clauses
     } catch (e) {
-      log.error(e);
+      _log.error(e);
       return AdJoinResult.UNKNOWN;
     }
   }

--- a/packages/ubuntu_bootstrap/lib/services/identity_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/identity_service.dart
@@ -1,9 +1,8 @@
 import 'package:crypt/crypt.dart';
 import 'package:meta/meta.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_bootstrap/services/post_install_service.dart';
 import 'package:ubuntu_provision/services.dart';
-
-import 'post_install_service.dart';
 
 class SubiquityIdentityService implements IdentityService {
   const SubiquityIdentityService(this._subiquity, this._postInstall);

--- a/packages/ubuntu_bootstrap/lib/services/identity_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/identity_service.dart
@@ -1,0 +1,49 @@
+import 'package:crypt/crypt.dart';
+import 'package:meta/meta.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_provision/services.dart';
+
+import 'post_install_service.dart';
+
+class SubiquityIdentityService implements IdentityService {
+  const SubiquityIdentityService(this._subiquity, this._postInstall);
+
+  final SubiquityClient _subiquity;
+  final PostInstallService _postInstall;
+
+  /// The auto-login post-install config key for testing purposes.
+  @visibleForTesting
+  static const kAutoLoginUser = 'AutoLoginUser';
+
+  @override
+  Future<Identity> getIdentity() async {
+    final data = await _subiquity.getIdentity();
+    return Identity(
+      realname: data.realname,
+      username: data.username,
+      hostname: data.hostname,
+      autoLogin: await _postInstall.get(kAutoLoginUser) != null,
+    );
+  }
+
+  @override
+  Future<void> setIdentity(Identity identity) async {
+    if (identity.autoLogin) {
+      await _postInstall.set(kAutoLoginUser, identity.username);
+    } else {
+      await _postInstall.set(kAutoLoginUser, null);
+    }
+
+    return _subiquity.setIdentity(IdentityData(
+      realname: identity.realname,
+      username: identity.username,
+      cryptedPassword: Crypt.sha512(identity.password).toString(),
+      hostname: identity.hostname,
+    ));
+  }
+
+  @override
+  Future<UsernameValidation> validateUsername(String username) {
+    return _subiquity.validateUsername(username);
+  }
+}

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -21,13 +21,10 @@ class InstallerService {
       // Use the default values for a number of endpoints that aren't used in
       // the bootstrap stage, or for which a UI page isn't implemented yet.
       await _client.markConfigured([
-        'active_directory',
-        'identity',
         'mirror',
         'proxy',
         'ssh',
         'snaplist',
-        'timezone',
         'ubuntu_pro',
       ]);
     }

--- a/packages/ubuntu_bootstrap/lib/services/timezone_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/timezone_service.dart
@@ -1,0 +1,18 @@
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_provision/services.dart';
+
+class SubiquityTimezoneService implements TimezoneService {
+  const SubiquityTimezoneService(this._subiquity);
+
+  final SubiquityClient _subiquity;
+
+  @override
+  Future<String> getTimezone() {
+    return _subiquity.getTimezone().then((info) => info.timezone);
+  }
+
+  @override
+  Future<void> setTimezone(String? timezone) {
+    return _subiquity.setTimezone(timezone ?? 'geoip');
+  }
+}

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -200,6 +200,16 @@ void main() {
 
     await tester.tapNext();
     await tester.pumpAndSettle();
+    expect(find.byType(IdentityPage), findsOneWidget);
+    verify(identityModel.init()).called(1);
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    expect(find.byType(TimezonePage), findsOneWidget);
+    verify(timezoneModel.init()).called(1);
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
     expect(find.byType(ConfirmPage), findsOneWidget);
     verify(bitLockerModel.init()).called(1); // skipped
     verify(guidedReformatModel.init()).called(1); // skipped
@@ -208,16 +218,6 @@ void main() {
     verify(confirmModel.init()).called(1);
 
     await tester.tapButton(l10n.confirmInstallButton);
-    await tester.pumpAndSettle();
-    expect(find.byType(TimezonePage), findsOneWidget);
-    verify(timezoneModel.init()).called(1);
-
-    await tester.tapNext();
-    await tester.pumpAndSettle();
-    expect(find.byType(IdentityPage), findsOneWidget);
-    verify(identityModel.init()).called(1);
-
-    await tester.tapNext();
     await tester.pumpAndSettle();
     expect(find.byType(InstallPage), findsOneWidget);
     verify(installModel.init()).called(1);
@@ -376,6 +376,9 @@ void main() {
           'not-enough-disk-space',
           'secure-boot',
           'storage',
+          'identity',
+          'active-directory',
+          'timezone',
         ]),
       ),
     );

--- a/packages/ubuntu_bootstrap/test/services/active_directory_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/active_directory_service_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_bootstrap/services/active_directory_service.dart';
+import 'package:ubuntu_provision/src/services/active_directory_service.dart';
+
+void main() {
+  group('subiquity', () {
+    test('has support', () async {
+      final client = MockSubiquityClient();
+      when(client.hasActiveDirectorySupport()).thenAnswer((_) async => true);
+
+      final service = SubiquityActiveDirectoryService(client);
+
+      final hasSupport = await service.hasSupport();
+      expect(hasSupport, isTrue);
+
+      verify(client.hasActiveDirectorySupport()).called(1);
+    });
+
+    test('connection info', () async {
+      const ad = AdConnectionInfo(
+        adminName: 'admin',
+        domainName: 'domain',
+        password: 'password',
+      );
+
+      final client = MockSubiquityClient();
+      when(client.getActiveDirectory()).thenAnswer((_) async => ad);
+      when(client.setActiveDirectory(ad)).thenAnswer((_) async {});
+
+      final service = SubiquityActiveDirectoryService(client);
+
+      expect(await service.getConnectionInfo(), equals(ad));
+
+      await service.setConnectionInfo(ad);
+      verify(client.setActiveDirectory(ad)).called(1);
+    });
+
+    test('validate input', () async {
+      final client = MockSubiquityClient();
+      when(client.checkActiveDirectoryDomainName('domain'))
+          .thenAnswer((_) async => [AdDomainNameValidation.OK]);
+      when(client.checkActiveDirectoryAdminName('admin'))
+          .thenAnswer((_) async => AdAdminNameValidation.OK);
+      when(client.checkActiveDirectoryPassword('password'))
+          .thenAnswer((_) async => AdPasswordValidation.OK);
+
+      final service = SubiquityActiveDirectoryService(client);
+
+      expect(
+        await service.checkDomainName('domain'),
+        equals([AdDomainNameValidation.OK]),
+      );
+      verify(client.checkActiveDirectoryDomainName('domain')).called(1);
+
+      expect(
+        await service.checkAdminName('admin'),
+        equals(AdAdminNameValidation.OK),
+      );
+      verify(client.checkActiveDirectoryAdminName('admin')).called(1);
+
+      expect(
+        await service.checkPassword('password'),
+        equals(AdPasswordValidation.OK),
+      );
+      verify(client.checkActiveDirectoryPassword('password')).called(1);
+    });
+
+    test('ping domain controller', () async {
+      final client = MockSubiquityClient();
+      when(client.pingActiveDirectoryDomainController('domain'))
+          .thenAnswer((_) async => AdDomainNameValidation.OK);
+
+      final service = SubiquityActiveDirectoryService(client);
+
+      expect(
+        await service.pingDomainController('domain'),
+        equals(AdDomainNameValidation.OK),
+      );
+      verify(client.pingActiveDirectoryDomainController('domain')).called(1);
+    });
+
+    test('join result', () async {
+      final client = MockSubiquityClient();
+      when(client.getActiveDirectoryJoinResult())
+          .thenAnswer((_) async => AdJoinResult.OK);
+
+      final service = SubiquityActiveDirectoryService(client);
+
+      expect(
+        await service.getJoinResult(),
+        equals(AdJoinResult.OK),
+      );
+      verify(client.getActiveDirectoryJoinResult()).called(1);
+    });
+
+    test('is used', () async {
+      final client = MockSubiquityClient();
+      when(client.markConfigured(['active_directory']))
+          .thenAnswer((_) async {});
+
+      final service = SubiquityActiveDirectoryService(client);
+
+      expect(await service.isUsed(), isFalse);
+
+      await service.setUsed(true);
+      verifyNever(client.markConfigured(['active_directory']));
+
+      expect(await service.isUsed(), isTrue);
+
+      await service.setUsed(false);
+      verify(client.markConfigured(['active_directory'])).called(1);
+
+      expect(await service.isUsed(), isFalse);
+    });
+  });
+}

--- a/packages/ubuntu_bootstrap/test/services/identity_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/identity_service_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_bootstrap/services/identity_service.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  const testIdentity = IdentityData(
+    realname: 'Arthur Dent',
+    username: 'adent',
+    hostname: 'heart-of-gold',
+  );
+
+  test('get identity', () async {
+    final client = MockSubiquityClient();
+    when(client.getIdentity()).thenAnswer((_) async => testIdentity);
+    final postInstall = MockPostInstallService();
+    when(postInstall.get(SubiquityIdentityService.kAutoLoginUser))
+        .thenAnswer((_) async => testIdentity.username);
+    final service = SubiquityIdentityService(client, postInstall);
+    expect(
+        await service.getIdentity(),
+        equals(Identity(
+          realname: testIdentity.realname,
+          username: testIdentity.username,
+          hostname: testIdentity.hostname,
+          autoLogin: true,
+        )));
+
+    verify(client.getIdentity()).called(1);
+    verify(postInstall.get(SubiquityIdentityService.kAutoLoginUser)).called(1);
+  });
+
+  test('set identity', () async {
+    final client = MockSubiquityClient();
+    final postInstall = MockPostInstallService();
+    final service = SubiquityIdentityService(client, postInstall);
+    await service.setIdentity(Identity(
+      realname: testIdentity.realname,
+      username: testIdentity.username,
+      hostname: testIdentity.hostname,
+      password: 'password',
+      autoLogin: true,
+    ));
+
+    verify(client.setIdentity(argThat(isA<IdentityData>()
+            .having((i) => i.realname, 'realname', testIdentity.realname)
+            .having((i) => i.username, 'username', testIdentity.username)
+            .having((i) => i.hostname, 'hostname', testIdentity.hostname)
+            .having((i) => i.cryptedPassword, 'cryptedPassword',
+                hasLength(greaterThan(8))))))
+        .called(1);
+    verify(postInstall.set(
+            SubiquityIdentityService.kAutoLoginUser, testIdentity.username))
+        .called(1);
+  });
+}

--- a/packages/ubuntu_bootstrap/test/services/timezone_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/timezone_service_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+import 'package:subiquity_test/subiquity_test.dart';
+import 'package:ubuntu_bootstrap/services/timezone_service.dart';
+
+void main() {
+  group('subiquity', () {
+    test('get timezone', () async {
+      final client = MockSubiquityClient();
+      when(client.getTimezone()).thenAnswer((_) async =>
+          const TimeZoneInfo(timezone: 'Europe/Stockholm', fromGeoip: false));
+
+      final service = SubiquityTimezoneService(client);
+
+      final timezone = await service.getTimezone();
+      expect(timezone, equals('Europe/Stockholm'));
+
+      verify(client.getTimezone()).called(1);
+    });
+
+    test('set timezone', () async {
+      final client = MockSubiquityClient();
+      when(client.setTimezone('geoip')).thenAnswer((_) async {});
+      when(client.setTimezone('Europe/Oslo')).thenAnswer((_) async {});
+
+      final service = SubiquityTimezoneService(client);
+
+      await service.setTimezone(null);
+      verify(client.setTimezone('geoip')).called(1);
+
+      await service.setTimezone('Europe/Oslo');
+      verify(client.setTimezone('Europe/Oslo')).called(1);
+    });
+  });
+}

--- a/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
+++ b/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
@@ -49,7 +49,7 @@ void main() {
     );
     await tester.tapNext();
     await tester.pumpAndSettle();
-    expectIdentity(identity);
+    await expectIdentity(identity);
 
     await tester.testUbuntuProPage();
     await tester.tapNext();

--- a/packages/ubuntu_provision/lib/src/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_provision/lib/src/active_directory/active_directory_page.dart
@@ -1,17 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ubuntu_provision/services.dart';
 import 'package:ubuntu_provision/src/active_directory/active_directory_dialogs.dart';
-import 'package:ubuntu_provision/src/active_directory/active_directory_l10n.dart';
-import 'package:ubuntu_provision/src/active_directory/active_directory_model.dart';
 import 'package:ubuntu_provision/src/active_directory/active_directory_widgets.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-class ActiveDirectoryPage extends ConsumerStatefulWidget {
+class ActiveDirectoryPage extends ConsumerStatefulWidget with ProvisioningPage {
   const ActiveDirectoryPage({super.key});
 
-  static Future<bool> load(WidgetRef ref) {
+  @override
+  Future<bool> load(BuildContext context, WidgetRef ref) {
     return ref.read(activeDirectoryModelProvider).init();
   }
 

--- a/packages/ubuntu_provision_test/lib/src/expect.dart
+++ b/packages/ubuntu_provision_test/lib/src/expect.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
-import 'package:ubuntu_provision_test/ubuntu_provision_test.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 Future<void> expectLocale(String locale) async {
@@ -24,9 +23,9 @@ Future<void> expectTimezone(String timezone) async {
   );
 }
 
-void expectIdentity(Identity identity) {
-  return expect(
-    getService<FakeSystemService>().identity,
+Future<void> expectIdentity(Identity identity) async {
+  return expectLater(
+    await getService<IdentityService>().getIdentity(),
     isA<Identity>()
         .having((id) => id.realname, 'realname', identity.realname)
         .having((id) => id.username, 'username', identity.username)

--- a/packages/ubuntu_provision_test/lib/src/fake_init.dart
+++ b/packages/ubuntu_provision_test/lib/src/fake_init.dart
@@ -36,8 +36,6 @@ Future<void> registerFakeInitServices({
   registerServiceFactory<GSettings, String>(
       (s) => GSettings(s, backend: keyfile));
 
-  registerService(FakeSystemService.new);
-
   registerService<IdentityService>(
       // ignore: invalid_use_of_visible_for_testing_member
       () => ProvdIdentityService(userClient: FakeProvdUserClient()));
@@ -329,22 +327,9 @@ class _FakeUrlLauncher implements UrlLauncher {
 
 class FakeProvdUserClient implements provd.ProvdUserClient {
   @override
-  Future<void> createUser(provd.User user) async {
-    getService<FakeSystemService>().identity = Identity(
-      realname: user.realName,
-      username: user.username,
-      password: user.password,
-      hostname: user.hostname,
-      autoLogin: user.autoLogin,
-    );
-  }
+  Future<void> createUser(provd.User user) async {}
 
   @override
   Future<provd.UsernameValidation> validateUsername(String username) async =>
       provd.UsernameValidation.OK;
-}
-
-/// Keeps track of changes made by the fake services.
-class FakeSystemService {
-  Identity? identity;
 }


### PR DESCRIPTION
Adds the identity, active directory and timezone pages back into ubuntu bootstrap (they're now shown immediately before the confirmation page). I've removed the `FakeSystemService` we used in ubuntu init to test user creation and restored the original behavior of `expectIdentity`.

We'll need to remove the [postinst script](https://github.com/canonical/ubuntu-desktop-provision/blob/44dff1bea18dcc384d7f7d268946773ccd480e19/snap/local/postinst.d/99_disable_user_creation) that disables user creation from the snap and then find a solution for the OEM case where the identity page will be hidden and no user account should be created. I'll open separate issues for those things after merging this.

Looks like this now:

[Screencast from 2024-01-31 18-39-30.webm](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/4d2f6f99-4c46-415f-a568-7167b11bbd61)

@anasereijo I suspect we might want to move the timezone page further to the beginning here, next to the locale/keyboard, right?

I noticed we didn't have a privacy page before the timezone page in the 23.10 installer, so that means location services are enabled in the live system by default?

P.S. @spydon the numbering in the screenshot test is all over the place now :D let's sort this out once we revive the screenshot repo.


Fix #369
UDENG-2218