### PR TITLE
fix(provd): bus is up if unix:path exists

### DIFF
--- a/provd/internal/testutils/systembus.go
+++ b/provd/internal/testutils/systembus.go
@@ -142,5 +142,6 @@ func GetSystemBusConnection() (*dbus.Conn, error) {
 
 // isRunning checks if the system bus mock is running.
 func isRunning() bool {
-	return strings.HasPrefix(os.Getenv("DBUS_SYSTEM_BUS_ADDRESS"), "unix:abstract=/tmp")
+	return strings.HasPrefix(os.Getenv("DBUS_SYSTEM_BUS_ADDRESS"), "unix:abstract=/tmp") ||
+		strings.HasPrefix(os.Getenv("DBUS_SYSTEM_BUS_ADDRESS"), "unix:path=/tmp")
 }


### PR DESCRIPTION
I had a problem in my machine when copying these testutils. I hit

> system bus mock is not running. If that's intended, manually connect to the system bus instead of using this function

after calling both 
```
StartLocalSystemBus()
GetSystemBusConnection()
```

Turned out my system would create a unix:path instead of a unix:abstract socket.

Either of them existing means that the private Dbus is running and so I propose checking for both.