### PR TITLE
feat(bootstrap): expose encrypted ZFS in advanced features dialog

### DIFF
--- a/ci/snap/bootstrap/snapcraft.yaml
+++ b/ci/snap/bootstrap/snapcraft.yaml
@@ -10,7 +10,7 @@ base: core22
 architectures:
   - build-on: amd64
   - build-on: arm64
-  
+
 apps:
   subiquity-server:
     command: bin/subiquity-server
@@ -47,7 +47,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 237053d9d18916dd72cf861280474d4df0e9fd24
+    source-commit: c3c4f42862b01e76ef6767e66b808707897aa558
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
@@ -175,7 +175,7 @@ parts:
       cp -r snap/local/postinst.d $CRAFT_PART_INSTALL/etc/subiquity
       mkdir -p $CRAFT_PART_INSTALL/usr/share/applications
       cp snap/local/ubuntu-desktop-bootstrap.desktop $CRAFT_PART_INSTALL/usr/share/applications/
-      
+
       dart pub global activate melos
       dart pub global run melos bootstrap
       cd packages/ubuntu_bootstrap

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -234,21 +234,25 @@
   },
   "installationTypeLVMSelected": "LVM selected",
   "@installationTypeLVMSelected": {},
-  "installationTypeLVMEncryptionSelected": "LVM and encryption selected",
-  "@installationTypeLVMEncryptionSelected": {},
-  "installationTypeEncrypt": "Encrypt the new {RELEASE} installation for security",
-  "@installationTypeEncrypt": {
+  "installationTypeLVMEncryption": "Use LVM and encryption with the new {RELEASE} installation",
+  "@installationTypeLVMEncryption": {
     "type": "text",
     "placeholders": {
       "RELEASE": {}
     }
   },
+  "installationTypeLVMEncryptionSelected": "LVM and encryption selected",
+  "@installationTypeLVMEncryptionSelected": {},
   "installationTypeEncryptInfo": "You will choose a security key in the next step.",
   "@installationTypeEncryptInfo": {},
   "installationTypeZFS": "EXPERIMENTAL: Erase disk and use ZFS",
   "@installationTypeZFS": {},
+  "installationTypeZFSEncryption": "EXPERIMENTAL: Erase disk and use ZFS with encryption",
+  "@installationTypeZFSEncryption": {},
   "installationTypeZFSSelected": "ZFS selected",
   "@installationTypeZFSSelected": {},
+  "installationTypeZFSEncryptionSelected": "ZFS and encryption selected",
+  "@installationTypeZFSEncryptionSelected": {},
   "installationTypeTPM": "EXPERIMENTAL: Enable hardware-backed full disk encryption",
   "@installationTypeTPM": {},
   "installationTypeTPMWarning": "<font color=\"{color}\">Warning:</font> This feature is only supported on certain hardware configurations and may not support upgrading to future Ubuntu releases. Please read the <a href=\"{url}\">release notes</a> before enabling.",

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -651,17 +651,17 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'LVM selected'**
   String get installationTypeLVMSelected;
 
+  /// No description provided for @installationTypeLVMEncryption.
+  ///
+  /// In en, this message translates to:
+  /// **'Use LVM and encryption with the new {RELEASE} installation'**
+  String installationTypeLVMEncryption(Object RELEASE);
+
   /// No description provided for @installationTypeLVMEncryptionSelected.
   ///
   /// In en, this message translates to:
   /// **'LVM and encryption selected'**
   String get installationTypeLVMEncryptionSelected;
-
-  /// No description provided for @installationTypeEncrypt.
-  ///
-  /// In en, this message translates to:
-  /// **'Encrypt the new {RELEASE} installation for security'**
-  String installationTypeEncrypt(Object RELEASE);
 
   /// No description provided for @installationTypeEncryptInfo.
   ///
@@ -675,11 +675,23 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'EXPERIMENTAL: Erase disk and use ZFS'**
   String get installationTypeZFS;
 
+  /// No description provided for @installationTypeZFSEncryption.
+  ///
+  /// In en, this message translates to:
+  /// **'EXPERIMENTAL: Erase disk and use ZFS with encryption'**
+  String get installationTypeZFSEncryption;
+
   /// No description provided for @installationTypeZFSSelected.
   ///
   /// In en, this message translates to:
   /// **'ZFS selected'**
   String get installationTypeZFSSelected;
+
+  /// No description provided for @installationTypeZFSEncryptionSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'ZFS and encryption selected'**
+  String get installationTypeZFSEncryptionSelected;
 
   /// No description provided for @installationTypeTPM.
   ///

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'حُدد LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'حُدد LVM مع التشفير';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'حُدد LVM مع التشفير';
 
   @override
   String get installationTypeEncryptInfo => 'ستختار مفتاح أمان في الخطوة التالية.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'تجريبي:أمحُ القرص واستخدم ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'حُدد ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'Seleccionat LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'En el pas següent triareu la clau de seguretat.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Seleccionat ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'Vybráno LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'Vybráno LVM a šifrování';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Zabezpečit novou instalaci $RELEASE šifrováním';
-  }
+  String get installationTypeLVMEncryptionSelected => 'Vybráno LVM a šifrování';
 
   @override
   String get installationTypeEncryptInfo => 'V následujícím kroku si zvolíte šifrovací klíč.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTÁLNÍ: Vymazat disk a použít souborový systém ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Vybráno ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTÁLNÍ: zapnout na hardware založené šifrování celého disku';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM wedi\'i ddewis';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Amgryptio\'r gosodiad $RELEASE newydd ar gyfer diogelwch';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'Byddwch yn dewis allwedd diogelwch yn y cam nesaf.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS wedi\'i ddewis';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM opfanget';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM og kryptering valgt';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Kryptér den nye $RELEASE-installation, for en sikkerheds skyld';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM og kryptering valgt';
 
   @override
   String get installationTypeEncryptInfo => 'Du vil vælge en sikkerhedsnøgle, i næste trin.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EKSPERIMENTEL: Udslet disk og benyt ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS valgt';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EKSPERIMENTEL: Hardware-assisteret fuld diskkrypterings aktivering';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM ausgewählt';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM und Verschlüsselung ausgewählt';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Die neue $RELEASE -Installation zur Sicherheit verschlüsseln';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM und Verschlüsselung ausgewählt';
 
   @override
   String get installationTypeEncryptInfo => 'Im nächsten Schritt wählen Sie einen Sicherheitsschlüssel aus.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTELL: Festplatte löschen und ZFS verwenden';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS ausgewählt';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTELL: Hardwaregestützte vollständige Festplattenverschlüsselung aktivieren';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM elektita';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM kaj ĉifrado elektitaj';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Ĉifri la novan instalaĵon de $RELEASE por sekurigi ĝin';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM kaj ĉifrado elektitaj';
 
   @override
   String get installationTypeEncryptInfo => 'Vi elektos sekurigan ŝlosilon dum la sekva paŝo.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EKSPERIMENTE: Forviŝi la diskon kaj uzi la dosiersistemon ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS elektita';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EKSPERIMENTE: Ŝalti aparato-bazan plendiskan ĉifradon';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM seleccionado';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM y cifrado seleccionado';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Cifrar la nueva instalación de $RELEASE para mayor seguridad';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM y cifrado seleccionado';
 
   @override
   String get installationTypeEncryptInfo => 'Elegirá una clave de seguridad en el siguiente paso.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Borrar disco y usar ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS seleccionado';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Activar el cifrado del disco completo por hardware';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'استفاده از LVM گزیده شد';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'استفاده از LVM و رمزنگاری گزیده شد';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'رمزنگاری نصب $RELEASE جدید برای امنیت';
