### PR TITLE
fix: Rename `PreviousWizardButton` to `BackWizardButton`

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -109,7 +109,7 @@ class ConfirmPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             highlighted: true,

--- a/packages/ubuntu_bootstrap/lib/pages/loading/loading_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/loading/loading_page.dart
@@ -41,7 +41,7 @@ class _LoadingPageState extends ConsumerState<LoadingPage> {
         ],
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(enabled: false),
+        leading: BackWizardButton(enabled: false),
         trailing: [NextWizardButton(enabled: false)],
       ),
     );

--- a/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
@@ -85,8 +85,8 @@ class RefreshBar extends StatelessWidget {
 
     return WizardBar(
       leading: state.whenOrNull(
-        checking: PreviousWizardButton.new,
-        status: (_) => const PreviousWizardButton(),
+        checking: BackWizardButton.new,
+        status: (_) => const BackWizardButton(),
       ),
       trailing: state.whenOrNull(
         checking: () => [skip],

--- a/packages/ubuntu_bootstrap/lib/pages/rst/rst_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/rst/rst_page.dart
@@ -65,7 +65,7 @@ class RstPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
       ),
     );
   }

--- a/packages/ubuntu_bootstrap/lib/pages/secure_boot/secure_boot_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/secure_boot/secure_boot_page.dart
@@ -61,7 +61,7 @@ class _SecureBootPageState extends ConsumerState<SecureBootPage> {
         },
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(enabled: model.isFormValid),
         ],

--- a/packages/ubuntu_bootstrap/lib/pages/source/not_enough_disk_space/not_enough_disk_space_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/source/not_enough_disk_space/not_enough_disk_space_page.dart
@@ -90,7 +90,7 @@ class NotEnoughDiskSpacePage extends ConsumerWidget with ProvisioningPage {
           ),
         ),
         bottomBar: const WizardBar(
-          leading: PreviousWizardButton(),
+          leading: BackWizardButton(),
         ),
       ),
     );

--- a/packages/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
@@ -88,7 +88,7 @@ class BitLockerPage extends ConsumerWidget {
         ),
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
       ),
     );
   }

