### PR TITLE
feat(bootstrap): stage python3-distro-info in snapcraft

### DIFF
--- a/snap/bootstrap/snapcraft.yaml
+++ b/snap/bootstrap/snapcraft.yaml
@@ -105,6 +105,7 @@ parts:
       - python3-attr
       - python3-bson
       - python3-debian
+      - python3-distro-info
       - python3-jsonschema
       - python3-minimal
       - python3-oauthlib


### PR DESCRIPTION
This package seems to be required by subiquity now, see https://github.com/canonical/subiquity/pull/1910.