### PR TITLE
fix(ubuntu_utils): use base 1000 for SI units

### DIFF
--- a/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -561,7 +561,23 @@ void main() {
     await tester.tapContinueTesting();
     await expectLater(windowClosed, completes);
 
-    await verifySubiquityConfig(storage: storage);
+    await verifySubiquityConfig(
+      storage: [
+        fakeDisk(
+          path: '/dev/sda',
+          partitions: [
+            Partition(
+              size: mibiAlign(toBytes(6, DataUnit.gigabytes)),
+              mount: '/',
+            ),
+            Partition(
+              size: mibiAlign(toBytes(2, DataUnit.gigabytes)),
+              mount: '/mnt/test',
+            ),
+          ],
+        ),
+      ],
+    );
   });
 
   testWidgets('alongside windows', (tester) async {
@@ -634,12 +650,19 @@ void main() {
     await tester.tapContinueTesting();
     await expectLater(windowClosed, completes);
 
+    const totalSize =
+        512 * 166486126; // total size of sda3 from the machine config
+    final newPartitionSize = mibiAlign(toBytes(40000, DataUnit.megabytes));
+
     await verifySubiquityConfig(storage: [
       fakeDisk(
         path: '/dev/sda',
         partitions: [
-          Partition(number: 3, size: toBytes(40000, DataUnit.megabytes)),
-          const Partition(number: 6, size: 43298848768, mount: '/'),
+          Partition(number: 3, size: newPartitionSize),
+          Partition(
+              number: 6,
+              size: mibiAlign(totalSize - newPartitionSize, totalSize),
+              mount: '/'),
         ],
       ),
     ]);

--- a/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_dialogs.dart
@@ -110,7 +110,10 @@ Future<void> showCreatePartitionDialog(
                             model.addPartition(
                               disk,
                               gap,
-                              size: partitionSize.value,
+                              size: mibiAlign(
+                                partitionSize.value,
+                                gap.size,
+                              ),
                               format: partitionFormat.value,
                               mount: partitionMount.value,
                             );

--- a/packages/ubuntu_bootstrap/test/storage/manual/manual_storage_dialogs_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/manual/manual_storage_dialogs_test.dart
@@ -23,7 +23,7 @@ import 'test_manual_storage.dart';
 void main() {
   testWidgets('create partition', (tester) async {
     final disk = fakeDisk();
-    const gap = Gap(offset: 0, size: 1000000, usable: GapUsable.YES);
+    const gap = Gap(offset: 0, size: 100000000, usable: GapUsable.YES);
     final model = buildManualStorageModel(selectedDisk: disk);
 
     registerMockService<UdevService>(MockUdevService());
@@ -45,7 +45,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey(DataUnit.bytes)).last);
     await tester.pump();
 
-    await tester.enterText(find.byType(SpinBox), '123');
+    await tester.enterText(find.byType(SpinBox), '12345678');
     await tester.pump();
 
     await tester.tap(find.byType(MenuButtonBuilder<PartitionFormat?>));
@@ -63,7 +63,7 @@ void main() {
     verify(model.addPartition(
       disk,
       gap,
-      size: 123,
+      size: mibiAlign(12345678, gap.size),
       format: PartitionFormat.btrfs,
       mount: '/tst',
     )).called(1);

--- a/packages/ubuntu_bootstrap/test/widgets/storage_size_box_test.dart
+++ b/packages/ubuntu_bootstrap/test/widgets/storage_size_box_test.dart
@@ -81,7 +81,7 @@ void main() {
         ),
       );
       expect(
-          find.widgetWithText(SpinBox, (5 * 1024).toString()), findsOneWidget);
+          find.widgetWithText(SpinBox, (5 * 1000).toString()), findsOneWidget);
     });
 
     testWidgets('in kilobytes', (tester) async {
@@ -94,7 +94,7 @@ void main() {
           onUnitSelected: (_) {},
         ),
       );
-      expect(find.widgetWithText(SpinBox, (5 * 1024 * 1024).toString()),
+      expect(find.widgetWithText(SpinBox, (5 * 1000 * 1000).toString()),
           findsOneWidget);
     });
   });

