### PR TITLE
fix: Remove unnecessary content flex

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/source/codecs_and_drivers_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/source/codecs_and_drivers_page.dart
@@ -30,7 +30,6 @@ class CodecsAndDriversPage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: lang.codecsAndDriversPageTitle,
       title: lang.codecsAndDriversPageDescription,
-      contentFlex: 3,
       snackBar: model.onBattery
           ? SnackBar(
               width: 500,

--- a/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
+++ b/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
@@ -23,7 +23,6 @@ class AccessibilityPage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: lang.accessibilityPageTitle,
       title: lang.accessibilityPageHeader(flavor.displayName),
-      contentFlex: 8,
       bottomBar: const WizardBar(
         leading: BackWizardButton(),
         trailing: [NextWizardButton()],

--- a/packages/ubuntu_provision/lib/src/identity/identity_page.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_page.dart
@@ -24,7 +24,6 @@ class IdentityPage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: lang.identityPageTitle,
       title: lang.identityPageTitle,
-      contentFlex: 100,
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
         trailing: [

--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -37,7 +37,6 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: lang.networkPageTitle,
       title: lang.networkPageHeader,
-      contentFlex: model.connectMode == ConnectMode.wifi ? 100 : 6,
       padding: const EdgeInsets.all(kYaruPagePadding),
       bottomBar: WizardBar(
         leading: const BackWizardButton(),

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -23,11 +23,15 @@ class HorizontalPage extends ConsumerWidget {
       3 * kYaruPagePadding,
       kYaruPagePadding,
     ),
-    this.contentFlex = 6,
     this.bottomBar,
     this.snackBar,
+    int? contentFlex,
     super.key,
-  });
+  })  : assert(
+          !managedScrolling || contentFlex == null,
+          'contentFlex has no effect unless managedScrolling is set to false.',
+        ),
+        _contentFlex = contentFlex ?? 1;
 
   /// The title for the title bar.
   final String windowTitle;
@@ -63,7 +67,7 @@ class HorizontalPage extends ConsumerWidget {
   /// How much the content should flex compared to the expanded above and below
   /// the content (which defaults to a flexing value of 1).
   /// If [managedScrolling] is set to false, this value is ignored.
-  final int contentFlex;
+  final int _contentFlex;
 
   /// Override of the default bottom bar.
   final Widget? bottomBar;
@@ -111,7 +115,7 @@ class HorizontalPage extends ConsumerWidget {
                     ),
                   ],
                   Expanded(
-                    flex: managedScrolling ? 1 : contentFlex,
+                    flex: managedScrolling ? 1 : _contentFlex,
                     child: managedScrolling
                         ? Center(
                             child: Scrollbar(


### PR DESCRIPTION
The content flex is only needed if `managedScrolling` is false.