### PR TITLE
fix(renovate): enable git submodules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "github>canonical/ubuntu-flutter-plugins"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
   "enabledManagers": [
     "github-actions",
     "pub",


### PR DESCRIPTION
The subiquity submodule is out of date again and renovate doesn't seem to open update PRs for it. I suspect it's because that feature is still in beta testing and needs to be enabled [explicitly](https://docs.renovatebot.com/modules/manager/git-submodules/).