### PR TITLE
feat: remove flavor detection

### DIFF
--- a/packages/ubuntu_provision/lib/src/providers/flavor.dart
+++ b/packages/ubuntu_provision/lib/src/providers/flavor.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:meta/meta.dart';
 import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
@@ -10,9 +9,7 @@ final _log = Logger('flavor_provider');
 
 final flavorProvider = StateProvider((_) => UbuntuFlavor.ubuntu);
 
-Future<UbuntuFlavor> loadFlavor({
-  @visibleForTesting UbuntuFlavor? detectedFlavor,
-}) async {
+Future<UbuntuFlavor> loadFlavor() async {
   final configService = getService<ConfigService>();
   final configFlavorName = await configService.get<String>('flavor');
 
@@ -31,11 +28,6 @@ Future<UbuntuFlavor> loadFlavor({
     }
   }
 
-  detectedFlavor ??= UbuntuFlavor.detect();
-  if (detectedFlavor == UbuntuFlavor.unknown) {
-    _log.warning('Unknown flavor detected, defaulting to Ubuntu');
-    return UbuntuFlavor.ubuntu;
-  }
-  _log.info('Using detected flavor: $detectedFlavor');
-  return detectedFlavor;
+  _log.info('Using default flavor: ${UbuntuFlavor.ubuntu}');
+  return UbuntuFlavor.ubuntu;
 }

--- a/packages/ubuntu_provision/test/providers/flavor_test.dart
+++ b/packages/ubuntu_provision/test/providers/flavor_test.dart
@@ -12,32 +12,17 @@ void main() {
       (
         name: 'valid config',
         configFlavorName: 'studio',
-        detectedFlavor: UbuntuFlavor.unknown,
         expectedFlavor: UbuntuFlavor.studio,
       ),
       (
-        name: 'unknown flavor in config and from detection',
+        name: 'unknown flavor in config',
         configFlavorName: 'kubuntux',
-        detectedFlavor: UbuntuFlavor.unknown,
         expectedFlavor: UbuntuFlavor.ubuntu,
-      ),
-      (
-        name: 'unknown flavor in config and valid detection',
-        configFlavorName: 'kubuntux',
-        detectedFlavor: UbuntuFlavor.kubuntu,
-        expectedFlavor: UbuntuFlavor.kubuntu,
       ),
       (
         name: 'empty config and unknown flavor from detection',
         configFlavorName: null,
-        detectedFlavor: UbuntuFlavor.unknown,
         expectedFlavor: UbuntuFlavor.ubuntu,
-      ),
-      (
-        name: 'empty config and valid flavor from detection',
-        configFlavorName: null,
-        detectedFlavor: UbuntuFlavor.mate,
-        expectedFlavor: UbuntuFlavor.mate,
       ),
     ];
 
@@ -50,8 +35,7 @@ void main() {
             .thenAnswer((_) async => testCase.configFlavorName);
         registerMockService<ConfigService>(configService);
 
-        final flavor =
-            await loadFlavor(detectedFlavor: testCase.detectedFlavor);
+        final flavor = await loadFlavor();
         expect(flavor, equals(testCase.expectedFlavor));
       });
     }

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -16,11 +16,7 @@ extension UbuntuProvisionPageTester on WidgetTester {
     final context = element(find.byType(LocalePage));
     final l10n = LocaleLocalizations.of(context);
 
-    final detectedFlavor = UbuntuFlavor.detect();
-    final flavor = detectedFlavor != UbuntuFlavor.unknown
-        ? detectedFlavor
-        : UbuntuFlavor.ubuntu;
-    expect(find.titleBar(l10n.localePageTitle(flavor.displayName)),
+    expect(find.titleBar(l10n.localePageTitle(UbuntuFlavor.ubuntu.displayName)),
         findsOneWidget);
 
     if (language != null) {


### PR DESCRIPTION
In order to avoid any confusion, we've decided to simplify the configuration for flavors. This PR removes the automatic detection mechanism based on `XDG_CURRENT_DESKTOP`, so that the flavor needs to be set explicitly via the `flavor` key in `/usr/share/desktop-provision/whitelabel.yaml`.