### PR TITLE
feat: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-task.md
+++ b/.github/ISSUE_TEMPLATE/new-task.md
@@ -1,0 +1,10 @@
+---
+name: New task
+about: Create a new development task. Please report bugs on Launchpad!
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please report any bugs related to Ubuntu Desktop Provision on [Launchpad](https://bugs.launchpad.net/ubuntu-desktop-provision). We use the GitHub issue tracker only for issues related to the development of Ubuntu Desktop Provision itself.


### PR DESCRIPTION
Adds an issue template that reminds users to use the launchpad issue tracker for bug reports as mentioned in the readme.