### PR TITLE
fix(ci): update submodules after git reset

### DIFF
--- a/.github/workflows/rebase-for-snap-cicd.yaml
+++ b/.github/workflows/rebase-for-snap-cicd.yaml
@@ -24,6 +24,7 @@ jobs:
 
           git fetch origin main:main
           git reset --hard main
+          git submodule update --init --recursive
 
           ./ci/snap-build-setup.sh ${{ matrix.input }}
 


### PR DESCRIPTION
After running `git reset --hard main` we need to update the submodule, otherwise the previous state of the submodule will be included in the top commit (see [here](https://github.com/canonical/ubuntu-desktop-provision/commit/f92f8d9057082d5f6864c53a64d21178a7420b68)).

This should fix https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2055225 which was caused by a mismatch between subiquity versions.