-  }
+  String get installationTypeLVMEncryptionSelected => 'استفاده از LVM و رمزنگاری گزیده شد';
 
   @override
   String get installationTypeEncryptInfo => 'در گام بعدی، کلید امنیتی‌ای خواهید گزید.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'آزمایشی: پاک کردن دیسک و استفاده از ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'استفاده از ZFS گزیده شد';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM valittu';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM ja salaus valittu';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Salaa uusi $RELEASE-asennus paremman tietoturvan vuoksi';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM ja salaus valittu';
 
   @override
   String get installationTypeEncryptInfo => 'Salausavain valitaan seuraavassa vaiheessa.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'KOKEELLINEN: Tyhjennä levy ja käytä ZFS:ää';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS valittu';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'KOKEELLINEN: Käytä laitteistopohjaista koko levyn salausta';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM sélectionné';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM et chiffrement sélectionnés';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Chiffrer la nouvelle installation d’$RELEASE pour la sécurité';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM et chiffrement sélectionnés';
 
   @override
   String get installationTypeEncryptInfo => 'Vous allez choisir une clé de sécurité à l’étape suivante.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL : Effacer le disque et utiliser ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS sélectionné';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'נבחר מנהל כרכים לוגי';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'נבחרו LVM והצפנה';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'להצפין את התקנת $RELEASE החדשה לשיפור האבטחה';