--- a/packages/ubuntu_utils/lib/src/data_size.dart
+++ b/packages/ubuntu_utils/lib/src/data_size.dart
@@ -31,3 +31,16 @@ int toBytes(num size, DataUnit unit) {
 double fromBytes(int size, DataUnit unit) {
   return size / math.pow(1000, unit.index).toInt();
 }
+
+/// Aligns the given size to the next MiB boundary. If [maxSize] is given, the
+/// alignment is limited to that size and the next smaller MiB boundary is
+/// returned if the next alignment would exceed the maximum size.
+int mibiAlign(int size, [int? maxSize]) {
+  assert(maxSize == null || size <= maxSize);
+  const mibiByte = 1024 * 1024;
+  final nextAlignment = (size + mibiByte - 1) ~/ mibiByte * mibiByte;
+  if (maxSize == null || nextAlignment <= maxSize) {
+    return nextAlignment;
+  }
+  return size ~/ mibiByte * mibiByte;
+}

--- a/packages/ubuntu_utils/lib/src/data_size.dart
+++ b/packages/ubuntu_utils/lib/src/data_size.dart
@@ -25,9 +25,9 @@ enum DataUnit {
 }
 
 int toBytes(num size, DataUnit unit) {
-  return (size * math.pow(1024, unit.index)).round();
+  return (size * math.pow(1000, unit.index)).round();
 }
 
 double fromBytes(int size, DataUnit unit) {
-  return size / math.pow(1024, unit.index).toInt();
+  return size / math.pow(1000, unit.index).toInt();
 }

--- a/packages/ubuntu_utils/test/data_size_test.dart
+++ b/packages/ubuntu_utils/test/data_size_test.dart
@@ -8,17 +8,17 @@ void main() {
   });
 
   test('kilobytes', () {
-    expect(toBytes(1, DataUnit.kilobytes), equals(1024));
-    expect(fromBytes(1024, DataUnit.kilobytes), equals(1));
+    expect(toBytes(1, DataUnit.kilobytes), equals(1000));
+    expect(fromBytes(1000, DataUnit.kilobytes), equals(1));
   });
 
   test('megabytes', () {
-    expect(toBytes(1, DataUnit.megabytes), equals(1024 * 1024));
-    expect(fromBytes(1024 * 1024, DataUnit.megabytes), equals(1));
+    expect(toBytes(1, DataUnit.megabytes), equals(1000 * 1000));
+    expect(fromBytes(1000 * 1000, DataUnit.megabytes), equals(1));
   });
 
   test('bytes', () {
-    expect(toBytes(1, DataUnit.gigabytes), equals(1024 * 1024 * 1024));
-    expect(fromBytes(1024 * 1024 * 1024, DataUnit.gigabytes), equals(1));
+    expect(toBytes(1, DataUnit.gigabytes), equals(1000 * 1000 * 1000));
+    expect(fromBytes(1000 * 1000 * 1000, DataUnit.gigabytes), equals(1));
   });
 }


### PR DESCRIPTION
This fixes a data size unit inconsistency:

[`toBytes` and `fromBytes`](https://github.com/canonical/ubuntu-desktop-provision/blob/d2dcc733537bfcc84bc9470ed69bd7defa1dec85/packages/ubuntu_utils/lib/src/data_size.dart#L27-L33) from `ubuntu_utils` are using base-2, but are always used in conjunction with [`formatByteSize`](https://github.com/canonical/ubuntu-flutter-plugins/blob/a219aca346fbd732b9ef4d2958dd83ccb70e5883/packages/ubuntu_localizations/lib/src/data_size.dart#L39-L53) from `ubuntu_localizations`, which uses base-10.
Base-10 is correct here as the corresponding [l10n strings](https://github.com/canonical/ubuntu-flutter-plugins/blob/a219aca346fbd732b9ef4d2958dd83ccb70e5883/packages/ubuntu_localizations/lib/src/l10n/ubuntu_en.arb#L235-L246) use SI prefixes. See also [UnitsPolicy](https://wiki.ubuntu.com/UnitsPolicy), which requires us to use base-10 for disk sizes.

Before:

[Screencast from 2024-03-20 15-36-58.webm](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/c6b09296-3c1c-42e0-b8ed-153d0c7883b8)

After:

[Screencast from 2024-03-20 15-38-52.webm](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/87d9f4d9-9705-4652-b166-e2225a439be4)