### PR TITLE
feat(snap): update provd socket paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,13 @@ jobs:
           set -ux
           set +e
           mv provd/example.config.yaml provd/provd.yaml
-          sudo mkdir -p /run/provd
-          sudo chown $USER /run/provd
+          sudo mkdir -p /run/gnome-initial-setup/desktop-provision
+          sudo chown $USER /run/gnome-initial-setup/desktop-provision
           sudo provd/provd &
-          until [ -S /run/provd/provd.sock ]; do
+          until [ -S /run/gnome-initial-setup/desktop-provision/init.socket ]; do
             sleep 1
           done
-          sudo chmod go+rw /run/provd/provd.sock
+          sudo chmod go+rw /run/gnome-initial-setup/desktop-provision/init.socket
 
       - run: xvfb-run -a -s '-screen 0 1024x768x24 +extension GLX' flutter test integration_test/e2e_test.dart
         working-directory: packages/ubuntu_init

--- a/ci/snap/init/snapcraft.yaml
+++ b/ci/snap/init/snapcraft.yaml
@@ -93,9 +93,9 @@ plugs:
   run-provd-socket:
     interface: system-files
     read:
-      - /run/provd/provd.sock
+      - /run/gnome-initial-setup/desktop-provision/init.socket
     write:
-      - /run/provd/provd.sock
+      - /run/gnome-initial-setup/desktop-provision/init.socket
   tmp:
     interface: system-files
     read:

--- a/packages/ubuntu_init/lib/src/services/provd_address.dart
+++ b/packages/ubuntu_init/lib/src/services/provd_address.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 mixin ProvdAddress {
   static final socketAddress = InternetAddress(
-    '/run/provd/provd.sock',
+    '/run/gnome-initial-setup/desktop-provision/init.socket',
     type: InternetAddressType.unix,
   );
   static const port = 443;

--- a/provd/example.config.yaml
+++ b/provd/example.config.yaml
@@ -1,2 +1,2 @@
 Paths:
-  Socket: "/run/provd/provd.sock"
+  Socket: "/run/gnome-initial-setup/desktop-provision/init.socket"

--- a/provd/internal/consts/consts.go
+++ b/provd/internal/consts/consts.go
@@ -16,7 +16,7 @@ const (
 	DefaultLogLevel = slog.LevelWarn
 
 	// DefaultSocketPath is the default socket path.
-	DefaultSocketPath = "/run/provd.sock"
+	DefaultSocketPath = "/run/gnome-initial-setup/desktop-provision/init.socket"
 )
 
 // D-Bus constants.


### PR DESCRIPTION
This aligns the snap with the socket path that will be used for the init backend moving forward
I had to move it into `/run/gnome-initial-setup` as the gis user has ownership only over that `/run` subdirectory