### PR TITLE
feat(bootstrap): show 'close' button when selecting 'try'

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_model.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_model.dart
@@ -15,12 +15,6 @@ final tryOrInstallModelProvider = ChangeNotifierProvider(
 
 /// The available options on the Try or Install page.
 enum TryOrInstallOption {
-  /// No option is selected.
-  none,
-
-  /// The user wants to repair Ubuntu.
-  repairUbuntu,
-
   /// The user wants to try Ubuntu.
   tryUbuntu,
 
@@ -48,7 +42,7 @@ class TryOrInstallModel extends SafeChangeNotifier with PropertyStreamNotifier {
 
   /// The currently selected option.
   TryOrInstallOption get option => _option;
-  TryOrInstallOption _option = TryOrInstallOption.none;
+  TryOrInstallOption _option = TryOrInstallOption.installUbuntu;
 
   /// Selects the given [option].
   void selectOption(TryOrInstallOption option) {

--- a/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/try_or_install/try_or_install_page.dart
@@ -61,15 +61,18 @@ class TryOrInstallPage extends ConsumerWidget with ProvisioningPage {
         leading: const BackWizardButton(),
         trailing: [
           WizardButton(
-            label: UbuntuLocalizations.of(context).nextLabel,
-            visible: model.option == TryOrInstallOption.tryUbuntu,
-            execute: YaruWindow.of(context).close,
-          ),
-          NextWizardButton(
-            visible: model.option != TryOrInstallOption.tryUbuntu,
-            enabled: model.option != TryOrInstallOption.none,
-            arguments: model.option,
-          ),
+            label: switch (model.option) {
+              TryOrInstallOption.installUbuntu =>
+                UbuntuLocalizations.of(context).nextLabel,
+              TryOrInstallOption.tryUbuntu =>
+                UbuntuLocalizations.of(context).closeLabel,
+            },
+            execute: switch (model.option) {
+              TryOrInstallOption.installUbuntu => Wizard.of(context).next,
+              TryOrInstallOption.tryUbuntu => YaruWindow.of(context).close,
+            },
+            highlighted: model.option == TryOrInstallOption.tryUbuntu,
+          )
         ],
       ),
     );

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -120,7 +120,7 @@ void main() {
 
     final windowClosed = YaruTestWindow.waitForClosed();
 
-    await tester.tapNext();
+    await tester.tapClose();
     await tester.pumpAndSettle();
 
     await expectLater(windowClosed, completes);

--- a/packages/ubuntu_bootstrap/test/try_or_install/test_try_or_install.dart
+++ b/packages/ubuntu_bootstrap/test/try_or_install/test_try_or_install.dart
@@ -17,7 +17,7 @@ TryOrInstallModel buildTryOrInstallModel(
     {bool? isConnected, TryOrInstallOption? option}) {
   final model = MockTryOrInstallModel();
   when(model.isConnected).thenReturn(isConnected ?? false);
-  when(model.option).thenReturn(option ?? TryOrInstallOption.none);
+  when(model.option).thenReturn(option ?? TryOrInstallOption.installUbuntu);
   return model;
 }
 

--- a/packages/ubuntu_bootstrap/test/try_or_install/test_try_or_install.mocks.dart
+++ b/packages/ubuntu_bootstrap/test/try_or_install/test_try_or_install.mocks.dart
@@ -34,7 +34,7 @@ class MockTryOrInstallModel extends _i1.Mock implements _i2.TryOrInstallModel {
   @override
   _i2.TryOrInstallOption get option => (super.noSuchMethod(
         Invocation.getter(#option),
-        returnValue: _i2.TryOrInstallOption.none,
+        returnValue: _i2.TryOrInstallOption.tryUbuntu,
       ) as _i2.TryOrInstallOption);
 
   @override

--- a/packages/ubuntu_bootstrap/test/try_or_install/try_or_install_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/try_or_install/try_or_install_model_test.dart
@@ -35,13 +35,13 @@ void main() {
     var wasNotified = false;
     model.addListener(() => wasNotified = true);
 
-    expect(model.option, equals(TryOrInstallOption.none));
-    model.selectOption(TryOrInstallOption.none);
-    expect(model.option, equals(TryOrInstallOption.none));
-    expect(wasNotified, isFalse);
-
+    expect(model.option, equals(TryOrInstallOption.installUbuntu));
     model.selectOption(TryOrInstallOption.installUbuntu);
     expect(model.option, equals(TryOrInstallOption.installUbuntu));
+    expect(wasNotified, isFalse);
+
+    model.selectOption(TryOrInstallOption.tryUbuntu);
+    expect(model.option, equals(TryOrInstallOption.tryUbuntu));
     expect(wasNotified, isTrue);
   });
 }

--- a/packages/ubuntu_bootstrap/test/try_or_install/try_or_install_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/try_or_install/try_or_install_page_test.dart
@@ -18,10 +18,10 @@ void main() {
   });
 
   testWidgets('select option', (tester) async {
-    final model = buildTryOrInstallModel(option: TryOrInstallOption.none);
+    final model = buildTryOrInstallModel();
     await tester.pumpApp((_) => buildTryOrInstallPage(model));
 
-    expect(find.button(find.nextLabel), isDisabled);
+    expect(find.button(find.nextLabel), findsOneWidget);
 
     await tester.tap(find.radio(TryOrInstallOption.installUbuntu));
     verify(model.selectOption(TryOrInstallOption.installUbuntu)).called(1);
@@ -46,7 +46,7 @@ void main() {
 
     final windowClosed = YaruTestWindow.waitForClosed();
 
-    await tester.tapNext();
+    await tester.tapClose();
     await tester.pump();
 
     await expectLater(windowClosed, completes);


### PR DESCRIPTION
This also removes the unused `none` and `repairUbuntu` options and makes `installUbuntu` the default.

Ref: #495 
UDENG-2506