### PR TITLE
fix: More title space on the done page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ theme:
 # - not-enough-disk-space: Notifies if there is insufficient disk space
 # - secure-boot: Handles secure boot
 # - storage: Select target disk and partition
+# - storage-icon: Not a separate page, but sets the distribution icon on the storage page
 # - identity: Create the first-user account (only displayed if mode = default)
 # - confirm: A summary of the installation and confirmation button to start the install
 # - done: Choose whether to restart or continue testing in the live session
+# - error: The page that shows when something goes wrong
 #
 # Init pages (for oem only)
 # - identity: Create the first-user account 

--- a/packages/ubuntu_bootstrap/lib/pages/install/done_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/install/done_page.dart
@@ -24,7 +24,7 @@ class DonePage extends ConsumerWidget {
         children: [
           const Spacer(),
           Expanded(
-            flex: 3,
+            flex: 7,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -35,6 +35,7 @@ class DonePage extends ConsumerWidget {
                       ? lang.rebootToConfigure(model.productInfo.toString())
                       : lang.readyToUse(model.productInfo.toString()),
                   style: theme.textTheme.headlineSmall,
+                  textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: kWizardSpacing),
                 Text(


### PR DESCRIPTION
Some long distribution titles overflowed apparently,

![image](https://github.com/canonical/ubuntu-desktop-provision/assets/744771/40bb6c42-2c9e-402c-8f1e-aabea9592097)
