### PR TITLE
chore(provd): bump go toolchain to 1.22.1

### DIFF
--- a/provd/go.mod
+++ b/provd/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/ubuntu-desktop-provision/provd
 
 go 1.21.0
 
-toolchain go1.21.6
+toolchain go1.22.1
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf


### PR DESCRIPTION
Bump the go tool-chain to 1.22.1 to get past security vulns

This also gives me some neat fixes I want to use in my tests :slightly_smiling_face: 