### PR TITLE
feat(bootstrap): skip user creation and timezone for OEM

### DIFF
--- a/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -106,6 +106,60 @@ void main() {
     );
   });
 
+  testWidgets('OEM', (tester) async {
+    registerMockService<ConfigService>(
+      FakeConfigService(mode: ProvisioningMode.oem),
+    );
+
+    await tester.runApp(() => app.main(<String>[]));
+    await tester.pumpAndSettle();
+
+    await tester.testLocalePage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testAccessibilityPage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testKeyboardPage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testNetworkPage(mode: ConnectMode.none);
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testRefreshPage();
+    await tester.tapSkip();
+    await tester.pumpAndSettle();
+
+    await tester.testSourceSelectionPage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testCodecsAndDriversPage();
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testStoragePage(type: StorageType.erase);
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+
+    await tester.testConfirmPage();
+    await tester.tapConfirm();
+    await tester.pumpAndSettle();
+
+    await tester.testInstallPage();
+    await tester.pumpAndSettle();
+
+    final windowClosed = YaruTestWindow.waitForClosed();
+    await tester.tapContinueTesting();
+    await expectLater(windowClosed, completes);
+
+    await verifySubiquityConfig(identity: const Identity());
+  });
+
   testWidgets('LVM Encrypted', (tester) async {
     const identity = Identity(
       realname: 'User',
@@ -662,7 +716,10 @@ Future<void> verifySubiquityConfig({
 
   final yaml = loadYaml(File(path).readAsStringSync());
 
-  if (identity != null) {
+  if (identity == const Identity()) {
+    // OEM case: no idendity should be configured
+    expect(yaml['autoinstall']['identity'], isNull);
+  } else if (identity != null) {
     final actualIdentity = yaml['autoinstall']['identity'];
     expect(actualIdentity['hostname'], equals(identity.hostname));
     expect(actualIdentity['realname'], equals(identity.realname));
@@ -756,4 +813,12 @@ class FakeDesktopService implements DesktopService {
 
   @override
   Future<void> close() async {}
+}
+
+class FakeConfigService extends ConfigService {
+  FakeConfigService({this.mode = ProvisioningMode.standard});
+  final ProvisioningMode mode;
+
+  @override
+  Future<ProvisioningMode> get provisioningMode async => mode;
 }

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -46,6 +46,8 @@ class InstallerService {
     _excludedPages = pageConfig.excludedPages.toSet();
     if (pageConfig.isOem) {
       _excludedPages.add('identity');
+      _excludedPages.add('timezone');
+      await _client.markConfigured(['identity', 'timezone']);
     }
 
     final excludedRequiredPages = _excludedPages.intersection(requiredPages);

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.dart
@@ -33,7 +33,6 @@ class PageConfigService {
     pages.addAll(pageConfig.pages);
 
     if (isOem) {
-      pages['identity'] = const PageConfigEntry(visible: false);
       pages['eula'] = const PageConfigEntry();
     }
 


### PR DESCRIPTION
See https://github.com/canonical/subiquity/pull/1928

Close #376
UDENG-2226