### PR TITLE
fix(snapcraft): restore `source-type: git`

### DIFF
--- a/ci/snap/bootstrap/snapcraft.yaml
+++ b/ci/snap/bootstrap/snapcraft.yaml
@@ -163,6 +163,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
+    source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
       set -eux


### PR DESCRIPTION
Without explicitly specifying the `source-type` I keep running into build issues when running `snapcraft` locally, because the subiquity submodule doesn't get initialized.