### PR TITLE
In core desktop only allow to erase the disk

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -136,7 +136,8 @@ class StorageModel extends SafeChangeNotifier {
   }
 
   /// Whether any advanced features are available.
-  bool get hasAdvancedFeatures => (hasLvm || hasZfs || hasTpm) && !isCoreDesktop;
+  bool get hasAdvancedFeatures =>
+      (hasLvm || hasZfs || hasTpm) && !isCoreDesktop;
 
   ProvisioningMode? _provisioningMode;
 

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -136,7 +136,7 @@ class StorageModel extends SafeChangeNotifier {
   }
 
   /// Whether any advanced features are available.
-  bool get hasAdvancedFeatures => hasLvm || hasZfs || hasTpm;
+  bool get hasAdvancedFeatures => (hasLvm || hasZfs || hasTpm) && !isCoreDesktop;
 
   ProvisioningMode? _provisioningMode;
 

--- a/packages/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -15,15 +15,10 @@ void main() {
     when(service.getGuidedStorage())
         .thenAnswer((_) async => fakeGuidedStorageResponse());
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
     await model.init();
 
@@ -48,15 +43,10 @@ void main() {
     final service = MockStorageService();
     when(service.existingOS).thenReturn([ubuntu2110, ubuntu2204]);
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
     expect(model.existingOS, equals([ubuntu2110, ubuntu2204]));
   });
