### PR TITLE
feat(refresh): quit installer instead of restarting

### DIFF
--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -722,7 +722,7 @@
       "snap": {}
     }
   },
-  "refreshRestart": "Please restart the installer.",
+  "refreshRestart": "Please quit and relaunch the installer.",
   "refreshSnapPrerequisites": "Ensuring {snap} prerequisites...",
   "@refreshSnapPrerequisites": {
     "type": "text",

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -1446,7 +1446,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @refreshRestart.
   ///
   /// In en, this message translates to:
-  /// **'Please restart the installer.'**
+  /// **'Please quit and relaunch the installer.'**
   String get refreshRestart;
 
   /// No description provided for @refreshSnapPrerequisites.

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -730,7 +730,7 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get refreshRestart => 'Please restart the installer.';
+  String get refreshRestart => 'Please quit and relaunch the installer.';
 
   @override
   String refreshSnapPrerequisites(Object snap) {

--- a/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_model.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:stdlibc/stdlibc.dart';
 import 'package:ubuntu_bootstrap/services.dart';
 
 export 'package:subiquity_client/subiquity_client.dart' show RefreshCheckState;
@@ -35,7 +34,7 @@ class RefreshModel extends ChangeNotifier {
   Future<RefreshState> check() => _service.check();
   Future<void> refresh() => _service.refresh();
 
-  Future<void> restart() async {
-    execv(Platform.resolvedExecutable, []);
+  Future<void> quit() async {
+    exit(0);
   }
 }

--- a/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_page.dart
@@ -38,7 +38,7 @@ class RefreshPage extends ConsumerWidget with ProvisioningPage {
           : RefreshBar(
               state: model.state,
               onSkip: Wizard.of(context).next,
-              onRestart: model.restart,
+              onQuit: model.quit,
             ),
     );
   }

--- a/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
@@ -63,12 +63,12 @@ class RefreshBar extends StatelessWidget {
     required this.state,
     super.key,
     this.onSkip,
-    this.onRestart,
+    this.onQuit,
   });
 
   final RefreshState state;
   final VoidCallback? onSkip;
-  final VoidCallback? onRestart;
+  final VoidCallback? onQuit;
 
   @override
   Widget build(BuildContext context) {
@@ -78,9 +78,9 @@ class RefreshBar extends StatelessWidget {
     );
 
     final restart = WizardButton(
-      label: UbuntuLocalizations.of(context).restartLabel,
+      label: UbuntuLocalizations.of(context).quitLabel,
       highlighted: true,
-      onActivated: onRestart,
+      onActivated: onQuit,
     );
 
     return WizardBar(

--- a/packages/ubuntu_bootstrap/test/refresh/refresh_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/refresh/refresh_page_test.dart
@@ -120,7 +120,7 @@ void main() {
     expect(progress.value, isZero);
 
     expect(
-      find.button(find.ul10n((l10n) => l10n.restartLabel)),
+      find.button(find.ul10n((l10n) => l10n.quitLabel)),
       findsOneWidget,
     );
   });
@@ -136,7 +136,7 @@ void main() {
     expect(progress.value, isZero);
 
     expect(
-      find.button(find.ul10n((l10n) => l10n.restartLabel)),
+      find.button(find.ul10n((l10n) => l10n.quitLabel)),
       findsOneWidget,
     );
   });

--- a/packages/ubuntu_bootstrap/test/refresh/test_refresh.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/refresh/test_refresh.mocks.dart
@@ -101,9 +101,9 @@ class MockRefreshModel extends _i1.Mock implements _i3.RefreshModel {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<void> restart() => (super.noSuchMethod(
+  _i4.Future<void> quit() => (super.noSuchMethod(
         Invocation.method(
-          #restart,
+          #quit,
           [],
         ),
         returnValue: _i4.Future<void>.value(),


### PR DESCRIPTION
The refresh mechanism currently fails to launch the updated version of the UI once the ubuntu-desktop-bootstrap snap has been refreshed by subiquity, see https://github.com/canonical/ubuntu-desktop-installer/issues/2377. This is because calling `execv(Platform.resolvedExecutable, [])` from within the snap relaunches the old revision instead of the updated one.
As a simple fix, we can just quit the installer and ask the user to relaunch it. I haven't figured out how to properly test this yet, but I don't see why this approach shouldn't work. In any case, merging this PR cannot make it worse than it currently is :)