### PR TITLE
feat: remove 99_disable_user_creation postinst script

### DIFF
--- a/snap/local/postinst.d/99_disable_user_creation
+++ b/snap/local/postinst.d/99_disable_user_creation
@@ -1,4 +1,0 @@
-#!/bin/sh
-TARGET=/target
-
-echo "users: []" > $TARGET/etc/cloud/cloud.cfg.d/99-disable-user-creation.cfg


### PR DESCRIPTION
Follow up to #370. To re-enable user account creation in ubuntu bootstrap, this script needs to be removed. We might need to re-add it later in a slightly modified way to support the OEM case.