### PR TITLE
chore: Update to Flutter 3.19.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.16.9-stable
+flutter 3.19.2-stable

--- a/melos.yaml
+++ b/melos.yaml
@@ -7,7 +7,7 @@ command:
   bootstrap:
     environment:
       sdk: ">=3.0.0 <4.0.0"
-      flutter: '>=3.13.0'
+      flutter: '>=3.19.2'
 
     dependencies:
       args: ^2.4.2

--- a/packages/provd_client/pubspec.yaml
+++ b/packages/provd_client/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   mockito: 5.4.4
   test: any
   ubuntu_lints: ^0.3.0

--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   freezed: ^2.4.6
   json_serializable: ^6.7.1
   mockito: 5.4.4

--- a/packages/subiquity_test/pubspec.yaml
+++ b/packages/subiquity_test/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
 
 dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   mockito: 5.4.4
   path: ^1.8.3
   subiquity_client: ^0.1.0

--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/storage_size_dialog.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/storage_size_dialog.dart
@@ -21,8 +21,8 @@ Future<int?> showStorageSizeDialog(
 
   return showDialog(
     context: context,
-    builder: (context) => AnimatedBuilder(
-      animation: Listenable.merge([size, unit]),
+    builder: (context) => ListenableBuilder(
+      listenable: Listenable.merge([size, unit]),
       builder: (context, child) => StorageSizeDialog(
         title: title,
         name: name,
@@ -101,7 +101,6 @@ class StorageSizeDialog extends StatelessWidget {
               ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 320),
                 child: StorageSizeBox(
-                  autofocus: true,
                   size: size,
                   unit: unit,
                   minimum: minimumSize,

--- a/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_dialogs.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/manual/manual_storage_model.dart';

--- a/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_dialogs.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/manual/manual_storage_model.dart';
@@ -45,8 +47,8 @@ Future<void> showCreatePartitionDialog(
             rows: [
               <Widget>[
                 Text(lang.partitionSizeLabel, textAlign: TextAlign.end),
-                AnimatedBuilder(
-                  animation: Listenable.merge([
+                ListenableBuilder(
+                  listenable: Listenable.merge([
                     partitionSize,
                     partitionUnit,
                   ]),
@@ -164,8 +166,8 @@ Future<void> showEditPartitionDialog(
             rows: [
               <Widget>[
                 Text(lang.partitionSizeLabel, textAlign: TextAlign.end),
-                AnimatedBuilder(
-                  animation: Listenable.merge([
+                ListenableBuilder(
+                  listenable: Listenable.merge([
                     partitionSize,
                     partitionUnit,
                   ]),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
@@ -35,8 +35,8 @@ Future<void> showAdvancedFeaturesDialog(
         contentPadding: const EdgeInsets.all(kYaruPagePadding),
         actionsPadding: const EdgeInsets.all(kYaruPagePadding),
         buttonPadding: EdgeInsets.zero,
-        content: AnimatedBuilder(
-          animation: Listenable.merge([advancedFeature, encryption]),
+        content: ListenableBuilder(
+          listenable: Listenable.merge([advancedFeature, encryption]),
           builder: (context, child) {
             return SizedBox(
               width: kWizardDialogWidth,

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.19.2"
 
 dependencies:
   args: ^2.4.2

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -58,7 +58,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   flutter_test:
     sdk: flutter
   freezed: ^2.4.6

--- a/packages/ubuntu_bootstrap/test/storage/guided_resize/storage_size_dialog_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/guided_resize/storage_size_dialog_test.dart
@@ -6,7 +6,6 @@ import 'package:ubuntu_bootstrap/widgets/storage_size_box.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
-import 'package:yaru_test/yaru_test.dart';
 
 import '../../test_utils.dart';
 

--- a/packages/ubuntu_bootstrap/test/storage/guided_resize/storage_size_dialog_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/guided_resize/storage_size_dialog_test.dart
@@ -57,14 +57,11 @@ void main() {
     final context = tester.element(find.byType(StorageSizeDialog));
 
     for (final unit in DataUnit.values) {
-      final menuButton = find.byType(MenuButtonBuilder<DataUnit>).last;
+      final menuButton = find.byType(MenuButtonBuilder<DataUnit>);
       expect(menuButton, findsOneWidget);
       await tester.pumpAndSettle();
       await tester.ensureVisible(menuButton);
       await tester.pumpAndSettle();
-      // TODO: This is needed to a bug in Flutter 3.16.0 where the focus still
-      // is on the text field within the SpinBox (only in tests).
-      FocusScope.of(context).unfocus();
       await tester.tap(menuButton);
       await tester.pumpAndSettle();
 

--- a/packages/ubuntu_bootstrap/test/storage/guided_resize/storage_size_dialog_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/guided_resize/storage_size_dialog_test.dart
@@ -31,7 +31,6 @@ void main() {
 
     expect(find.byType(StorageSizeBox), findsOneWidget);
     expect(find.byType(EditableText), findsOneWidget);
-    expect(find.byType(EditableText), hasFocus);
 
     await tester.enterText(find.byType(StorageSizeBox), '150');
     await tester.pump();

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.19.2"
 
 dependencies:
   args: ^2.4.2

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -47,7 +47,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/ubuntu_provision/lib/src/keyboard/keyboard_widgets.dart
+++ b/packages/ubuntu_provision/lib/src/keyboard/keyboard_widgets.dart
@@ -83,25 +83,21 @@ class _DetectKeyboardViewState extends State<DetectKeyboardView> {
   @override
   void initState() {
     super.initState();
-    RawKeyboard.instance.addListener(_handleKey);
+    HardwareKeyboard.instance.addHandler(_handleKey);
   }
 
   @override
   void dispose() {
-    RawKeyboard.instance.removeListener(_handleKey);
+    HardwareKeyboard.instance.removeHandler(_handleKey);
     super.dispose();
   }
 
-  void _handleKey(RawKeyEvent event) {
-    if (event is! RawKeyDownEvent) return;
-    final data = event.data as RawKeyEventDataLinux;
-    // From Ubiquity:
-    // > FIXME needs to account for possible remapping. Find the API to translate
-    // > kernel keycodes to X keycodes (xkb).
-    //
-    // Refers to `min_key_code = 8` in xkb:
-    // https://github.com/xkbcommon/libxkbcommon/blob/master/src/xkbcomp/keycodes.c#L539
-    widget._onKeyPress?.call(data.scanCode - 8);
+  bool _handleKey(KeyEvent event) {
+    if (event is! KeyDownEvent) return false;
+    final hidCode = event.physicalKey.usbHidUsage & 0xFFFF;
+    final scanCode = _usbHidToScanCode[hidCode] ?? -1;
+    widget._onKeyPress?.call(scanCode);
+    return true;
   }
 
   @override
@@ -117,3 +113,128 @@ class _DetectKeyboardViewState extends State<DetectKeyboardView> {
     );
   }
 }
+
+final _usbHidToScanCode = {
+  0x01: 0x00FF, // Overrun Error
+  0x02: 0x00FC, // POST Fail
+  0x04: 0x001E, // a A
+  0x05: 0x0030, // b B
+  0x06: 0x002E, // c C
+  0x07: 0x0020, // d D
+  0x08: 0x0012, // e E
+  0x09: 0x0021, // f F
+  0x0A: 0x0022, // g G
+  0x0B: 0x0023, // h H
+  0x0C: 0x0017, // i I
+  0x0D: 0x0024, // j J
+  0x0E: 0x0025, // k K
+  0x0F: 0x0026, // l L
+  0x10: 0x0032, // m M
+  0x11: 0x0031, // n N
+  0x12: 0x0018, // o O
+  0x13: 0x0019, // p P
+  0x14: 0x0010, // q Q
+  0x15: 0x0013, // r R
+  0x16: 0x001F, // s S
+  0x17: 0x0014, // t T
+  0x18: 0x0016, // u U
+  0x19: 0x002F, // v V
+  0x1A: 0x0011, // w W
+  0x1B: 0x002D, // x X
+  0x1C: 0x0015, // y Y
+  0x1D: 0x002C, // z Z
+  0x1E: 0x0002, // 1 !
+  0x1F: 0x0003, // 2 @
+  0x20: 0x0004, // 3 #
+  0x21: 0x0005, // 4 $
+  0x22: 0x0006, // 5 %
+  0x23: 0x0007, // 6 ^
+  0x24: 0x0008, // 7 &
+  0x25: 0x0009, // 8 *
+  0x26: 0x000A, // 9 (
+  0x27: 0x000B, // 0 )
+  0x28: 0x001C, // Return
+  0x29: 0x0001, // Escape
+  0x2A: 0x000E, // Backspace
+  0x2B: 0x000F, // Tab
+  0x2C: 0x0039, // Space
+  0x2D: 0x000C, // - _
+  0x2E: 0x000D, // = +
+  0x2F: 0x001A, // [ {
+  0x30: 0x001B, // ] }
+  0x31: 0x002B, // \ |
+  0x33: 0x0027, // ; :
+  0x34: 0x0028, // ' "
+  0x35: 0x0029, // ` ~
+  0x36: 0x0033, // , <
+  0x37: 0x0034, // . >
+  0x38: 0x0035, // / ?
+  0x39: 0x003A, // Caps Lock
+  0x3A: 0x003B, // F1
+  0x3B: 0x003C, // F2
+  0x3C: 0x003D, // F3
+  0x3D: 0x003E, // F4
+  0x3E: 0x003F, // F5
+  0x3F: 0x0040, // F6
+  0x40: 0x0041, // F7
+  0x41: 0x0042, // F8
+  0x42: 0x0043, // F9
+  0x43: 0x0044, // F10
+  0x44: 0x0057, // F11
+  0x45: 0x0058, // F12
+  0x46: 0xE037, // Print Screen (Note 1)
+  0x47: 0x0046, // Scroll Lock
+  0x49: 0xE052, // Insert (Note 1)
+  0x4A: 0xE047, // Home (Note 1)
+  0x4B: 0xE049, // Page Up (Note 1)
+  0x4C: 0xE053, // Delete (Note 1)
+  0x4D: 0xE04F, // End (Note 1)
+  0x4E: 0xE051, // Page Down (Note 1)
+  0x4F: 0xE04D, // Right Arrow (Note 1)
+  0x50: 0xE04B, // Left Arrow (Note 1)
+  0x51: 0xE050, // Down Arrow (Note 1)
+  0x52: 0xE048, // Up Arrow (Note 1)
+  0x53: 0x0045, // Num Lock
+  0x54: 0xE035, // Keypad / (Note 1)
+  0x55: 0x0037, // Keypad *
+  0x56: 0x004A, // Keypad -
+  0x57: 0x004E, // Keypad +
+  0x58: 0xE01C, // Keypad Enter
+  0x59: 0x004F, // Keypad 1 End
+  0x5A: 0x0050, // Keypad 2 Down
+  0x5B: 0x0051, // Keypad 3 PageDn
+  0x5C: 0x004B, // Keypad 4 Left
+  0x5D: 0x004C, // Keypad 5
+  0x5E: 0x004D, // Keypad 6 Right
+  0x5F: 0x0047, // Keypad 7 Home
+  0x60: 0x0048, // Keypad 8 Up
+  0x61: 0x0049, // Keypad 9 PageUp
+  0x62: 0x0052, // Keypad 0 Insert
+  0x63: 0x0053, // Keypad . Delete
+  0x64: 0x0056, // Europe 2 (Note 2)
+  0x65: 0xE05D, // App
+  0x67: 0x0059, // Keypad =
+  0x68: 0x005D, // F13
+  0x69: 0x005E, // F14
+  0x6A: 0x005F, // F15
+  0x85: 0x007E, // Keypad , (Brazilian Keypad .)
+  0x87: 0x0073, // Keyboard Int'l 1 ろ (Ro)
+  0x88: 0x0070, // Keyboard Int'l 2 かたかな ひらがな ローマ字 (Katakana/Hiragana)
+  0x89: 0x007D, // Keyboard Int'l 3 ￥ (Yen)
+  0x8A: 0x0079, // Keyboard Int'l 4 前候補 変換 (次候補) 全候補 (Henkan)
+  0x8B: 0x007B, // Keyboard Int'l 5 無変換 (Muhenkan)
+  0x8C: 0x005C, // Keyboard Int'l 6 (PC9800 Keypad , )
+  0x90: 0x00F2, // Keyboard Lang 1 한/영 (Hanguel/English)
+  0x91: 0x00F1, // Keyboard Lang 2 한자 (Hanja)
+  0x92: 0x0078, // Keyboard Lang 3 かたかな (Katakana)
+  0x93: 0x0077, // Keyboard Lang 4 ひらがな (Hiragana)
+  0x94: 0x0076, // Keyboard Lang 5 半角/全角 (Zenkaku/Hankaku)
+  0xE0: 0x001D, // Left Control
+  0xE1: 0x002A, // Left Shift
+  0xE2: 0x0038, // Left Alt
+  0xE3: 0xE05B, // Left GUI
+  0xE4: 0xE01D, // Right Control
+  0xE5: 0x0036, // Right Shift
+  0xE6: 0xE038, // Right Alt
+  0xE7: 0xE05C, // Right GUI
+};

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.19.2"
 
 dependencies:
   args: ^2.4.2

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -54,7 +54,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   fake_async: ^1.3.1
   flutter_test:
     sdk: flutter

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -297,50 +297,50 @@ class _FakeDirectory_21 extends _i1.SmartFake implements _i10.Directory {
         );
 }
 
-class _FakeDateTime_22 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_22(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeRandomAccessFile_23 extends _i1.SmartFake
-    implements _i10.RandomAccessFile {
-  _FakeRandomAccessFile_23(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeIOSink_24 extends _i1.SmartFake implements _i10.IOSink {
-  _FakeIOSink_24(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeFileStat_25 extends _i1.SmartFake implements _i10.FileStat {
-  _FakeFileStat_25(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeFileSystemEntity_26 extends _i1.SmartFake
+class _FakeFileSystemEntity_22 extends _i1.SmartFake
     implements _i10.FileSystemEntity {
-  _FakeFileSystemEntity_26(
+  _FakeFileSystemEntity_22(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeDateTime_23 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_23(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRandomAccessFile_24 extends _i1.SmartFake
+    implements _i10.RandomAccessFile {
+  _FakeRandomAccessFile_24(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeIOSink_25 extends _i1.SmartFake implements _i10.IOSink {
+  _FakeIOSink_25(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFileStat_26 extends _i1.SmartFake implements _i10.FileStat {
+  _FakeFileStat_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -2407,6 +2407,44 @@ class MockFile extends _i1.Mock implements _i10.File {
       ) as _i10.File);
 
   @override
+  _i13.Future<_i10.FileSystemEntity> delete({bool? recursive = false}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #delete,
+          [],
+          {#recursive: recursive},
+        ),
+        returnValue:
+            _i13.Future<_i10.FileSystemEntity>.value(_FakeFileSystemEntity_22(
+          this,
+          Invocation.method(
+            #delete,
+            [],
+            {#recursive: recursive},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i13.Future<_i10.FileSystemEntity>.value(_FakeFileSystemEntity_22(
+          this,
+          Invocation.method(
+            #delete,
+            [],
+            {#recursive: recursive},
+          ),
+        )),
+      ) as _i13.Future<_i10.FileSystemEntity>);
+
+  @override
+  void deleteSync({bool? recursive = false}) => super.noSuchMethod(
+        Invocation.method(
+          #deleteSync,
+          [],
+          {#recursive: recursive},
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i13.Future<_i10.File> copy(String? newPath) => (super.noSuchMethod(
         Invocation.method(
           #copy,
@@ -2476,14 +2514,14 @@ class MockFile extends _i1.Mock implements _i10.File {
           #lastAccessed,
           [],
         ),
-        returnValue: _i13.Future<DateTime>.value(_FakeDateTime_22(
+        returnValue: _i13.Future<DateTime>.value(_FakeDateTime_23(
           this,
           Invocation.method(
             #lastAccessed,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<DateTime>.value(_FakeDateTime_22(
+        returnValueForMissingStub: _i13.Future<DateTime>.value(_FakeDateTime_23(
           this,
           Invocation.method(
             #lastAccessed,
@@ -2498,14 +2536,14 @@ class MockFile extends _i1.Mock implements _i10.File {
           #lastAccessedSync,
           [],
         ),
-        returnValue: _FakeDateTime_22(
+        returnValue: _FakeDateTime_23(
           this,
           Invocation.method(
             #lastAccessedSync,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeDateTime_22(
+        returnValueForMissingStub: _FakeDateTime_23(
           this,
           Invocation.method(
             #lastAccessedSync,
@@ -2539,14 +2577,14 @@ class MockFile extends _i1.Mock implements _i10.File {
           #lastModified,
           [],
         ),
-        returnValue: _i13.Future<DateTime>.value(_FakeDateTime_22(
+        returnValue: _i13.Future<DateTime>.value(_FakeDateTime_23(
           this,
           Invocation.method(
             #lastModified,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<DateTime>.value(_FakeDateTime_22(
+        returnValueForMissingStub: _i13.Future<DateTime>.value(_FakeDateTime_23(
           this,
           Invocation.method(
             #lastModified,
@@ -2561,14 +2599,14 @@ class MockFile extends _i1.Mock implements _i10.File {
           #lastModifiedSync,
           [],
         ),
-        returnValue: _FakeDateTime_22(
+        returnValue: _FakeDateTime_23(
           this,
           Invocation.method(
             #lastModifiedSync,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeDateTime_22(
+        returnValueForMissingStub: _FakeDateTime_23(
           this,
           Invocation.method(
             #lastModifiedSync,
@@ -2606,7 +2644,7 @@ class MockFile extends _i1.Mock implements _i10.File {
           {#mode: mode},
         ),
         returnValue:
-            _i13.Future<_i10.RandomAccessFile>.value(_FakeRandomAccessFile_23(
+            _i13.Future<_i10.RandomAccessFile>.value(_FakeRandomAccessFile_24(
           this,
           Invocation.method(
             #open,
@@ -2615,7 +2653,7 @@ class MockFile extends _i1.Mock implements _i10.File {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i10.RandomAccessFile>.value(_FakeRandomAccessFile_23(
+            _i13.Future<_i10.RandomAccessFile>.value(_FakeRandomAccessFile_24(
           this,
           Invocation.method(
             #open,
@@ -2633,7 +2671,7 @@ class MockFile extends _i1.Mock implements _i10.File {
           [],
           {#mode: mode},
         ),
-        returnValue: _FakeRandomAccessFile_23(
+        returnValue: _FakeRandomAccessFile_24(
           this,
           Invocation.method(
             #openSync,
@@ -2641,7 +2679,7 @@ class MockFile extends _i1.Mock implements _i10.File {
             {#mode: mode},
           ),
         ),
-        returnValueForMissingStub: _FakeRandomAccessFile_23(
+        returnValueForMissingStub: _FakeRandomAccessFile_24(
           this,
           Invocation.method(
             #openSync,
@@ -2682,7 +2720,7 @@ class MockFile extends _i1.Mock implements _i10.File {
             #encoding: encoding,
           },
         ),
-        returnValue: _FakeIOSink_24(
+        returnValue: _FakeIOSink_25(
           this,
           Invocation.method(
             #openWrite,
@@ -2693,7 +2731,7 @@ class MockFile extends _i1.Mock implements _i10.File {
             },
           ),
         ),
-        returnValueForMissingStub: _FakeIOSink_24(
+        returnValueForMissingStub: _FakeIOSink_25(
           this,
           Invocation.method(
             #openWrite,
@@ -2998,7 +3036,7 @@ class MockFile extends _i1.Mock implements _i10.File {
           #stat,
           [],
         ),
-        returnValue: _i13.Future<_i10.FileStat>.value(_FakeFileStat_25(
+        returnValue: _i13.Future<_i10.FileStat>.value(_FakeFileStat_26(
           this,
           Invocation.method(
             #stat,
@@ -3006,7 +3044,7 @@ class MockFile extends _i1.Mock implements _i10.File {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i10.FileStat>.value(_FakeFileStat_25(
+            _i13.Future<_i10.FileStat>.value(_FakeFileStat_26(
           this,
           Invocation.method(
             #stat,
@@ -3021,14 +3059,14 @@ class MockFile extends _i1.Mock implements _i10.File {
           #statSync,
           [],
         ),
-        returnValue: _FakeFileStat_25(
+        returnValue: _FakeFileStat_26(
           this,
           Invocation.method(
             #statSync,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeFileStat_25(
+        returnValueForMissingStub: _FakeFileStat_26(
           this,
           Invocation.method(
             #statSync,
@@ -3036,44 +3074,6 @@ class MockFile extends _i1.Mock implements _i10.File {
           ),
         ),
       ) as _i10.FileStat);
-
-  @override
-  _i13.Future<_i10.FileSystemEntity> delete({bool? recursive = false}) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #delete,
-          [],
-          {#recursive: recursive},
-        ),
-        returnValue:
-            _i13.Future<_i10.FileSystemEntity>.value(_FakeFileSystemEntity_26(
-          this,
-          Invocation.method(
-            #delete,
-            [],
-            {#recursive: recursive},
-          ),
-        )),
-        returnValueForMissingStub:
-            _i13.Future<_i10.FileSystemEntity>.value(_FakeFileSystemEntity_26(
-          this,
-          Invocation.method(
-            #delete,
-            [],
-            {#recursive: recursive},
-          ),
-        )),
-      ) as _i13.Future<_i10.FileSystemEntity>);
-
-  @override
-  void deleteSync({bool? recursive = false}) => super.noSuchMethod(
-        Invocation.method(
-          #deleteSync,
-          [],
-          {#recursive: recursive},
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i13.Stream<_i10.FileSystemEvent> watch({

--- a/packages/ubuntu_provision_test/pubspec.yaml
+++ b/packages/ubuntu_provision_test/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.19.2"
 
 dependencies:
   dbus: ^0.7.10

--- a/packages/ubuntu_utils/pubspec.yaml
+++ b/packages/ubuntu_utils/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  dart_style: 2.3.4
   flutter_test:
     sdk: flutter
   mockito: 5.4.4

--- a/packages/ubuntu_utils/pubspec.yaml
+++ b/packages/ubuntu_utils/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.19.2"
 
 dependencies:
   args: ^2.4.2

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.19.2"
 
 dependencies:
   flutter:


### PR DESCRIPTION
The biggest change is that we had to migrate to use the `HardwareKeyboard` API.
https://docs.flutter.dev/release/breaking-changes/key-event-migration

Autofocus is removed from the spinbox, since it throws assertions when the number goes down, not a big loss UX-wise.