-  }
+  String get installationTypeLVMEncryptionSelected => 'נבחרו LVM והצפנה';
 
   @override
   String get installationTypeEncryptInfo => 'בשלב הבא ניתן לבחור מפתח אבטחה.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'ניסיוני: למחוק את הכונן ולהשתמש ב־ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'נבחר ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'ניסיוני: להפעיל הצפנת מלוא הכונן בגיבוי חומרה';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM kiválasztva';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM és titkosítás kiválasztva';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Az új $RELEASE telepítés titkosítása a biztonság érdekében';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM és titkosítás kiválasztva';
 
   @override
   String get installationTypeEncryptInfo => 'Biztonsági kulcsot a következő lépésben fog választani.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'KÍSÉRLETI: lemez törlése és ZFS használata';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS kiválasztva';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'KÍSÉRLETI: hardveresen támogatott teljes lemeztitkosítás engedélyezése';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM dipilih';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Enkripsi instalasi $RELEASE baru untuk keamanan';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'Anda akan memilih kunci keamanan di langkah berikutnya.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EKSPERIMENTAL: Hapus disk dan gunakan ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS dipilih';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'Selezionato LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'SPERIMENTALE: Cancella il disco e usa ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Selezionato ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM を選択しました';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVMと暗号化を選択しました';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'セキュリティのためディスクを暗号化し、 $RELEASE をインストールする';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVMと暗号化を選択しました';
 
   @override
   String get installationTypeEncryptInfo => 'セキュリティキーは次のステップで選択します。';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => '試験的： ディスクを消去して ZFS を使用する';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS を選択しました';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM 선택됨';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM및 암호화 선택됨';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return '보안을 위해 새 $RELEASE 설치 암호화';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM및 암호화 선택됨';
 
   @override
   String get installationTypeEncryptInfo => '다음 단계에서 보안 키를 선택합니다.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => '실험적 기능: 디스크 지우고 ZFS 사용';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS 선택됨';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM pasirinkta';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'Pasirinkta LVM ir šifravimas';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Šifruoti naują $RELEASE diegimą, kad būtų užtikrintas saugumas';
-  }
+  String get installationTypeLVMEncryptionSelected => 'Pasirinkta LVM ir šifravimas';
 
   @override
   String get installationTypeEncryptInfo => 'Kitame žingsnyje pasirinksite saugumo raktą.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EKSPERIMENTINIS: Ištrinti diską ir naudoti ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS pasirinkta';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM തിരഞ്ഞെടുത്തു';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'സുരക്ഷയ്ക്കായി പുതിയ $RELEASE ഇൻസ്റ്റാളേഷൻ എൻക്രിപ്റ്റ് ചെയ്യുക';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'അടുത്ത ഘട്ടത്തിൽ നിങ്ങൾ ഒരു സുരക്ഷാ കീ തിരഞ്ഞെടുക്കും.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'പരീക്ഷണാത്മകം: ഡിസ്ക് മായ്ച്ച് ZFS ഉപയോഗിക്കുക';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS തിരഞ്ഞെടുത്തു';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM valg';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM og kryptering valgt';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Kryptere nye $RELEASE installasjon for sikkerhet';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM og kryptering valgt';
 
   @override
   String get installationTypeEncryptInfo => 'Du velger en sikkerhetsnøkkel i neste trinn.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EKSPERIMENTELL: Slett disk og bruk ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS valgt';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM seleccionat';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM e chiframent seleccionats';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Chifrar l’installacion de $RELEASE novèla per la seguretat';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM e chiframent seleccionats';
 
   @override
   String get installationTypeEncryptInfo => 'Causiretz una clau de seguretat a l’etapa seguenta.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL : escafar lo disc e utilizar ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS seleccionat';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL : activar lo chiframent material del disc complèt';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'Wybrano LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'Wybrano LVM i szyfrowanie';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Zaszyfruj nową instalację $RELEASE dla bezpieczeństwa';
