### PR TITLE
feat(whitelabel): read app title from top-level config scope

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -166,6 +166,10 @@ Future<void> runInstallerApp(
     final themeVariantService = getService<ThemeVariantService>();
     await themeVariantService.load();
     final themeVariant = themeVariantService.themeVariant;
+
+    final windowTitle =
+        await getService<ConfigService>().get<String>('app-name');
+
     final endpoint = await initialized;
     await _initInstallerApp(endpoint);
 
@@ -185,7 +189,6 @@ Future<void> runInstallerApp(
               darkTheme: darkTheme ?? themeVariant?.darkTheme,
               onGenerateTitle: onGenerateTitle ??
                   (context) {
-                    final windowTitle = themeVariant?.windowTitle;
                     if (windowTitle != null) return windowTitle;
 
                     final flavor = ref.watch(flavorProvider);

--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -40,6 +40,9 @@ Future<void> runInitApp(
     await themeVariantService.load();
     final themeVariant = themeVariantService.themeVariant;
 
+    final windowTitle =
+        await getService<ConfigService>().get<String>('app-name');
+
     log.debug('Loading page config');
     await getService<PageConfigService>().load();
 
@@ -57,8 +60,7 @@ Future<void> runInitApp(
             flavor: flavor,
             theme: theme ?? themeVariant?.theme,
             darkTheme: darkTheme ?? themeVariant?.darkTheme,
-            onGenerateTitle:
-                onGenerateTitle ?? (_) => themeVariant?.windowTitle ?? '',
+            onGenerateTitle: onGenerateTitle ?? (_) => windowTitle ?? '',
             locale: ref.watch(localeProvider),
             localizationsDelegates: [
               ...?localizationsDelegates,

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.dart
@@ -15,7 +15,6 @@ class ThemeConfig with _$ThemeConfig {
     String? accentColor,
     String? elevatedButtonColor,
     String? elevatedButtonTextColor,
-    String? windowTitle,
   }) = _ThemeConfig;
   factory ThemeConfig.fromJson(Map<String, dynamic> json) =>
       _$ThemeConfigFromJson(json);
@@ -25,13 +24,12 @@ class ThemeVariant {
   const ThemeVariant({
     this.theme,
     this.darkTheme,
-    this.windowTitle,
   });
 
   factory ThemeVariant.fromThemeConfig(ThemeConfig themeConfig) {
     final accentColor = _parseColorString(themeConfig.accentColor);
     if (accentColor == null) {
-      return ThemeVariant(windowTitle: themeConfig.windowTitle);
+      return const ThemeVariant();
     }
 
     final elevatedButtonColor =
@@ -52,13 +50,11 @@ class ThemeVariant {
     return ThemeVariant(
       theme: theme,
       darkTheme: darkTheme,
-      windowTitle: themeConfig.windowTitle,
     );
   }
 
   final ThemeData? theme;
   final ThemeData? darkTheme;
-  final String? windowTitle;
 
   static Color? _parseColorString(String? colorString) {
     if (colorString == null) {

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -23,7 +23,6 @@ mixin _$ThemeConfig {
   String? get accentColor => throw _privateConstructorUsedError;
   String? get elevatedButtonColor => throw _privateConstructorUsedError;
   String? get elevatedButtonTextColor => throw _privateConstructorUsedError;
-  String? get windowTitle => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -40,8 +39,7 @@ abstract class $ThemeConfigCopyWith<$Res> {
   $Res call(
       {String? accentColor,
       String? elevatedButtonColor,
-      String? elevatedButtonTextColor,
-      String? windowTitle});
+      String? elevatedButtonTextColor});
 }
 
 /// @nodoc
@@ -60,7 +58,6 @@ class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
     Object? accentColor = freezed,
     Object? elevatedButtonColor = freezed,
     Object? elevatedButtonTextColor = freezed,
-    Object? windowTitle = freezed,
   }) {
     return _then(_value.copyWith(
       accentColor: freezed == accentColor
@@ -74,10 +71,6 @@ class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
       elevatedButtonTextColor: freezed == elevatedButtonTextColor
           ? _value.elevatedButtonTextColor
           : elevatedButtonTextColor // ignore: cast_nullable_to_non_nullable
-              as String?,
-      windowTitle: freezed == windowTitle
-          ? _value.windowTitle
-          : windowTitle // ignore: cast_nullable_to_non_nullable
               as String?,
     ) as $Val);
   }
@@ -94,8 +87,7 @@ abstract class _$$ThemeConfigImplCopyWith<$Res>
   $Res call(
       {String? accentColor,
       String? elevatedButtonColor,
-      String? elevatedButtonTextColor,
-      String? windowTitle});
+      String? elevatedButtonTextColor});
 }
 
 /// @nodoc
@@ -112,7 +104,6 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
     Object? accentColor = freezed,
     Object? elevatedButtonColor = freezed,
     Object? elevatedButtonTextColor = freezed,
-    Object? windowTitle = freezed,
   }) {
     return _then(_$ThemeConfigImpl(
       accentColor: freezed == accentColor
@@ -127,10 +118,6 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
           ? _value.elevatedButtonTextColor
           : elevatedButtonTextColor // ignore: cast_nullable_to_non_nullable
               as String?,
-      windowTitle: freezed == windowTitle
-          ? _value.windowTitle
-          : windowTitle // ignore: cast_nullable_to_non_nullable
-              as String?,
     ));
   }
 }
