### PR TITLE
fix(init): patch /tmp/ path for gdm service in snap

### DIFF
--- a/ci/snap/init/snapcraft.yaml
+++ b/ci/snap/init/snapcraft.yaml
@@ -23,6 +23,7 @@ apps:
       - run-provd-socket
       - network
       - network-manager
+      - tmp
       - var-log-installer
 
 parts:
@@ -71,6 +72,9 @@ parts:
       # patch config directory path
       sed -i 's|/usr/share|/var/lib/snapd/hostfs/usr/share|'  packages/ubuntu_provision/lib/src/services/config_service.dart
 
+      # patch tmp directory path in gdm_service.dart
+      sed -i '/const tmpDirectory/{s|/tmp/|/var/lib/snapd/hostfs/tmp/|}' packages/ubuntu_init/lib/src/services/gdm_service.dart
+
       cd packages/ubuntu_init
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
@@ -92,6 +96,12 @@ plugs:
       - /run/provd/provd.sock
     write:
       - /run/provd/provd.sock
+  tmp:
+    interface: system-files
+    read:
+      - /var/lib/snapd/hostfs/tmp
+    write:
+      - /var/lib/snapd/hostfs/tmp
   usr-share-desktop-provision:
     interface: system-files
     read:

--- a/packages/ubuntu_init/lib/src/services/gdm_service.dart
+++ b/packages/ubuntu_init/lib/src/services/gdm_service.dart
@@ -15,6 +15,8 @@ class GdmService {
   DBusClient? _sessionClient;
   final Map<String, DBusRemoteObjectSignalStream>? _signalStreams;
 
+  static const tmpDirectory = '/tmp/';
+
   Future<void> init() async {
     if (_sessionClient != null) return;
 
@@ -26,10 +28,14 @@ class GdmService {
     _sessionClient = await gdmObject
         .callMethod('org.gnome.DisplayManager.Manager', 'OpenSession', [],
             replySignature: DBusSignature.string)
-        .then((response) => DBusClient(
-              DBusAddress(response.values.first.asString()),
-              messageBus: false,
-            ));
+        .then((response) {
+      final socketPath =
+          response.values.first.asString().replaceFirst('/tmp/', tmpDirectory);
+      return DBusClient(
+        DBusAddress(socketPath),
+        messageBus: false,
+      );
+    });
   }
 
   Future<void> launchSession(String username, String password) async {


### PR DESCRIPTION
Until we have sorted out the permission issues for #455, we need to rely on the existing dart implementation of the GDM service to launch the desktop session. Since GDM exposes its private socket in the host's `/tmp/` directory, we need yet another `system-files` plug to access that.