### PR TITLE
test: add end-to-end test for ubuntu-init + provd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         set -ux
         set +e
-        sed 's|test.sock|provd/provd.sock|' provd/example.config.yaml  > provd/provd.yaml
+        mv provd/example.config.yaml provd/provd.yaml
         sudo mkdir -p /run/provd
         sudo chown $USER /run/provd
         sudo provd/provd &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,42 @@ jobs:
     - uses: bluefireteam/melos-action@v2
     - run: melos format
 
+  init-e2e:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: asdf-vm/actions/install@v3
+    - uses: bluefireteam/melos-action@v2
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y clang cmake curl libgtk-3-dev ninja-build pkg-config unzip
+        sudo apt install -y gnome-initial-setup network-manager
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: "./provd/go.mod"
+    - name: Build provd
+      run: go build ./cmd/provd
+      working-directory: provd
+    - name: Run provd
+      run: |
+        set -ux
+        set +e
+        sed 's|test.sock|provd/provd.sock|' provd/example.config.yaml  > provd/provd.yaml
+        sudo mkdir -p /run/provd
+        sudo chown $USER /run/provd
+        sudo provd/provd &
+        until [ -S /run/provd/provd.sock ]; do
+          sleep 1
+        done
+        sudo chmod go+rw /run/provd/provd.sock
+
+    - run: xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test/e2e_test.dart
+      working-directory: packages/ubuntu_init
+
   init:
     runs-on: ubuntu-22.04
     strategy:

--- a/packages/ubuntu_init/integration_test/e2e_test.dart
+++ b/packages/ubuntu_init/integration_test/e2e_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:ubuntu_init/ubuntu_init.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_provision_test/ubuntu_provision_test.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
+import 'package:yaru_test/yaru_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(YaruTestWindow.ensureInitialized);
+
+  tearDown(() async {
+    await resetAllServices();
+    rootBundle.clear();
+  });
+
+  testWidgets('init wizard', (tester) async {
+    final windowClosed = YaruTestWindow.waitForClosed();
+
+    await tester.runApp(() => runInitApp([]));
+
+    await tester.testLocalePage(language: 'Deutsch');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testKeyboardPage(layout: 'Englisch (Britisch)');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await expectCommand('localectl', [], [
+      contains('LANG=de_DE.UTF-8'),
+      contains('X11 Layout: gb'),
+    ]);
+
+    // TODO: Test gsettings input-sources
+
+    await tester.testNetworkPage(mode: ConnectMode.none);
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    const identity = Identity(
+      realname: 'Test User',
+      username: 'testuser',
+      hostname: 'testhost',
+    );
+    await tester.testIdentityPage(
+      identity: identity,
+      password: 'password',
+    );
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await expectCommand('getent', [
+      'passwd',
+      identity.username,
+    ], [
+      contains('${identity.username}:x:'),
+      contains(identity.realname),
+    ]);
+    await expectCommand('hostnamectl', [], [
+      contains('Static hostname: ${identity.hostname}'),
+    ]);
+    await expectUser(identity, 'password');
+
+    await tester.testUbuntuProPage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testPrivacyPage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    // TODO: Test privacy settings
+
+    await tester.testTimezonePage(timezone: 'Europe/Berlin');
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await expectCommand('timedatectl', [], [
+      contains('Time zone: Europe/Berlin'),
+    ]);
+
+    await tester.testTelemetryPage(enabled: false);
+    await tester.tapDone();
+    await tester.pumpAndSettle();
+    await expectLater(windowClosed, completes);
+  });
+}
+
+Future<void> expectCommand(
+  String command,
+  List<String> args,
+  List<Matcher> matchers,
+) async {
+  final result = await Process.run(command, args);
+  for (final matcher in matchers) {
+    expect(result.stdout, matcher);
+  }
+}
+
+Future<void> expectUser(Identity identity, String password) async {
+  final process = await Process.start(
+    'su',
+    [identity.username],
+  );
+  process.stdin.writeln(password);
+  process.stdin.writeln('exit');
+  expect(await process.exitCode, isZero);
+}

--- a/provd/example.config.yaml
+++ b/provd/example.config.yaml
@@ -1,2 +1,2 @@
 Paths:
-  Socket: "/run/test.sock"
+  Socket: "/run/provd/provd.sock"


### PR DESCRIPTION
Current CI setup:
* Manually run `provd` as `root`
* Allow everyone `rw` access to `/run/provd/provd.sock`

An issue with that setup is, that `provd` can't change any gsettings options:
```
(process:16409): dconf-WARNING **: 10:58:40.715: failed to commit changes to dconf: Cannot autolaunch D-Bus without X11 $DISPLAY
```
I've left todo notes to add tests for the privacy service and the gnome keyboard input sources that rely on those, once we have a solution.

Once we figure the details on how to run `provd` as the `gnome-initial-setup` and use systemd socket activation, we should do that in the e2e test as well.

For reference, here's what I've tried so far (using the systemd files from #241):
```yaml
...
- name: Setup polkit rules
  run: |
    sed "s/gnome-initial-setup/$USER/g" 20-gnome-initial-setup.rules | sudo tee 20-$USER.rules
    sudo sed "s/gnome-initial-setup/$USER/g" /var/lib/polkit-1/localauthority/10-vendor.d/gnome-initial-setup.pkla | sudo tee /var/lib/polkit-1/localauthority/10-vendor.d/$USER.pkla
  working-directory: /usr/share/polkit-1/rules.d
- name: Run provd
  run: |
    sudo cp provd/provd /usr/sbin/
    sudo cp provd/systemd/provd.service /lib/systemd/system/
    sudo cp provd/systemd/provd.socket /lib/systemd/system/
    sudo sed -i "s/gnome-initial-setup/$USER/" /lib/systemd/system/provd.socket
    sudo systemctl daemon-reload
    sudo systemctl start provd.socket

...
```
I kept running into dbus permission issues, though.

Close #411 
UDENG-2286