### PR TITLE
feat(init): catch and log errors when lauching gdm session

### DIFF
--- a/packages/ubuntu_init/lib/src/init_model.dart
+++ b/packages/ubuntu_init/lib/src/init_model.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
+
+final _log = Logger('init_model');
 
 final initModelProvider = Provider(
   (_) => InitModel(
@@ -37,11 +40,15 @@ class InitModel {
     final identity = await _identityService?.getIdentity();
     if (identity == null) return;
 
-    await _gdmService?.init();
-    await _gdmService?.launchSession(
-      identity.username,
-      identity.password,
-    );
+    try {
+      await _gdmService?.init();
+      await _gdmService?.launchSession(
+        identity.username,
+        identity.password,
+      );
+    } on Exception catch (e) {
+      _log.error('Failed to launch desktop session', e);
+    }
   }
 
   bool hasRoute(String route) {


### PR DESCRIPTION
Until we have a gdm service in provd, let's make sure we handle errors while trying to launch the desktop session gracefully.