### PR TITLE
fix: Correct padding and divider for the network page

### DIFF
--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -37,7 +37,6 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: lang.networkPageTitle,
       title: lang.networkPageHeader,
-      contentFlex: model.connectMode == ConnectMode.wifi ? 100 : 6,
       padding: const EdgeInsets.all(kYaruPagePadding),
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
@@ -61,6 +60,8 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
       ),
       children: <Widget>[
         Text(lang.networkPageBody),
+        const SizedBox(height: kWizardSpacing),
+        const Divider(),
         const SizedBox(height: kWizardSpacing),
         EthernetRadioButton(
           value: model.connectMode,

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -32,7 +32,7 @@ class WifiRadioButton extends ConsumerWidget {
         !model.isEnabled ? lang.networkWifiOff : lang.networkWifiNone;
 
     return Padding(
-      padding: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.symmetric(vertical: 8),
       child: YaruRadioButton<ConnectMode>(
         title: Text(isEnabled ? lang.networkWifiOption : disabledTitle),
         value: ConnectMode.wifi,
@@ -95,7 +95,7 @@ class _WifiViewState extends ConsumerState<WifiView> {
     return AnimatedExpanded(
       expanded: widget.expanded,
       child: Padding(
-        padding: kWizardIndentedPadding,
+        padding: kWizardIndentation,
         child: WifiListView(onSelected: widget.onSelected),
       ),
     );

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -78,7 +78,7 @@ class HorizontalPage extends ConsumerWidget {
     final name = ModalRoute.of(context)!.settings.name!.replaceFirst('/', '');
     final image = ref.watch(pageImagesProvider).get(name);
     final windowSize = MediaQuery.of(context).size;
-    final isSmallWindow = windowSize.width < 960 || windowSize.height < 680;
+    final isSmallWindow = windowSize.width < 700 || windowSize.height < 500;
     final adjustedPadding =
         isSmallWindow ? padding.copyWith(right: 0, left: 0) : padding;
     final scrollBarPadding =


### PR DESCRIPTION
![image](https://github.com/canonical/ubuntu-desktop-provision/assets/744771/9d19300e-9342-4d79-9cbc-97e78bea2c46)
