### PR TITLE
ci(melos): don't run pub get in parallel

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -5,6 +5,7 @@ packages:
 
 command:
   bootstrap:
+    runPubGetInParallel: false
     environment:
       sdk: ">=3.0.0 <4.0.0"
       flutter: '>=3.19.2'


### PR DESCRIPTION
An attempt to resolve the recent dependency issues that are causing [test failures](https://github.com/canonical/ubuntu-desktop-provision/actions/runs/8295061463/job/22701953088)