### PR TITLE
feat(init): remove obsolete keyboard assets

### DIFF
--- a/packages/ubuntu_init/assets/kbds
+++ b/packages/ubuntu_init/assets/kbds
@@ -1,1 +1,0 @@
-../../subiquity_client/subiquity/kbds/

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -60,4 +60,3 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
-    - assets/kbds/


### PR DESCRIPTION
The keyboard files imported from subiquity are no longer needed in the UI after merging #381