### PR TITLE
fix(bootstrap): add isOem to page config mock

### DIFF
--- a/packages/ubuntu_bootstrap/test/test_utils.dart
+++ b/packages/ubuntu_bootstrap/test/test_utils.dart
@@ -63,6 +63,7 @@ class _Dummy {} // ignore: unused_element
 void setupMockPageConfig({
   Map<String, PageConfigEntry>? overridePages,
   List<String> excludedPages = const ['welcome'],
+  bool isOem = false,
 }) {
   final pages = overridePages ??
       Map.fromEntries(InstallationStep.values
@@ -71,6 +72,7 @@ void setupMockPageConfig({
   registerMockService<PageConfigService>(pageConfigService);
   when(pageConfigService.pages).thenReturn(pages);
   when(pageConfigService.excludedPages).thenReturn(excludedPages);
+  when(pageConfigService.isOem).thenReturn(isOem);
 }
 
 const keyboardSetup = KeyboardSetup(


### PR DESCRIPTION
Although it doesn't cause a failure, the tests are [complaining](https://github.com/canonical/ubuntu-desktop-provision/actions/runs/7848565423/job/21419979742#step:7:172) about a missing stub.