-  }
+  String get installationTypeLVMEncryptionSelected => 'Wybrano LVM i szyfrowanie';
 
   @override
   String get installationTypeEncryptInfo => 'Klucz bezpieczeństwa zostanie wybrany w następnym kroku.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EKSPERYMENTALNE: wymaż dysk i użyj ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Wybrano ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EKSPERYMENTALNE: włącz sprzętowe szyfrowanie całego dysku';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selecionado';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM e encriptação selecionado';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Criptografar a nova instalação do $RELEASE para maior segurança';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM e encriptação selecionado';
 
   @override
   String get installationTypeEncryptInfo => 'Deverá escolher uma chave de segurança no passo seguinte.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Apagar o disco e usar ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selecionado';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Ativar a criptografia completa de disco com suporte de hardware';
@@ -1075,11 +1081,6 @@ class UbuntuBootstrapLocalizationsPtBr extends UbuntuBootstrapLocalizationsPt {
 
   @override
   String get installationTypeLVMEncryptionSelected => 'LVM e criptografia selecionados';
-
-  @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Criptografar a nova instalação do $RELEASE para maior segurança';
-  }
 
   @override
   String get installationTypeEncryptInfo => 'Você deverá escolher uma chave de segurança no próximo passo.';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'Выбран LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM и шифрование выбраны';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Зашифровать новую установку $RELEASE для безопасности';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM и шифрование выбраны';
 
   @override
   String get installationTypeEncryptInfo => 'На следующем шаге выберите ключ безопасности.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'ЭКСПЕРИМЕНТАЛЬНОЕ: Стереть диск и использовать ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Выбрана ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'ЭКСПЕРИМЕНТАЛЬНО: Включить аппаратное шифрование диска';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM තෝරා ඇත';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM හා සංකේතනය තෝරා ඇත';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'ආරක්‍ෂාව උදෙසා නව $RELEASE ස්ථාපනය සංකේතනය කරන්න';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM හා සංකේතනය තෝරා ඇත';
 
   @override
   String get installationTypeEncryptInfo => 'ඔබ ඊළඟ පියවරේදී ආරක්‍ෂණ යතුරක් තෝරා ගනු ඇත.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'පරීක්‍ෂාත්මක: තැටිය මකාදමා ZFS භාවිතා කරන්න';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS තෝරා ඇත';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'Vybrané LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'Vybrané LVM a šifrovanie';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Zabezpečiť novú inštaláciu $RELEASE šifrovaním';
-  }
+  String get installationTypeLVMEncryptionSelected => 'Vybrané LVM a šifrovanie';
 
   @override
   String get installationTypeEncryptInfo => 'V nasledujúcom kroku si zvolíte bezpečnostný kľúč.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTÁLNE: Vymazať disk a použiť súborový systém ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Vybrané ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTÁLNE: Povolenie hardvérového šifrovania celého disku';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM e selektuare';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LMV dhe kodimi i selektuare';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LMV dhe kodimi i selektuare';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZfS e selektuare';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM valt';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM och kryptering vald';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Kryptera den nya $RELEASE-installationen för säkerhet';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM och kryptering vald';
 
   @override
   String get installationTypeEncryptInfo => 'Du väljer en säkerhetsnyckel i nästa steg.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTELLT: Radera disk och använd ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS valt';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTELLT: Aktivera hårdvarustöd fullständig diskkryptering';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM seçildi';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM ve şifreleme seçildi';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Güvenlik için yeni $RELEASE kurulumunu şifrele';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM ve şifreleme seçildi';
 
   @override
   String get installationTypeEncryptInfo => 'Bir sonraki adımda güvenlik anahtarı seçeceksiniz.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'DENEYSEL: Diski sil ve ZFS kullan';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS seçildi';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'DENEYSEL: Donanım destekli tam disk şifrelemeyi etkinleştir';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM обрано';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM та шифрування обрано';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Зашифрувати нову установку $RELEASE для безпеки';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM та шифрування обрано';
 
   @override
   String get installationTypeEncryptInfo => 'Ключ захисту можна буде вибрати на наступному кроці.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'ЕКСПЕРИМЕНТАЛЬНО: Витерти диск і скористатися ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'Обрано ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'ЕКСПЕРИМЕНТАЛЬНО: Увімкнути апаратне шифрування диска';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => 'LVM selected';
 
   @override
-  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return 'Encrypt the new $RELEASE installation for security';
-  }
+  String get installationTypeLVMEncryptionSelected => 'LVM and encryption selected';
 
   @override
   String get installationTypeEncryptInfo => 'You will choose a security key in the next step.';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => 'EXPERIMENTAL: Erase disk and use ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => 'ZFS selected';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -250,12 +250,12 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get installationTypeLVMSelected => '已选择配置 LVM';
 
   @override
