### PR TITLE
feat: read flavor from config

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -39,7 +39,7 @@ command:
       split_view: ^3.2.1
       stdlibc: ^0.1.4
       synchronized: ^3.1.0
-      ubuntu_flavor: ^0.2.2
+      ubuntu_flavor: ^0.3.0
       ubuntu_localizations: ^0.3.5
       ubuntu_logger: ^0.1.1
       ubuntu_service: ^0.3.1

--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -194,7 +194,7 @@ Future<void> runInstallerApp(
 
                     final flavor = ref.watch(flavorProvider);
                     return UbuntuBootstrapLocalizations.of(context)
-                        .windowTitle(flavor.name);
+                        .windowTitle(flavor.displayName);
                   },
               locale: ref.watch(localeProvider),
               localizationsDelegates: [

--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -15,7 +15,6 @@ import 'package:ubuntu_bootstrap/installer/installer_wizard.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/services.dart';
 import 'package:ubuntu_bootstrap/slides.dart';
-import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
@@ -28,7 +27,6 @@ export 'slides.dart';
 Future<void> runInstallerApp(
   List<String> args, {
   List<WidgetBuilder>? slides,
-  UbuntuFlavor? flavor,
   ThemeData? theme,
   ThemeData? darkTheme,
   GenerateAppTitle? onGenerateTitle,
@@ -168,8 +166,10 @@ Future<void> runInstallerApp(
     await themeVariantService.load();
     final themeVariant = themeVariantService.themeVariant;
 
-    final windowTitle =
-        await getService<ConfigService>().get<String>('app-name');
+    final configService = getService<ConfigService>();
+    final windowTitle = await configService.get<String>('app-name');
+
+    final flavor = await loadFlavor();
 
     final endpoint = await initialized;
     await _initInstallerApp(endpoint);
@@ -179,11 +179,9 @@ Future<void> runInstallerApp(
         slides: slides ?? defaultSlides,
         child: Consumer(
           builder: (context, ref, child) {
-            if (flavor != null) {
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                ref.read(flavorProvider.notifier).state = flavor;
-              });
-            }
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              ref.read(flavorProvider.notifier).state = flavor;
+            });
             return WizardApp(
               flavor: flavor,
               theme: theme ?? themeVariant?.theme,

--- a/packages/ubuntu_bootstrap/lib/pages/install/install_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/install/install_page.dart
@@ -212,7 +212,7 @@ class _DonePage extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: kWizardSpacing * 1.5),
-                Text(lang.restartWarning(flavor.name)),
+                Text(lang.restartWarning(flavor.displayName)),
                 const SizedBox(height: kWizardSpacing * 1.5),
                 Row(
                   children: [

--- a/packages/ubuntu_bootstrap/lib/pages/loading/loading_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/loading/loading_page.dart
@@ -28,7 +28,7 @@ class _LoadingPageState extends ConsumerState<LoadingPage> {
     final style = Theme.of(context).textTheme.headlineSmall!;
     return WizardPage(
       title: YaruWindowTitleBar(
-        title: Text(lang.loadingPageTitle(flavor.name)),
+        title: Text(lang.loadingPageTitle(flavor.displayName)),
       ),
       content: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -38,7 +38,7 @@ class _LoadingPageState extends ConsumerState<LoadingPage> {
             child: RepaintBoundary(child: YaruCircularProgressIndicator()),
           ),
           const SizedBox(height: kWizardSpacing * 2),
-          Text(lang.loadingHeader(flavor.name), style: style),
+          Text(lang.loadingHeader(flavor.displayName), style: style),
         ],
       ),
       bottomBar: const WizardBar(

--- a/packages/ubuntu_bootstrap/lib/pages/rst/rst_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/rst/rst_page.dart
@@ -51,7 +51,7 @@ class RstPage extends ConsumerWidget with ProvisioningPage {
               final confirmed = await showConfirmationDialog(
                 context,
                 title: lang.restartIntoWindowsTitle,
-                message: lang.restartIntoWindowsDescription(flavor.name),
+                message: lang.restartIntoWindowsDescription(flavor.displayName),
                 okLabel: UbuntuLocalizations.of(context).restartLabel,
                 okElevated: true,
               );

--- a/packages/ubuntu_bootstrap/lib/pages/source/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/source/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -37,7 +37,7 @@ class NotEnoughDiskSpacePage extends ConsumerWidget with ProvisioningPage {
                 color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
               ),
               const SizedBox(height: kWizardSpacing),
-              Text(lang.notEnoughDiskSpaceUbuntu(flavor.name),
+              Text(lang.notEnoughDiskSpaceUbuntu(flavor.displayName),
                   style: Theme.of(context).textTheme.headlineSmall),
               const SizedBox(height: kWizardSpacing),
               IntrinsicWidth(

--- a/packages/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
@@ -53,7 +53,7 @@ class BitLockerPage extends ConsumerWidget {
                       style: Theme.of(context).textTheme.headlineSmall),
                   const SizedBox(height: kWizardSpacing),
                   Text(lang.bitlockerDescription(
-                      lang.installationTypeErase(flavor.name))),
+                      lang.installationTypeErase(flavor.displayName))),
                   const SizedBox(height: kWizardSpacing),
                   Html(
                     data:
@@ -71,8 +71,8 @@ class BitLockerPage extends ConsumerWidget {
                       final confirmed = await showConfirmationDialog(
                         context,
                         title: lang.bitlockerTitle,
-                        message:
-                            lang.restartIntoWindowsDescription(flavor.name),
+                        message: lang
+                            .restartIntoWindowsDescription(flavor.displayName),
                         okLabel: UbuntuLocalizations.of(context).restartLabel,
                         okElevated: true,
                       );

--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
@@ -39,7 +39,7 @@ class GuidedReformatPage extends ConsumerWidget {
     final flavor = ref.watch(flavorProvider);
     return WizardPage(
       title: YaruWindowTitleBar(
-        title: Text(lang.selectGuidedStoragePageTitle(flavor.name)),
+        title: Text(lang.selectGuidedStoragePageTitle(flavor.displayName)),
       ),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -80,7 +80,7 @@ class GuidedReformatPage extends ConsumerWidget {
                   ),
                   const SizedBox(height: kWizardSpacing / 2),
                   Text(
-                    flavor.name,
+                    flavor.displayName,
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const SizedBox(height: kWizardSpacing / 2),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/security_key/security_key_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/security_key/security_key_page.dart
@@ -30,7 +30,7 @@ class SecurityKeyPage extends ConsumerWidget {
       ),
       header: FractionallySizedBox(
         widthFactor: kWizardWidthFraction,
-        child: Text(lang.chooseSecurityKeyHeader(flavor.name)),
+        child: Text(lang.chooseSecurityKeyHeader(flavor.displayName)),
       ),
       content: LayoutBuilder(builder: (context, constraints) {
         final fieldWidth = constraints.maxWidth * kWizardWidthFraction;

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
@@ -55,7 +55,8 @@ Future<void> showAdvancedFeaturesDialog(
                     YaruRadioButton<AdvancedFeature>(
                       title: Consumer(builder: (context, ref, child) {
                         final flavor = ref.watch(flavorProvider);
-                        return Text(lang.installationTypeLVM(flavor.name));
+                        return Text(
+                            lang.installationTypeLVM(flavor.displayName));
                       }),
                       value: AdvancedFeature.lvm,
                       groupValue: advancedFeature.value,
@@ -67,7 +68,7 @@ Future<void> showAdvancedFeaturesDialog(
                         title: Consumer(builder: (context, ref, child) {
                           final flavor = ref.watch(flavorProvider);
                           return Text(
-                              lang.installationTypeEncrypt(flavor.name));
+                              lang.installationTypeEncrypt(flavor.displayName));
                         }),
                         subtitle: Text(lang.installationTypeEncryptInfo),
                         value: encryption.value,

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -87,7 +87,7 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
             Padding(
               padding: const EdgeInsets.only(bottom: kWizardSpacing),
               child: YaruRadioButton<StorageType>(
-                title: Text(lang.installationTypeErase(flavor.name)),
+                title: Text(lang.installationTypeErase(flavor.displayName)),
                 subtitle: Html(
                   data: lang.installationTypeEraseWarning(
                       Theme.of(context).colorScheme.error.toHex()),
@@ -122,7 +122,8 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
           if (model.canManualPartition)
             YaruRadioButton<StorageType>(
               title: Text(lang.installationTypeManual),
-              subtitle: Text(lang.installationTypeManualInfo(flavor.name)),
+              subtitle:
+                  Text(lang.installationTypeManualInfo(flavor.displayName)),
               value: StorageType.manual,
               groupValue: model.type,
               onChanged: (v) => model.type = v,

--- a/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_page.dart
@@ -27,23 +27,23 @@ class TryOrInstallPage extends ConsumerWidget with ProvisioningPage {
     final flavor = ref.watch(flavorProvider);
 
     return HorizontalPage(
-      windowTitle: lang.tryOrInstallTitle(flavor.name),
-      title: lang.tryOrInstallHeader(flavor.name),
+      windowTitle: lang.tryOrInstallTitle(flavor.displayName),
+      title: lang.tryOrInstallHeader(flavor.displayName),
       content: Column(
         children: [
           OptionButton(
             value: TryOrInstallOption.installUbuntu,
             groupValue: model.option,
-            title: Text(lang.installOption(flavor.name)),
-            subtitle: Text(lang.installDescription(flavor.name)),
+            title: Text(lang.installOption(flavor.displayName)),
+            subtitle: Text(lang.installDescription(flavor.displayName)),
             onChanged: (value) => model.selectOption(value!),
           ),
           const SizedBox(height: kWizardSpacing / 2),
           OptionButton(
             value: TryOrInstallOption.tryUbuntu,
             groupValue: model.option,
-            title: Text(lang.tryOption(flavor.name)),
-            subtitle: Text(lang.tryDescription(flavor.name)),
+            title: Text(lang.tryOption(flavor.displayName)),
+            subtitle: Text(lang.tryDescription(flavor.displayName)),
             onChanged: (value) => model.selectOption(value!),
           ),
           const SizedBox(height: kWizardSpacing / 2),

--- a/packages/ubuntu_bootstrap/lib/slides/default_slides.dart
+++ b/packages/ubuntu_bootstrap/lib/slides/default_slides.dart
@@ -31,7 +31,7 @@ Widget _buildWelcomeSlide(BuildContext context) {
       children: [
         Consumer(builder: (context, ref, child) {
           final flavor = ref.watch(flavorProvider);
-          return Text(lang.installationSlidesWelcomeHeader(flavor.name));
+          return Text(lang.installationSlidesWelcomeHeader(flavor.displayName));
         }),
         Text(lang.installationSlidesWelcomeBody(product.getProductInfo())),
       ],
@@ -49,7 +49,7 @@ Widget _buildSoftwareSlide(BuildContext context) {
     title: Text(lang.installationSlidesSoftwareTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesSoftwareBody(flavor.name));
+      return Text(lang.installationSlidesSoftwareBody(flavor.displayName));
     }),
     banner: Container(
       alignment: Alignment.center,
@@ -88,7 +88,7 @@ Widget _buildDevelopmentSlide(BuildContext context) {
     title: Text(lang.installationSlidesDevelopmentTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesDevelopmentBody(flavor.name));
+      return Text(lang.installationSlidesDevelopmentBody(flavor.displayName));
     }),
     image: const SlideScreenshot('vscode.png'),
     table: SlideTable(
@@ -123,7 +123,7 @@ Widget _buildCreativitySlide(BuildContext context) {
     title: Text(lang.installationSlidesCreativityTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesCreativityBody(flavor.name));
+      return Text(lang.installationSlidesCreativityBody(flavor.displayName));
     }),
     image: const SlideScreenshot('blender.png'),
     table: SlideTable(
@@ -158,7 +158,7 @@ Widget _buildGamingSlide(BuildContext context) {
     title: Text(lang.installationSlidesGamingTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesGamingBody(flavor.name));
+      return Text(lang.installationSlidesGamingBody(flavor.displayName));
     }),
     banner: const SlideScreenshot(
       'steam.png',
@@ -200,7 +200,7 @@ Widget _buildSecuritySlide(BuildContext context) {
     title: Text(lang.installationSlidesSecurityTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesSecurityBody(flavor.name));
+      return Text(lang.installationSlidesSecurityBody(flavor.displayName));
     }),
     // TODO: show installationSlidesSecurityLts in LTS releases
     image: const SlideScreenshot('bitwarden.png'),
@@ -239,7 +239,7 @@ Widget _buildProductivitySlide(BuildContext context) {
     title: Text(lang.installationSlidesProductivityTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesProductivityBody(flavor.name));
+      return Text(lang.installationSlidesProductivityBody(flavor.displayName));
     }),
     banner: const SlideScreenshot(
       'libreoffice.png',
@@ -281,7 +281,7 @@ Widget _buildAccessibilitySlide(BuildContext context) {
     title: Text(lang.installationSlidesAccessibilityTitle),
     body: Consumer(builder: (context, ref, child) {
       final flavor = ref.watch(flavorProvider);
-      return Text(lang.installationSlidesAccessibilityBody(flavor.name));
+      return Text(lang.installationSlidesAccessibilityBody(flavor.displayName));
     }),
     image: const SlideScreenshot('accessibility.png'),
     table: SlideTable(
@@ -317,7 +317,7 @@ Widget _buildSupportSlide(BuildContext context) {
       children: [
         Consumer(builder: (context, ref, child) {
           final flavor = ref.watch(flavorProvider);
-          return Text(lang.installationSlidesSupportHeader(flavor.name));
+          return Text(lang.installationSlidesSupportHeader(flavor.displayName));
         }),
         Text(lang.installationSlidesSupportCommunity),
         Text(lang.installationSlidesSupportEnterprise),

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
       ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
-  ubuntu_flavor: ^0.2.2
+  ubuntu_flavor: ^0.3.0
   ubuntu_localizations: ^0.3.5
   ubuntu_logger: ^0.1.1
   ubuntu_provision: ^0.1.0

--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
@@ -15,7 +14,6 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 Future<void> runInitApp(
   List<String> args, {
   String package = 'ubuntu_init',
-  UbuntuFlavor? flavor,
   ThemeData? theme,
   ThemeData? darkTheme,
   GenerateAppTitle? onGenerateTitle,
@@ -48,14 +46,14 @@ Future<void> runInitApp(
 
     final welcome = tryGetService<ArgResults>()?['welcome'] as bool? ?? false;
 
+    final flavor = await loadFlavor();
+
     runApp(ProviderScope(
       child: Consumer(
         builder: (context, ref, child) {
-          if (flavor != null) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              ref.read(flavorProvider.notifier).state = flavor;
-            });
-          }
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            ref.read(flavorProvider.notifier).state = flavor;
+          });
           return WizardApp(
             flavor: flavor,
             theme: theme ?? themeVariant?.theme,

--- a/packages/ubuntu_init/lib/src/telemetry/telemetry_page.dart
+++ b/packages/ubuntu_init/lib/src/telemetry/telemetry_page.dart
@@ -37,18 +37,18 @@ class TelemetryPage extends ConsumerWidget with ProvisioningPage {
               SvgPicture.asset('assets/telemetry.svg', package: 'ubuntu_init'),
               const SizedBox(height: kWizardSpacing),
               Text(
-                l10n.telemetryHeader(flavor.name),
+                l10n.telemetryHeader(flavor.displayName),
                 style: theme.textTheme.titleLarge,
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: kWizardSpacing / 2),
               Text(
-                l10n.telemetryDescription(flavor.name),
+                l10n.telemetryDescription(flavor.displayName),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: kWizardSpacing),
               TelemetryButton(
-                title: Text(l10n.telemetryLabelOn(flavor.name)),
+                title: Text(l10n.telemetryLabelOn(flavor.displayName)),
                 value: true,
                 groupValue: model.enabled,
                 onChanged: (v) => model.enabled = v!,

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
       ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
-  ubuntu_flavor: ^0.2.2
+  ubuntu_flavor: ^0.3.0
   ubuntu_localizations: ^0.3.5
   ubuntu_logger: ^0.1.1
   ubuntu_provision: ^0.1.0

--- a/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
+++ b/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
@@ -26,8 +26,8 @@ class AccessibilityPage extends ConsumerWidget with ProvisioningPage {
         (ScrollbarTheme.of(context).thickness?.resolve({}) ?? 6) * 4;
 
     return HorizontalPage(
-      windowTitle: lang.accessibilityPageTitle(flavor.name),
-      title: lang.accessibilityPageTitle(flavor.name),
+      windowTitle: lang.accessibilityPageTitle(flavor.displayName),
+      title: lang.accessibilityPageTitle(flavor.displayName),
       expandContent: true,
       content: Center(
         child: Scrollbar(
@@ -39,7 +39,7 @@ class AccessibilityPage extends ConsumerWidget with ProvisioningPage {
               padding: EdgeInsets.only(right: scrollBarPadding),
               child: Column(
                 children: [
-                  Text(lang.accessibilityPageBody(flavor.name)),
+                  Text(lang.accessibilityPageBody(flavor.displayName)),
                   const SizedBox(height: kWizardSpacing),
                   YaruExpansionPanel(
                     headers: [

--- a/packages/ubuntu_provision/lib/src/locale/locale_page.dart
+++ b/packages/ubuntu_provision/lib/src/locale/locale_page.dart
@@ -20,7 +20,7 @@ class LocalePage extends ConsumerWidget with ProvisioningPage {
     final lang = LocaleLocalizations.of(context);
 
     return HorizontalPage(
-      windowTitle: lang.localePageTitle(flavor.name),
+      windowTitle: lang.localePageTitle(flavor.displayName),
       title: lang.localeHeader,
       onNext: () async {
         final locale = model.locale(model.selectedIndex);

--- a/packages/ubuntu_provision/lib/src/providers/flavor.dart
+++ b/packages/ubuntu_provision/lib/src/providers/flavor.dart
@@ -1,14 +1,41 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:meta/meta.dart';
 import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
 
 final _log = Logger('flavor_provider');
 
-final flavorProvider = StateProvider((_) {
-  final detectedFlavor = UbuntuFlavor.detect();
+final flavorProvider = StateProvider((_) => UbuntuFlavor.ubuntu);
+
+Future<UbuntuFlavor> loadFlavor({
+  @visibleForTesting UbuntuFlavor? detectedFlavor,
+}) async {
+  final configService = getService<ConfigService>();
+  final configFlavorName = await configService.get<String>('flavor');
+
+  if (configFlavorName?.isNotEmpty ?? false) {
+    final configFlavor = UbuntuFlavor.fromName(configFlavorName!);
+    if (configFlavor != UbuntuFlavor.unknown) {
+      _log.info('Using flavor from config: $configFlavor');
+      return configFlavor;
+    } else {
+      final validFlavorsNames = UbuntuFlavor.values
+          .whereNot((f) => f == UbuntuFlavor.unknown)
+          .map((f) => f.name)
+          .toList();
+      _log.warning('Unknown flavor found in config: $configFlavorName. '
+          'Valid flavors are: $validFlavorsNames');
+    }
+  }
+
+  detectedFlavor ??= UbuntuFlavor.detect();
   if (detectedFlavor == UbuntuFlavor.unknown) {
     _log.warning('Unknown flavor detected, defaulting to Ubuntu');
     return UbuntuFlavor.ubuntu;
   }
+  _log.info('Using detected flavor: $detectedFlavor');
   return detectedFlavor;
-});
+}

--- a/packages/ubuntu_provision/lib/src/providers/flavor.dart
+++ b/packages/ubuntu_provision/lib/src/providers/flavor.dart
@@ -1,5 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_flavor/ubuntu_flavor.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 
-final flavorProvider =
-    StateProvider((_) => UbuntuFlavor.detect() ?? UbuntuFlavor.ubuntu);
+final _log = Logger('flavor_provider');
+
+final flavorProvider = StateProvider((_) {
+  final detectedFlavor = UbuntuFlavor.detect();
+  if (detectedFlavor == UbuntuFlavor.unknown) {
+    _log.warning('Unknown flavor detected, defaulting to Ubuntu');
+    return UbuntuFlavor.ubuntu;
+  }
+  return detectedFlavor;
+});

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
       ref: 5af6896c75b5ab8f78b93f7f358836a8c4c7857f
-  ubuntu_flavor: ^0.2.2
+  ubuntu_flavor: ^0.3.0
   ubuntu_localizations: ^0.3.5
   ubuntu_logger: ^0.1.1
   ubuntu_service: ^0.3.1

--- a/packages/ubuntu_provision/test/providers/flavor_test.dart
+++ b/packages/ubuntu_provision/test/providers/flavor_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:ubuntu_flavor/ubuntu_flavor.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+
+import '../test_utils.mocks.dart';
+
+void main() {
+  group('load flavor', () {
+    final testCases = [
+      (
+        name: 'valid config',
+        configFlavorName: 'studio',
+        detectedFlavor: UbuntuFlavor.unknown,
+        expectedFlavor: UbuntuFlavor.studio,
+      ),
+      (
+        name: 'unknown flavor in config and from detection',
+        configFlavorName: 'kubuntux',
+        detectedFlavor: UbuntuFlavor.unknown,
+        expectedFlavor: UbuntuFlavor.ubuntu,
+      ),
+      (
+        name: 'unknown flavor in config and valid detection',
+        configFlavorName: 'kubuntux',
+        detectedFlavor: UbuntuFlavor.kubuntu,
+        expectedFlavor: UbuntuFlavor.kubuntu,
+      ),
+      (
+        name: 'empty config and unknown flavor from detection',
+        configFlavorName: null,
+        detectedFlavor: UbuntuFlavor.unknown,
+        expectedFlavor: UbuntuFlavor.ubuntu,
+      ),
+      (
+        name: 'empty config and valid flavor from detection',
+        configFlavorName: null,
+        detectedFlavor: UbuntuFlavor.mate,
+        expectedFlavor: UbuntuFlavor.mate,
+      ),
+    ];
+
+    tearDown(resetAllServices);
+
+    for (final testCase in testCases) {
+      test(testCase.name, () async {
+        final configService = MockConfigService();
+        when(configService.get<String>('flavor'))
+            .thenAnswer((_) async => testCase.configFlavorName);
+        registerMockService<ConfigService>(configService);
+
+        final flavor =
+            await loadFlavor(detectedFlavor: testCase.detectedFlavor);
+        expect(flavor, equals(testCase.expectedFlavor));
+      });
+    }
+  });
+}

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -16,8 +16,12 @@ extension UbuntuProvisionPageTester on WidgetTester {
     final context = element(find.byType(LocalePage));
     final l10n = LocaleLocalizations.of(context);
 
-    final flavor = UbuntuFlavor.detect() ?? UbuntuFlavor.ubuntu;
-    expect(find.titleBar(l10n.localePageTitle(flavor.name)), findsOneWidget);
+    final detectedFlavor = UbuntuFlavor.detect();
+    final flavor = detectedFlavor != UbuntuFlavor.unknown
+        ? detectedFlavor
+        : UbuntuFlavor.ubuntu;
+    expect(find.titleBar(l10n.localePageTitle(flavor.displayName)),
+        findsOneWidget);
 
     if (language != null) {
       final tile = find.listTile(language, skipOffstage: false);

--- a/packages/ubuntu_provision_test/pubspec.yaml
+++ b/packages/ubuntu_provision_test/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   subiquity_client: ^0.1.0
   sysmetrics: ^0.1.0
   ubuntu_bootstrap: ^0.1.0
-  ubuntu_flavor: ^0.2.2
+  ubuntu_flavor: ^0.3.0
   ubuntu_init: ^0.1.0
   ubuntu_provision: ^0.1.0
   ubuntu_service: ^0.3.1

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ubuntu_flavor: ^0.2.2
+  ubuntu_flavor: ^0.3.0
   ubuntu_localizations: ^0.3.5
   ubuntu_widgets: ^0.3.3
   wizard_router: ^1.1.0


### PR DESCRIPTION
Parses the `flavor` from the config file. If it can't be parsed (i.e. it's not one of budgie, cinnamon, edubuntu, kubuntu, kylin, lubuntu, mate, studio, ubuntu, unity or xubuntu) it uses [`ubuntu_flavor`](https://github.com/canonical/ubuntu-flutter-plugins/tree/main/packages/ubuntu_flavor)'s `detect()`, which tries to determine the flavor from the value of `XDG_CURRENT_DESKTOP`. 'ubuntu' is used as a fallback.

The flavor determines the primary color of the yaru theme as well as the `DISTRO` name used in l10n strings.

Closes #415
UDENG-2300