@@ -141,8 +128,7 @@ class _$ThemeConfigImpl implements _ThemeConfig {
   const _$ThemeConfigImpl(
       {this.accentColor,
       this.elevatedButtonColor,
-      this.elevatedButtonTextColor,
-      this.windowTitle});
+      this.elevatedButtonTextColor});
 
   factory _$ThemeConfigImpl.fromJson(Map<String, dynamic> json) =>
       _$$ThemeConfigImplFromJson(json);
@@ -153,12 +139,10 @@ class _$ThemeConfigImpl implements _ThemeConfig {
   final String? elevatedButtonColor;
   @override
   final String? elevatedButtonTextColor;
-  @override
-  final String? windowTitle;
 
   @override
   String toString() {
-    return 'ThemeConfig(accentColor: $accentColor, elevatedButtonColor: $elevatedButtonColor, elevatedButtonTextColor: $elevatedButtonTextColor, windowTitle: $windowTitle)';
+    return 'ThemeConfig(accentColor: $accentColor, elevatedButtonColor: $elevatedButtonColor, elevatedButtonTextColor: $elevatedButtonTextColor)';
   }
 
   @override
@@ -172,15 +156,13 @@ class _$ThemeConfigImpl implements _ThemeConfig {
                 other.elevatedButtonColor == elevatedButtonColor) &&
             (identical(
                     other.elevatedButtonTextColor, elevatedButtonTextColor) ||
-                other.elevatedButtonTextColor == elevatedButtonTextColor) &&
-            (identical(other.windowTitle, windowTitle) ||
-                other.windowTitle == windowTitle));
+                other.elevatedButtonTextColor == elevatedButtonTextColor));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, accentColor, elevatedButtonColor,
-      elevatedButtonTextColor, windowTitle);
+  int get hashCode => Object.hash(
+      runtimeType, accentColor, elevatedButtonColor, elevatedButtonTextColor);
 
   @JsonKey(ignore: true)
   @override
@@ -200,8 +182,7 @@ abstract class _ThemeConfig implements ThemeConfig {
   const factory _ThemeConfig(
       {final String? accentColor,
       final String? elevatedButtonColor,
-      final String? elevatedButtonTextColor,
-      final String? windowTitle}) = _$ThemeConfigImpl;
+      final String? elevatedButtonTextColor}) = _$ThemeConfigImpl;
 
   factory _ThemeConfig.fromJson(Map<String, dynamic> json) =
       _$ThemeConfigImpl.fromJson;
@@ -212,8 +193,6 @@ abstract class _ThemeConfig implements ThemeConfig {
   String? get elevatedButtonColor;
   @override
   String? get elevatedButtonTextColor;
-  @override
-  String? get windowTitle;
   @override
   @JsonKey(ignore: true)
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.g.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.g.dart
@@ -11,7 +11,6 @@ _$ThemeConfigImpl _$$ThemeConfigImplFromJson(Map<String, dynamic> json) =>
       accentColor: json['accent-color'] as String?,
       elevatedButtonColor: json['elevated-button-color'] as String?,
       elevatedButtonTextColor: json['elevated-button-text-color'] as String?,
-      windowTitle: json['window-title'] as String?,
     );
 
 Map<String, dynamic> _$$ThemeConfigImplToJson(_$ThemeConfigImpl instance) =>
@@ -19,5 +18,4 @@ Map<String, dynamic> _$$ThemeConfigImplToJson(_$ThemeConfigImpl instance) =>
       'accent-color': instance.accentColor,
       'elevated-button-color': instance.elevatedButtonColor,
       'elevated-button-text-color': instance.elevatedButtonTextColor,
-      'window-title': instance.windowTitle,
     };

--- a/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
+++ b/packages/ubuntu_provision/test/services/theme_variant_service_test.dart
@@ -11,7 +11,6 @@ void main() {
       'accent-color': '#ff0000',
       'elevated-button-color': '#00ff00',
       'elevated-button-text-color': '#0000ff',
-      'window-title': 'Window Title',
     };
     final service =
         ThemeVariantService(config: createMockConfigService(config: config));
@@ -29,7 +28,6 @@ void main() {
         equals(const Color(0xff00ff00)));
     expect(themeVariant.darkTheme?.elevatedButtonTextColor,
         equals(const Color(0xff0000ff)));
-    expect(themeVariant.windowTitle, 'Window Title');
   });
 
   test('getThemeVariant with missing config', () async {
@@ -39,7 +37,6 @@ void main() {
     expect(variant, isNotNull);
     expect(variant!.theme, null);
     expect(variant.darkTheme, null);
-    expect(variant.windowTitle, null);
   });
 }
 


### PR DESCRIPTION
Replaces `window-title` from `theme` scope with `app-name` in top-level scope.