### PR TITLE
feat(init): update snap interfaces

### DIFF
--- a/ci/snap/init/snapcraft.yaml
+++ b/ci/snap/init/snapcraft.yaml
@@ -19,9 +19,11 @@ apps:
     environment:
       LOG_LEVEL: debug
     plugs:
-      - hardware-observe
-      - log-observe
-      - system-observe
+      - usr-share-desktop-provision
+      - run-provd-socket
+      - network
+      - network-manager
+      - var-log-installer
 
 parts:
   flutter-git:
@@ -65,10 +67,14 @@ parts:
       cp snap/local/ubuntu-desktop-init.desktop $CRAFT_PART_INSTALL/usr/share/applications/
       dart pub global activate melos
       dart pub global run melos bootstrap
+
+      # patch config directory path
+      sed -i 's|/usr/share|/var/lib/snapd/hostfs/usr/share|'  packages/ubuntu_provision/lib/src/services/config_service.dart
+
       cd packages/ubuntu_init
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
-      
+
     stage-packages:
       - libsysmetrics1
       - pciutils
@@ -78,6 +84,22 @@ lint:
   ignore:
     - library:
         - usr/lib/**/libsysmetrics.so.1
+
+plugs:
+  run-provd-socket:
+    interface: system-files
+    read:
+      - /run/provd/provd.sock
+    write:
+      - /run/provd/provd.sock
+  usr-share-desktop-provision:
+    interface: system-files
+    read:
+      - /var/lib/snapd/hostfs/usr/share/desktop-provision
+  var-log-installer:
+    interface: system-files
+    write:
+      - /var/log/installer
 
 slots:
   dbus-name:

--- a/packages/ubuntu_init/lib/src/init_app.dart
+++ b/packages/ubuntu_init/lib/src/init_app.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
@@ -20,7 +22,8 @@ Future<void> runInitApp(
   Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
   FutureOr<void> Function()? onDone,
 }) async {
-  final log = Logger.setup();
+  final exe = p.basename(Platform.resolvedExecutable);
+  final log = Logger.setup(path: '/var/log/installer/$exe.log');
 
   return runZonedGuarded(() async {
     FlutterError.onError = (error) {

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   gsettings: ^0.2.8
   handy_window: ^0.3.1
   meta: ^1.10.0
+  path: ^1.8.3
   provd_client:
     path: ../provd_client
   stdlibc: ^0.1.4


### PR DESCRIPTION
Removes the outdated plugs and replaces them with:
- `network` and `network-manager` to access the network and configure network-manager
- `system-files`-based plugs that allow access to various locations in the host file system:
  - `/usr/share/desktop-provision` (r) - configuration directory for whitelabelling
  - `/run/provd/provd.sock` (rw) - communication with provd
  - `/var/log/installer` (w) - logging

What's left to figure out is how to access GDM via DBus. There's no interface that lets us do this using the current dart implementation of the GDM service in ubuntu-init. #455 adds that capability to provd, but we need to figure out how provd can access GDM if it runs as a socket-activated systemd service.