### PR TITLE
fix: Don't crash if `canberra-gtk-play` doesn't exist

### DIFF
--- a/packages/ubuntu_provision/lib/src/services/sound_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/sound_service.dart
@@ -9,7 +9,7 @@ class SoundService {
   Future<void> play(String id) async {
     try {
       await Process.run('canberra-gtk-play', ['--id=$id']);
-    } on ProcessException catch (e) {
+    } on ProcessException catch (_) {
       _log.error(
         'Error playing sound with id: $id (most likely missing canberra-gtk-play)',
       );

--- a/packages/ubuntu_provision/lib/src/services/sound_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/sound_service.dart
@@ -1,7 +1,18 @@
 import 'dart:io';
 
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+
+final _log = Logger('sound_service');
+
+/// A service for playing sounds.
 class SoundService {
   Future<void> play(String id) async {
-    await Process.run('canberra-gtk-play', ['--id=$id']);
+    try {
+      await Process.run('canberra-gtk-play', ['--id=$id']);
+    } on ProcessException catch (e) {
+      _log.error(
+        'Error playing sound with id: $id (most likely missing canberra-gtk-play)',
+      );
+    }
   }
 }


### PR DESCRIPTION
This is a quick workaround so that we don't crash on systems without `canberra-gtk-play`, until #419 is done.