--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
@@ -96,7 +96,7 @@ class GuidedReformatPage extends ConsumerWidget {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             onNext: model.saveGuidedStorage,

--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
@@ -81,7 +81,7 @@ class GuidedResizePage extends ConsumerWidget {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             onNext: model.selectedStorage != null ? model.save : null,

--- a/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
@@ -90,7 +90,7 @@ class _ManualStoragePageState extends ConsumerState<ManualStoragePage> {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             enabled: model.isValid,

--- a/packages/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
@@ -39,7 +39,7 @@ class PassphrasePage extends ConsumerWidget {
         ].withSpacing(kWizardSpacing),
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             enabled: ref.watch(

--- a/packages/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_page.dart
@@ -53,7 +53,7 @@ class RecoveryKeyPage extends StatelessWidget {
         ],
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
         trailing: [
           NextWizardButton(),
         ],

--- a/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_page.dart
@@ -58,7 +58,7 @@ class TryOrInstallPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           WizardButton(
             label: UbuntuLocalizations.of(context).nextLabel,

--- a/packages/ubuntu_bootstrap/test/refresh/refresh_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/refresh/refresh_page_test.dart
@@ -31,7 +31,7 @@ void main() {
     expect(progress.value, isNull); // indeterminate
 
     expect(
-      find.button(find.ul10n((l10n) => l10n.previousLabel)),
+      find.button(find.ul10n((l10n) => l10n.backLabel)),
       findsOneWidget,
     );
     expect(
@@ -59,7 +59,7 @@ void main() {
     );
 
     expect(
-      find.button(find.ul10n((l10n) => l10n.previousLabel)),
+      find.button(find.ul10n((l10n) => l10n.backLabel)),
       findsOneWidget,
     );
     expect(
@@ -87,7 +87,7 @@ void main() {
     );
 
     expect(
-      find.button(find.ul10n((l10n) => l10n.previousLabel)),
+      find.button(find.ul10n((l10n) => l10n.backLabel)),
       findsOneWidget,
     );
     expect(

--- a/packages/ubuntu_bootstrap/test/source/not_enough_disk_space_test.dart
+++ b/packages/ubuntu_bootstrap/test/source/not_enough_disk_space_test.dart
@@ -138,7 +138,7 @@ extension on WidgetTester {
                   '/last': WizardRoute(
                     builder: (context) => const WizardPage(
                       content: Text('last route'),
-                      bottomBar: WizardBar(leading: PreviousWizardButton()),
+                      bottomBar: WizardBar(leading: BackWizardButton()),
                     ),
                   ),
                 },

--- a/packages/ubuntu_bootstrap/test/source/not_enough_disk_space_test.dart
+++ b/packages/ubuntu_bootstrap/test/source/not_enough_disk_space_test.dart
@@ -34,13 +34,13 @@ void main() {
     expect(find.text('last route'), findsOneWidget);
 
     // last -> source
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
 
     expect(find.byType(SourceSelectionPage), findsOneWidget);
 
     // source -> first
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
 
     expect(find.text('first route'), findsOneWidget);
@@ -65,13 +65,13 @@ void main() {
     expect(find.text('last route'), findsNothing);
 
     // not enough disk space -> source
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
 
     expect(find.byType(SourceSelectionPage), findsOneWidget);
 
     // source -> first
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
 
     expect(find.text('first route'), findsOneWidget);

--- a/packages/ubuntu_init/lib/src/privacy/privacy_page.dart
+++ b/packages/ubuntu_init/lib/src/privacy/privacy_page.dart
@@ -62,7 +62,7 @@ class PrivacyPage extends ConsumerWidget with ProvisioningPage {
         ),
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
         trailing: [
           NextWizardButton(),
         ],

--- a/packages/ubuntu_init/lib/src/telemetry/telemetry_page.dart
+++ b/packages/ubuntu_init/lib/src/telemetry/telemetry_page.dart
@@ -91,7 +91,7 @@ class TelemetryPage extends ConsumerWidget with ProvisioningPage {
         ),
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(onNext: model.save),
         ],

--- a/packages/ubuntu_init/lib/src/ubuntu_pro/ubuntu_pro_page.dart
+++ b/packages/ubuntu_init/lib/src/ubuntu_pro/ubuntu_pro_page.dart
@@ -19,7 +19,7 @@ class UbuntuProPage extends ConsumerWidget with ProvisioningPage {
         child: Text('Ubuntu Pro'),
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
         trailing: [
           NextWizardButton(),
         ],

--- a/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
+++ b/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
@@ -113,7 +113,7 @@ class AccessibilityPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
         trailing: [NextWizardButton()],
       ),
     );

--- a/packages/ubuntu_provision/lib/src/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_provision/lib/src/active_directory/active_directory_page.dart
@@ -52,7 +52,7 @@ class _ActiveDirectoryPageState extends ConsumerState<ActiveDirectoryPage> {
         );
       }),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             enabled: ref

--- a/packages/ubuntu_provision/lib/src/identity/identity_page.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_page.dart
@@ -38,7 +38,7 @@ class IdentityPage extends ConsumerWidget with ProvisioningPage {
         ].withSpacing(kWizardSpacing),
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             enabled: ref.watch(identityModelProvider.select((m) => m.isValid)),

--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -73,7 +73,7 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           WizardButton(
             label: UbuntuLocalizations.of(context).connectLabel,

--- a/packages/ubuntu_provision/lib/src/timezone/timezone_page.dart
+++ b/packages/ubuntu_provision/lib/src/timezone/timezone_page.dart
@@ -113,7 +113,7 @@ class TimezonePage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const PreviousWizardButton(),
+        leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(onNext: ref.read(timezoneModelProvider).save),
         ],

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -149,7 +149,7 @@ class HorizontalPage extends ConsumerWidget {
       snackBar: snackBar,
       bottomBar: bottomBar ??
           WizardBar(
-            leading: const PreviousWizardButton(),
+            leading: const BackWizardButton(),
             trailing: [
               NextWizardButton(
                 onNext: onNext,

--- a/packages/ubuntu_wizard/lib/src/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_button.dart
@@ -17,7 +17,7 @@ final _noAnimation = Listenable.merge([]);
 ///
 /// See also:
 ///  * [NextWizardButton]
-///  * [PreviousWizardButton]
+///  * [BackWizardButton]
 class WizardButton extends StatefulWidget {
   /// Creates a wizard button.
   const WizardButton({
@@ -163,9 +163,9 @@ class _WizardButtonState extends State<WizardButton> {
   }
 }
 
-/// A _Previous_ button that returns back to the previous page.
-class PreviousWizardButton extends StatelessWidget {
-  const PreviousWizardButton({
+/// A _Back button that returns back to the previous page.
+class BackWizardButton extends StatelessWidget {
+  const BackWizardButton({
     super.key,
     this.visible = true,
     this.enabled,
@@ -192,7 +192,7 @@ class PreviousWizardButton extends StatelessWidget {
     return AnimatedBuilder(
       animation: wizard?.controller ?? _noAnimation,
       builder: (context, child) => WizardButton(
-          label: UbuntuLocalizations.of(context).previousLabel,
+          label: UbuntuLocalizations.of(context).backLabel,
           visible: visible,
           flat: true,
           enabled: !isLoading && (enabled ?? hasPrevious),

--- a/packages/ubuntu_wizard/test/nested_wizard_test.dart
+++ b/packages/ubuntu_wizard/test/nested_wizard_test.dart
@@ -62,19 +62,19 @@ void main() {
     await tester.pumpAndSettle();
     expect(page3, findsOneWidget);
 
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
     expect(page2c, findsOneWidget);
 
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
     expect(page2b, findsOneWidget);
 
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
     expect(page2a, findsOneWidget);
 
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
     expect(page1, findsOneWidget);
   });
@@ -124,11 +124,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(page3, findsOneWidget);
 
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
     expect(page2a, findsOneWidget);
 
-    await tester.tapPrevious();
+    await tester.tapBack();
     await tester.pumpAndSettle();
     expect(page1, findsOneWidget);
   });

--- a/packages/ubuntu_wizard/test/nested_wizard_test.dart
+++ b/packages/ubuntu_wizard/test/nested_wizard_test.dart
@@ -9,7 +9,7 @@ void main() {
     return WizardPage(
       content: Text(title),
       bottomBar: const WizardBar(
-        leading: PreviousWizardButton(),
+        leading: BackWizardButton(),
         trailing: [NextWizardButton()],
       ),
     );

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -180,7 +180,7 @@ void main() {
     expect(
       find.descendant(
         of: find.bySubtype<OutlinedButton>(),
-        matching: find.text(lang.previousLabel),
+        matching: find.text(lang.backLabel),
       ),
       findsOneWidget,
     );
@@ -208,7 +208,7 @@ void main() {
     expect(
       find.descendant(
         of: find.bySubtype<OutlinedButton>(),
-        matching: find.text(lang.previousLabel),
+        matching: find.text(lang.backLabel),
       ),
       findsOneWidget,
     );
@@ -305,7 +305,7 @@ void main() {
 
     await tester.tap(find.descendant(
       of: find.bySubtype<OutlinedButton>(),
-      matching: find.text(lang.previousLabel),
+      matching: find.text(lang.backLabel),
     ));
     await tester.pumpAndSettle();
 
@@ -321,7 +321,7 @@ void main() {
 
     await tester.tap(find.descendant(
       of: find.bySubtype<OutlinedButton>(),
-      matching: find.text(lang.previousLabel),
+      matching: find.text(lang.backLabel),
     ));
     await tester.pumpAndSettle();
 

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -150,7 +150,7 @@ void main() {
             return Builder(builder: (context) {
               return const WizardPage(
                 bottomBar: WizardBar(
-                  leading: PreviousWizardButton(),
+                  leading: BackWizardButton(),
                   trailing: [
                     NextWizardButton(),
                   ],
@@ -162,7 +162,7 @@ void main() {
             return Builder(builder: (context) {
               return const WizardPage(
                 bottomBar: WizardBar(
-                  leading: PreviousWizardButton(),
+                  leading: BackWizardButton(),
                   trailing: [
                     NextWizardButton(),
                   ],
@@ -242,7 +242,7 @@ void main() {
               return const WizardPage(
                 content: Text('first'),
                 bottomBar: WizardBar(
-                  leading: PreviousWizardButton(),
+                  leading: BackWizardButton(),
                   trailing: [NextWizardButton()],
                 ),
               );
@@ -254,8 +254,7 @@ void main() {
                 return WizardPage(
                   content: const Text('second'),
                   bottomBar: WizardBar(
-                    leading:
-                        PreviousWizardButton(onBack: () => wentBack = true),
+                    leading: BackWizardButton(onBack: () => wentBack = true),
                     trailing: const [NextWizardButton()],
                   ),
                 );
@@ -269,8 +268,7 @@ void main() {
                 return WizardPage(
                   content: const Text('last'),
                   bottomBar: WizardBar(
-                    leading:
-                        PreviousWizardButton(onBack: () => wentBack = true),
+                    leading: BackWizardButton(onBack: () => wentBack = true),
                     trailing: const [NextWizardButton()],
                   ),
                 );
@@ -283,7 +281,7 @@ void main() {
               return Builder(builder: (context) {
                 return const WizardPage(
                   bottomBar: WizardBar(
-                    leading: PreviousWizardButton(),
+                    leading: BackWizardButton(),
                     trailing: [NextWizardButton()],
                   ),
                 );


### PR DESCRIPTION
And the label is now "Back" instead of "Previous".