### PR TITLE
fix(keyboard_page_test): scroll to item before tapping it

### DIFF
--- a/packages/ubuntu_provision/test/keyboard/keyboard_page_test.dart
+++ b/packages/ubuntu_provision/test/keyboard/keyboard_page_test.dart
@@ -42,6 +42,12 @@ void main() {
     for (var i = 0; i < 3; ++i) {
       final layoutTile = find.listTile('Layout $i');
       expect(layoutTile, findsOneWidget);
+      await tester.scrollUntilVisible(
+        layoutTile,
+        -kMinInteractiveDimension / 2,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pump();
       await tester.tap(layoutTile);
       verify(model.selectLayout(i)).called(1);
     }


### PR DESCRIPTION
@spydon the keyboard page still looks fine to me on small layouts, although a bit more scrolling is required. Feel free to propose a better solution tomorrow, if you have one :)