### PR TITLE
fix: realName on identity page can’t be empty.

### DIFF
--- a/packages/ubuntu_provision/lib/src/identity/identity_model.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_model.dart
@@ -134,7 +134,8 @@ class IdentityModel extends SafeChangeNotifier with PropertyStreamNotifier {
 
   /// Whether the current input is valid.
   bool get isValid {
-    return realName.length <= kMaxRealNameLength &&
+    return realName.isNotEmpty &&
+        realName.length <= kMaxRealNameLength &&
         hostname.isNotEmpty &&
         hostname.length <= kMaxHostnameLength &&
         username.isNotEmpty &&

--- a/packages/ubuntu_provision/test/identity/identity_model_test.dart
+++ b/packages/ubuntu_provision/test/identity/identity_model_test.dart
@@ -353,7 +353,7 @@ void main() {
     testValid('real', 'host', 'user', 'passwd', 'mismatch', isFalse);
 
     // real name validation
-    testValid('', 'host', 'user', 'passwd', 'passwd', isTrue);
+    testValid('', 'host', 'user', 'passwd', 'passwd', isFalse);
     testValid(
         'these are slightly more than the allowed one hundred and sixty characters for the extraordinarily lengthy name of the user who is currently running the installer',
         'host',


### PR DESCRIPTION
In this PR:

- fix #540 