@@ -65,15 +55,10 @@ void main() {
     final storage = MockStorageService();
     when(storage.guidedCapability).thenReturn(null);
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       storage,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
 
     var wasNotified = false;
@@ -98,15 +83,10 @@ void main() {
     when(product.getProductInfo())
         .thenReturn(const ProductInfo(name: 'Ubuntu', version: '24.04 LTS'));
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       MockStorageService(),
       MockTelemetryService(),
       product,
-      configService,
     );
     expect(model.productInfo.name, 'Ubuntu');
     expect(model.productInfo.version, '24.04 LTS');
@@ -118,16 +98,10 @@ void main() {
     when(storage.guidedCapability).thenReturn(null);
 
     final telemetry = MockTelemetryService();
-
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       storage,
       telemetry,
       MockProductService(),
-      configService,
     );
     verifyNever(telemetry.addMetric('PartitionMethod', any));
 
@@ -167,15 +141,10 @@ void main() {
     when(storage.hasMultipleDisks).thenReturn(false);
     when(storage.guidedCapability).thenReturn(null);
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       storage,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
 
     model.guidedCapability = GuidedCapability.LVM;
@@ -185,20 +154,15 @@ void main() {
     verify(storage.guidedCapability = GuidedCapability.LVM_LUKS).called(1);
   });
 
-  test('Core Desktop only allows to erase disk, nothing else', () async {
+  test('DD images only allow to erase disk, nothing else', () async {
     final service = MockStorageService();
     when(service.guidedCapability).thenReturn(null);
     when(service.hasBitLocker()).thenAnswer((_) async => false);
-
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.coreDesktop);
 
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
 
     // none
@@ -207,7 +171,7 @@ void main() {
     // reformat
     const reformat = GuidedStorageTargetReformat(
       diskId: '',
-      allowed: [GuidedCapability.LVM, GuidedCapability.DIRECT],
+      allowed: [GuidedCapability.DD, GuidedCapability.LVM],
     );
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => fakeGuidedStorageResponse(targets: [reformat]));
@@ -224,15 +188,10 @@ void main() {
     when(service.guidedCapability).thenReturn(null);
     when(service.hasBitLocker()).thenAnswer((_) async => false);
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
 
     // none
@@ -309,15 +268,10 @@ void main() {
     final service = MockStorageService();
     when(service.resetStorage()).thenAnswer((_) async => []);
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
     await model.resetStorage();
     verify(service.resetStorage()).called(1);
@@ -333,15 +287,10 @@ void main() {
     });
     when(storage.hasBitLocker()).thenAnswer((_) async => false);
 
-    final configService = MockConfigService();
-    when(configService.provisioningMode)
-        .thenAnswer((_) async => ProvisioningMode.standard);
-
     final model = StorageModel(
       storage,
       MockTelemetryService(),
       MockProductService(),
-      configService,
     );
 
     when(storage.getGuidedStorage())

--- a/packages/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -171,7 +171,12 @@ void main() {
     // reformat
     const reformat = GuidedStorageTargetReformat(
       diskId: '',
-      allowed: [GuidedCapability.DD, GuidedCapability.LVM],
+      allowed: [
+        GuidedCapability.DD,
+        GuidedCapability.LVM,
+        GuidedCapability.CORE_BOOT_ENCRYPTED,
+        GuidedCapability.MANUAL
+      ],
     );
     when(service.getGuidedStorage()).thenAnswer(
         (_) async => fakeGuidedStorageResponse(targets: [reformat]));

--- a/packages/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -15,10 +15,15 @@ void main() {
     when(service.getGuidedStorage())
         .thenAnswer((_) async => fakeGuidedStorageResponse());
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
     await model.init();
 
@@ -43,10 +48,15 @@ void main() {
     final service = MockStorageService();
     when(service.existingOS).thenReturn([ubuntu2110, ubuntu2204]);
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
     expect(model.existingOS, equals([ubuntu2110, ubuntu2204]));
   });
@@ -55,10 +65,15 @@ void main() {
     final storage = MockStorageService();
     when(storage.guidedCapability).thenReturn(null);
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       storage,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
 
     var wasNotified = false;
@@ -83,10 +98,15 @@ void main() {
     when(product.getProductInfo())
         .thenReturn(const ProductInfo(name: 'Ubuntu', version: '24.04 LTS'));
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       MockStorageService(),
       MockTelemetryService(),
       product,
+      configService,
     );
     expect(model.productInfo.name, 'Ubuntu');
     expect(model.productInfo.version, '24.04 LTS');
@@ -98,10 +118,16 @@ void main() {
     when(storage.guidedCapability).thenReturn(null);
 
     final telemetry = MockTelemetryService();
+
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       storage,
       telemetry,
       MockProductService(),
+      configService,
     );
     verifyNever(telemetry.addMetric('PartitionMethod', any));
 
@@ -141,10 +167,15 @@ void main() {
     when(storage.hasMultipleDisks).thenReturn(false);
     when(storage.guidedCapability).thenReturn(null);
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       storage,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
 
     model.guidedCapability = GuidedCapability.LVM;
@@ -159,10 +190,15 @@ void main() {
     when(service.guidedCapability).thenReturn(null);
     when(service.hasBitLocker()).thenAnswer((_) async => false);
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
 
     // none
@@ -239,10 +275,15 @@ void main() {
     final service = MockStorageService();
     when(service.resetStorage()).thenAnswer((_) async => []);
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       service,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
     await model.resetStorage();
     verify(service.resetStorage()).called(1);
@@ -258,10 +299,15 @@ void main() {
     });
     when(storage.hasBitLocker()).thenAnswer((_) async => false);
 
+    final configService = MockConfigService();
+    when(configService.provisioningMode)
+        .thenAnswer((_) async => ProvisioningMode.standard);
+
     final model = StorageModel(
       storage,
       MockTelemetryService(),
       MockProductService(),
+      configService,
     );
 
     when(storage.getGuidedStorage())

--- a/packages/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
@@ -141,12 +141,6 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
       ) as bool);
 
   @override
-  bool get isCoreDesktop => (super.noSuchMethod(
-        Invocation.getter(#isCoreDesktop),
-        returnValue: false,
-      ) as bool);
-
-  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,

--- a/packages/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
@@ -141,6 +141,12 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
       ) as bool);
 
   @override
+  bool get isCoreDesktop => (super.noSuchMethod(
+        Invocation.getter(#isCoreDesktop),
+        returnValue: false,
+      ) as bool);
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,


### PR DESCRIPTION
Core desktop is installed by copying a disk image directly to the hard disk, so other options like partitioning or installing along the current operating systems aren't supported.

This patch removes all those options when installing core desktop.