-  String get installationTypeLVMEncryptionSelected => '已选择配置加密的 LVM';
+  String installationTypeLVMEncryption(Object RELEASE) {
+    return 'Use LVM and encryption with the new $RELEASE installation';
+  }
 
   @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return '为安全起见，对新的 $RELEASE 安装进行加密';
-  }
+  String get installationTypeLVMEncryptionSelected => '已选择配置加密的 LVM';
 
   @override
   String get installationTypeEncryptInfo => '您将在下一步中选择一个安全密钥。';
@@ -264,7 +264,13 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get installationTypeZFS => '实验性功能：擦除磁盘并使用ZFS';
 
   @override
+  String get installationTypeZFSEncryption => 'EXPERIMENTAL: Erase disk and use ZFS with encryption';
+
+  @override
   String get installationTypeZFSSelected => '已选择 ZFS';
+
+  @override
+  String get installationTypeZFSEncryptionSelected => 'ZFS and encryption selected';
 
   @override
   String get installationTypeTPM => 'EXPERIMENTAL: Enable hardware-backed full disk encryption';
@@ -1075,11 +1081,6 @@ class UbuntuBootstrapLocalizationsZhTw extends UbuntuBootstrapLocalizationsZh {
 
   @override
   String get installationTypeLVMEncryptionSelected => '已選用 LVM 及加密';
-
-  @override
-  String installationTypeEncrypt(Object RELEASE) {
-    return '加密新安裝的 $RELEASE 以確保資訊安全';
-  }
 
   @override
   String get installationTypeEncryptInfo => '在下一步中您需要輸入安全密鑰。';

--- a/packages/ubuntu_bootstrap/lib/pages/storage/security_key/security_key_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/security_key/security_key_model.dart
@@ -44,7 +44,8 @@ class SecurityKeyModel extends SafeChangeNotifier {
 
   /// Initializes the model.
   Future<bool> init() async {
-    if (_service.guidedCapability != GuidedCapability.LVM_LUKS) {
+    if (_service.guidedCapability != GuidedCapability.LVM_LUKS &&
+        _service.guidedCapability != GuidedCapability.ZFS_LUKS_KEYSTORE) {
       return false;
     }
     await loadSecurityKey();

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -91,8 +91,10 @@ class StorageModel extends SafeChangeNotifier {
       .any((c) => c == GuidedCapability.LVM || c == GuidedCapability.LVM_LUKS));
 
   /// Whether ZFS guided storage targets are available.
-  bool get hasZfs => _getTargets<GuidedStorageTargetReformat>()
-      .any((t) => t.allowed.contains(GuidedCapability.ZFS));
+  bool get hasZfs =>
+      _getTargets<GuidedStorageTargetReformat>().any((t) => t.allowed.any((c) =>
+          c == GuidedCapability.ZFS ||
+          c == GuidedCapability.ZFS_LUKS_KEYSTORE));
 
   /// Whether TPM is detected.
   bool get hasTpm =>

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -152,6 +152,8 @@ extension _GuidedCapabilityL10n on GuidedCapability {
         return lang.installationTypeLVMEncryptionSelected;
       case GuidedCapability.ZFS:
         return lang.installationTypeZFSSelected;
+      case GuidedCapability.ZFS_LUKS_KEYSTORE:
+        return lang.installationTypeZFSEncryptionSelected;
       case GuidedCapability.CORE_BOOT_ENCRYPTED:
       case GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED:
         return lang.installationTypeTPMSelected;

--- a/packages/ubuntu_bootstrap/test/storage/storage_dialogs_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_dialogs_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
-import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_dialogs.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_page.dart';
@@ -33,7 +32,7 @@ void main() {
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.radio(AdvancedFeature.zfs));
+    await tester.tap(find.radio(GuidedCapability.ZFS));
     await tester.pump();
 
     await tester.tapOk();
@@ -50,7 +49,7 @@ void main() {
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.radio(AdvancedFeature.lvm));
+    await tester.tap(find.radio(GuidedCapability.LVM));
     await tester.pump();
 
     await tester.tapOk();
@@ -63,17 +62,11 @@ void main() {
     final model = buildStorageModel();
     await tester.pumpWidget(buildPage(tester, model));
 
-    final context = tester.element(find.byType(StoragePage));
-    final l10n = UbuntuBootstrapLocalizations.of(context);
-
     final result = showAdvancedFeaturesDialog(
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.radio(AdvancedFeature.lvm));
-    await tester.pump();
-
-    await tester.tap(find.checkButton(l10n.installationTypeEncrypt('Ubuntu')));
+    await tester.tap(find.radio(GuidedCapability.LVM_LUKS));
     await tester.pump();
 
     await tester.tapOk();
@@ -97,12 +90,14 @@ void main() {
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    expect(find.radio(AdvancedFeature.none), findsNothing);
-    expect(find.radio(AdvancedFeature.lvm), findsNothing);
-    expect(find.radio(AdvancedFeature.zfs), findsNothing);
-    expect(find.radio(AdvancedFeature.tpm), findsOneWidget);
+    expect(find.radio(GuidedCapability.DIRECT), findsNothing);
+    expect(find.radio(GuidedCapability.LVM), findsNothing);
+    expect(find.radio(GuidedCapability.LVM_LUKS), findsNothing);
+    expect(find.radio(GuidedCapability.ZFS), findsNothing);
+    expect(find.radio(GuidedCapability.ZFS_LUKS_KEYSTORE), findsNothing);
+    expect(find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED), findsOneWidget);
 
-    final finder = find.radio(AdvancedFeature.tpm);
+    final finder = find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED);
     await tester.tap(finder);
     await tester.pump();
     await tester.tapOk();
@@ -123,7 +118,7 @@ void main() {
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    final finder = find.radio(AdvancedFeature.tpm);
+    final finder = find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED);
     expect(finder, findsOneWidget);
     expect(finder, isDisabled);
 
@@ -145,7 +140,7 @@ void main() {
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    final finder = find.radio(AdvancedFeature.tpm);
+    final finder = find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED);
     expect(finder, findsOneWidget);
     expect(finder, isDisabled);
 
@@ -167,7 +162,7 @@ void main() {
         tester.element(find.byType(StoragePage)), model);
     await tester.pumpAndSettle();
 
-    final finder = find.radio(AdvancedFeature.tpm);
+    final finder = find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED);
     expect(finder, findsOneWidget);
     expect(finder, isDisabled);
 

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -172,13 +172,13 @@ extension UbuntuBootstrapPageTester on WidgetTester {
           await tap(find.text(l10n.installationTypeLVM('Ubuntu')));
           break;
         case GuidedCapability.LVM_LUKS:
-          await tap(find.text(l10n.installationTypeLVM('Ubuntu')));
-          await pump();
-          await tap(find.text(l10n.installationTypeEncrypt('Ubuntu')));
+          await tap(find.text(l10n.installationTypeLVMEncryption('Ubuntu')));
           break;
         case GuidedCapability.ZFS:
           await tap(find.text(l10n.installationTypeZFS));
-          await pump();
+          break;
+        case GuidedCapability.ZFS_LUKS_KEYSTORE:
+          await tap(find.text(l10n.installationTypeZFSEncryption));
           break;
         default:
           break;

--- a/scripts/update-subiquity-deps
+++ b/scripts/update-subiquity-deps
@@ -7,7 +7,7 @@ yaml.default_flow_style = False
 yaml.pure = True
 yaml.indent(mapping=2, sequence=2, offset=2)
 
-with open('snap/snapcraft.yaml', 'r') as fp:
+with open('ci/snap/bootstrap/snapcraft.yaml', 'r') as fp:
     udi_data = yaml.load(fp)
 
 with open('packages/subiquity_client/subiquity/snapcraft.yaml', 'r') as fp:
@@ -17,5 +17,5 @@ for part in ('probert', 'curtin'):
     udi_data['parts'][part]['source-commit'] = \
         subiquity_data['parts'][part]['source-commit']
 
-with open('snap/snapcraft.yaml', 'w') as fp:
+with open('ci/snap/bootstrap/snapcraft.yaml', 'w') as fp:
     yaml.dump(udi_data, fp)


### PR DESCRIPTION
In order to avoid confusion, the list of available options has been flattened, removing the separate checkbox for encryption:

|Before|After|
|-|-|
|![Screenshot from 2024-03-01 17-59-21](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/fade75f4-e619-4194-81b5-4665c8dfe9a6)|![Screenshot from 2024-03-01 17-58-53](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/d6f8713d-6065-468b-9cf7-d8193f0b4d07)|

Will include @anasereijo's UI improvements next week.