### PR TITLE
fix: Disable network radio buttons instead of showing a red cross

### DIFF
--- a/packages/ubuntu_provision/lib/src/network/ethernet_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/ethernet_view.dart
@@ -4,7 +4,6 @@ import 'package:ubuntu_provision/src/network/connect_model.dart';
 import 'package:ubuntu_provision/src/network/ethernet_model.dart';
 import 'package:ubuntu_provision/src/network/network_l10n.dart';
 import 'package:ubuntu_provision/src/network/network_tile.dart';
-import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 class EthernetRadioButton extends ConsumerWidget {
@@ -21,21 +20,15 @@ class EthernetRadioButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final model = ref.watch(ethernetModelProvider);
     final lang = NetworkLocalizations.of(context);
-    if (!model.isEnabled || model.devices.isEmpty) {
-      return NetworkTile(
-        leading: Icon(YaruIcons.window_close,
-            color: Theme.of(context).colorScheme.error),
-        title: model.devices.isEmpty
-            ? Text(lang.networkWiredNone)
-            : Text(lang.networkWiredOff),
-      );
-    }
+    final isEnabled = model.isEnabled && model.devices.isNotEmpty;
+    final disabledTitle =
+        model.devices.isEmpty ? lang.networkWiredNone : lang.networkWiredOff;
 
     return YaruRadioButton<ConnectMode>(
-      title: Text(lang.networkWiredOption),
+      title: Text(isEnabled ? lang.networkWiredOption : disabledTitle),
       value: ConnectMode.ethernet,
       groupValue: value,
-      onChanged: onChanged,
+      onChanged: isEnabled ? onChanged : null,
     );
   }
 }

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -28,22 +28,18 @@ class WifiRadioButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final model = ref.watch(wifiModelProvider);
     final lang = NetworkLocalizations.of(context);
+    final isEnabled = model.isEnabled && model.devices.isNotEmpty;
+    final disabledTitle =
+        !model.isEnabled ? lang.networkWifiOff : lang.networkWifiNone;
+
     return Padding(
       padding: const EdgeInsets.only(top: 8),
-      child: !model.isEnabled || model.devices.isEmpty
-          ? NetworkTile(
-              leading: Icon(YaruIcons.window_close,
-                  color: Theme.of(context).colorScheme.error),
-              title: !model.isEnabled
-                  ? Text(lang.networkWifiOff)
-                  : Text(lang.networkWifiNone),
-            )
-          : YaruRadioButton<ConnectMode>(
-              title: Text(lang.networkWifiOption),
-              value: ConnectMode.wifi,
-              groupValue: value,
-              onChanged: onChanged,
-            ),
+      child: YaruRadioButton<ConnectMode>(
+        title: Text(isEnabled ? lang.networkWifiOption : disabledTitle),
+        value: ConnectMode.wifi,
+        groupValue: value,
+        onChanged: isEnabled ? onChanged : null,
+      ),
     );
   }
 }

--- a/packages/ubuntu_provision/test/network/ethernet_view_test.dart
+++ b/packages/ubuntu_provision/test/network/ethernet_view_test.dart
@@ -65,7 +65,12 @@ void main() {
     final context = tester.element(find.byType(EthernetView));
     final l10n = NetworkLocalizations.of(context);
 
-    expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
+    final radioButtonFinder = find.byType(YaruRadioButton<ConnectMode>);
+    expect(radioButtonFinder, findsOneWidget);
+
+    final radioButton =
+        tester.widget<YaruRadioButton<ConnectMode>>(radioButtonFinder);
+    expect(radioButton.onChanged, isNull);
 
     expect(find.text(l10n.networkWiredOff), findsOneWidget);
     expect(find.text(l10n.networkWiredDisabled), findsOneWidget);
@@ -103,7 +108,13 @@ void main() {
     final l10n = NetworkLocalizations.of(context);
 
     expect(find.byType(OutlinedButton), findsNothing);
-    expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
+
+    final radioButtonFinder = find.byType(YaruRadioButton<ConnectMode>);
+    expect(radioButtonFinder, findsOneWidget);
+
+    final radioButton =
+        tester.widget<YaruRadioButton<ConnectMode>>(radioButtonFinder);
+    expect(radioButton.onChanged, isNull);
     expect(find.text(l10n.networkWiredNone), findsOneWidget);
   });
 }

--- a/packages/ubuntu_provision/test/network/wifi_view_test.dart
+++ b/packages/ubuntu_provision/test/network/wifi_view_test.dart
@@ -140,7 +140,13 @@ void main() {
     final l10n = NetworkLocalizations.of(context);
 
     expect(find.byType(WifiListView), findsNothing);
-    expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
+
+    final radioButtonFinder = find.byType(YaruRadioButton<ConnectMode>);
+    expect(radioButtonFinder, findsOneWidget);
+
+    final radioButton =
+        tester.widget<YaruRadioButton<ConnectMode>>(radioButtonFinder);
+    expect(radioButton.onChanged, isNull);
 
     expect(find.text(l10n.networkWifiOff), findsOneWidget);
     expect(find.text(l10n.networkWifiDisabled), findsOneWidget);
@@ -178,8 +184,13 @@ void main() {
     final context = tester.element(find.byType(WifiView));
     final l10n = NetworkLocalizations.of(context);
 
-    expect(find.byType(WifiListView), findsNothing);
-    expect(find.byType(YaruRadioButton<ConnectMode>), findsNothing);
+    final radioButtonFinder = find.byType(YaruRadioButton<ConnectMode>);
+    expect(radioButtonFinder, findsOneWidget);
+
+    final radioButton =
+        tester.widget<YaruRadioButton<ConnectMode>>(radioButtonFinder);
+    expect(radioButton.onChanged, isNull);
+
     expect(find.text(l10n.networkWifiNone), findsOneWidget);
   });
 


### PR DESCRIPTION
![image](https://github.com/canonical/ubuntu-desktop-provision/assets/744771/dc450b82-f544-4a5a-98a7-b339ccebcfa4)
