### PR TITLE
fix(bootstrap): remove horizontal spacer on storage page

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -96,7 +96,6 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
                     )
                   : null,
             ),
-            const SizedBox(height: kWizardSpacing),
           ],
           if (model.canManualPartition)
             _InstallationTypeTile(


### PR DESCRIPTION
Sorry, missed that one. With the boxes removed we don't need any additional spacers.

Ref: #495
UDENG-2506