### PR TITLE
fix(bootstrap): don't search for subiquity in live run

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -63,8 +63,6 @@ Future<void> runInstallerApp(
       Logger.setup(path: liveRun ? '/var/log/installer/$exe.log' : null);
 
   final serverMode = liveRun ? ServerMode.LIVE : ServerMode.DRY_RUN;
-  final subiquityPath = await getSubiquityPath()
-      .then((dir) => Directory(dir).existsSync() ? dir : null);
   final endpoint = await defaultEndpoint(serverMode);
   final includeTryOrInstall = options['try-or-install'] as bool? ?? false;
   final process = liveRun
@@ -72,7 +70,8 @@ Future<void> runInstallerApp(
       : SubiquityProcess.python(
           'subiquity.cmd.server',
           serverMode: ServerMode.DRY_RUN,
-          subiquityPath: subiquityPath,
+          subiquityPath: await getSubiquityPath()
+              .then((dir) => Directory(dir).existsSync() ? dir : null),
         );
 
   final baseName = p.basename(Platform.resolvedExecutable);


### PR DESCRIPTION
When running the installer in live mode the following message is written to the logs:

```
flutter: WARNING subiquity_server: Unable to find the subiquity_client package. Falling back to the current working dir: /home/ubuntu
```

This happens because `getSubiquityPath()` is called even if the installer doesn't spawn its own subiquity server. Removing the local variable should solve this and make the logs a little less confusing for people trying to debug issues :)