### PR TITLE
feat: Transfer factory_reset_tools to monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ coverage/
 *.iml
 .vscode/
 pubspec.lock
-pubspec_overrides.yaml
+**/pubspec_overrides.yaml
 /*.snap
 **/build/
 **/.dart_tool/

--- a/packages/factory_reset_tools/.gitignore
+++ b/packages/factory_reset_tools/.gitignore
@@ -1,0 +1,53 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+*.lock
+.packages
+.pub-cache/
+.pub/
+/build/
+/android/
+/ios/
+
+# Linux related
+generated_plugins.cmake
+generated_plugin_registrant.*
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/packages/factory_reset_tools/.metadata
+++ b/packages/factory_reset_tools/.metadata
@@ -1,0 +1,45 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "abb292a07e20d696c4568099f918f6c5f330e6b0"
+  channel: "stable"
+
+project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+    - platform: android
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+    - platform: ios
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+    - platform: linux
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+    - platform: macos
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+    - platform: web
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+    - platform: windows
+      create_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+      base_revision: abb292a07e20d696c4568099f918f6c5f330e6b0
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/packages/factory_reset_tools/README.md
+++ b/packages/factory_reset_tools/README.md
@@ -1,0 +1,5 @@
+# Factory Reset Tools
+
+TODO: To have a proper README
+
+License: GPLv3, see LICENSE fo license text

--- a/packages/factory_reset_tools/analysis_options.yaml
+++ b/packages/factory_reset_tools/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:ubuntu_lints/analysis_options.yaml
+
+linter:
+  rules:
+    - require_trailing_commas

--- a/packages/factory_reset_tools/data/factory-reset-tools-object.xml
+++ b/packages/factory_reset_tools/data/factory-reset-tools-object.xml
@@ -1,0 +1,8 @@
+<node name="/com/canonical/oem/FactoryResetTools">
+  <interface name="com.canonical.oem.FactoryResetTools">
+    <property name="Version" type="s" access="read"/>
+    <method name="Reboot">
+      <arg name="rebootOption" type="s" direction="in"/>
+    </method>
+  </interface>
+</node>

--- a/packages/factory_reset_tools/lib/cmdline.dart
+++ b/packages/factory_reset_tools/lib/cmdline.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+import 'package:args/command_runner.dart';
+import 'package:factory_reset_tools/dbus_daemon.dart';
+import 'package:factory_reset_tools/reboot.dart';
+import 'package:factory_reset_tools/reset_media.dart';
+
+/// Command line entrypoint of factory-reset-tools
+class CreateResetMediaCommand extends Command<void> {
+  CreateResetMediaCommand() {
+    argParser.addOption(
+      'rp-uuid',
+      help: 'Use another reset partition filesystem UUID',
+      valueHelp: '1234-ABCD',
+    );
+  }
+  @override
+  final name = 'create-reset-media';
+  @override
+  final description = 'Create a reset media from reset partition';
+  @override
+  String get invocation {
+    final parents = [name];
+    for (var command = parent; command != null; command = command.parent) {
+      parents.add(command.name);
+    }
+    parents.add(runner!.executableName);
+
+    final invocation = parents.reversed.join(' ');
+    return '$invocation [arguments] disk-path';
+  }
+
+  @override
+  Future<void> run() async {
+    final argResults = this.argResults!;
+    final fsuuid = argResults['rp-uuid'] as String?;
+    if (argResults.rest.isEmpty) {
+      printUsage();
+      throw Exception('missing disk path');
+    }
+    await for (final progress
+        in createResetMedia(argResults.rest[0], fsuuid: fsuuid)) {
+      stdout.write(
+        "${((progress.percent ?? 0.0) * 100).toStringAsFixed(2)}% ${progress.status.name} ${progress.errMsg ?? ""}"
+            .padRight(75),
+      );
+      stdout.write('\r');
+    }
+    stdout.writeln();
+    exit(0);
+  }
+}
+
+class RebootCommand extends Command<void> {
+  RebootCommand();
+  @override
+  final name = 'reboot';
+
+  @override
+  final description =
+      'Reboot into reset partition, or any other preconfigured options.\n'
+      'If no option is given, a list of available options will be listed.';
+
+  @override
+  String get invocation {
+    final parents = [name];
+    for (var command = parent; command != null; command = command.parent) {
+      parents.add(command.name);
+    }
+    parents.add(runner!.executableName);
+
+    final invocation = parents.reversed.join(' ');
+    return '$invocation [reboot-option]';
+  }
+
+  @override
+  Future<void> run() async {
+    final argResults = this.argResults!;
+    if (argResults.rest.isEmpty) {
+      final options = getResetOptions();
+      stdout.writeln('List of available options:\n');
+      for (final option in options) {
+        stdout.writeln('${option.key}: ${option.title}');
+        if (option.description != null) {
+          stdout.writeln('  ${option.description}');
+        }
+        stdout.writeln();
+      }
+      return;
+    }
+    await startCommandViaDbus(argResults.rest[0]);
+    exit(0);
+  }
+}
+
+class DBusCommand extends Command<void> {
+  DBusCommand();
+  @override
+  final name = 'dbus';
+  @override
+  final description = 'Starts a DBus daemon';
+  @override
+  final hidden = true;
+
+  @override
+  Future<void> run() async {
+    await runDBusDaemon();
+  }
+}
+
+void main(List<String> args) async {
+  final runner = CommandRunner(
+    'factory-reset-tools-cli',
+    'Command line utility for factory reset.',
+  )
+    ..addCommand(CreateResetMediaCommand())
+    ..addCommand(RebootCommand())
+    ..addCommand(DBusCommand());
+  await runner.run(args);
+}

--- a/packages/factory_reset_tools/lib/dbus_daemon.dart
+++ b/packages/factory_reset_tools/lib/dbus_daemon.dart
@@ -1,0 +1,22 @@
+import 'package:dbus/dbus.dart';
+import 'package:factory_reset_tools/dbus_local_object.dart';
+import 'package:factory_reset_tools/reboot.dart';
+
+class FactoryResetToolsObject extends ComCanonicalOemFactoryResetTools {
+  @override
+  Future<DBusMethodResponse> getVersion() async {
+    return DBusGetPropertyResponse(const DBusString('1.0'));
+  }
+
+  @override
+  Future<DBusMethodResponse> doReboot(String rebootOption) async {
+    await startCommand(rebootOption);
+    return DBusMethodSuccessResponse();
+  }
+}
+
+Future<void> runDBusDaemon() async {
+  final client = DBusClient.system();
+  await client.requestName('com.canonical.oem.FactoryResetTools');
+  await client.registerObject(FactoryResetToolsObject());
+}

--- a/packages/factory_reset_tools/lib/dbus_local_object.dart
+++ b/packages/factory_reset_tools/lib/dbus_local_object.dart
@@ -1,0 +1,110 @@
+// This file was generated using the following command and may be overwritten.
+// dart-dbus generate-object ../data/factory-reset-tools-object.xml
+
+import 'package:dbus/dbus.dart';
+
+class ComCanonicalOemFactoryResetTools extends DBusObject {
+  /// Creates a new object to expose on [path].
+  ComCanonicalOemFactoryResetTools({
+    DBusObjectPath path = const DBusObjectPath.unchecked(
+      '/com/canonical/oem/FactoryResetTools',
+    ),
+  }) : super(path);
+
+  /// Gets value of property com.canonical.oem.FactoryResetTools.Version
+  Future<DBusMethodResponse> getVersion() async {
+    return DBusMethodErrorResponse.failed(
+      'Get com.canonical.oem.FactoryResetTools.Version not implemented',
+    );
+  }
+
+  /// Implementation of com.canonical.oem.FactoryResetTools.Reboot()
+  Future<DBusMethodResponse> doReboot(String rebootOption) async {
+    return DBusMethodErrorResponse.failed(
+      'com.canonical.oem.FactoryResetTools.Reboot() not implemented',
+    );
+  }
+
+  @override
+  List<DBusIntrospectInterface> introspect() {
+    return [
+      DBusIntrospectInterface(
+        'com.canonical.oem.FactoryResetTools',
+        methods: [
+          DBusIntrospectMethod(
+            'Reboot',
+            args: [
+              DBusIntrospectArgument(
+                DBusSignature('s'),
+                DBusArgumentDirection.in_,
+                name: 'rebootOption',
+              ),
+            ],
+          ),
+        ],
+        properties: [
+          DBusIntrospectProperty(
+            'Version',
+            DBusSignature('s'),
+            access: DBusPropertyAccess.read,
+          ),
+        ],
+      ),
+    ];
+  }
+
+  @override
+  Future<DBusMethodResponse> handleMethodCall(DBusMethodCall methodCall) async {
+    if (methodCall.interface == 'com.canonical.oem.FactoryResetTools') {
+      if (methodCall.name == 'Reboot') {
+        if (methodCall.signature != DBusSignature('s')) {
+          return DBusMethodErrorResponse.invalidArgs();
+        }
+        return doReboot(methodCall.values[0].asString());
+      } else {
+        return DBusMethodErrorResponse.unknownMethod();
+      }
+    } else {
+      return DBusMethodErrorResponse.unknownInterface();
+    }
+  }
+
+  @override
+  Future<DBusMethodResponse> getProperty(String interface, String name) async {
+    if (interface == 'com.canonical.oem.FactoryResetTools') {
+      if (name == 'Version') {
+        return getVersion();
+      } else {
+        return DBusMethodErrorResponse.unknownProperty();
+      }
+    } else {
+      return DBusMethodErrorResponse.unknownProperty();
+    }
+  }
+
+  @override
+  Future<DBusMethodResponse> setProperty(
+    String interface,
+    String name,
+    DBusValue value,
+  ) async {
+    if (interface == 'com.canonical.oem.FactoryResetTools') {
+      if (name == 'Version') {
+        return DBusMethodErrorResponse.propertyReadOnly();
+      } else {
+        return DBusMethodErrorResponse.unknownProperty();
+      }
+    } else {
+      return DBusMethodErrorResponse.unknownProperty();
+    }
+  }
+
+  @override
+  Future<DBusMethodResponse> getAllProperties(String interface) async {
+    final properties = <String, DBusValue>{};
+    if (interface == 'com.canonical.oem.FactoryResetTools') {
+      properties['Version'] = (await getVersion()).returnValues[0];
+    }
+    return DBusMethodSuccessResponse([DBusDict.stringVariant(properties)]);
+  }
+}

--- a/packages/factory_reset_tools/lib/dbus_remote_object.dart
+++ b/packages/factory_reset_tools/lib/dbus_remote_object.dart
@@ -1,0 +1,40 @@
+// This file was generated using the following command and may be overwritten.
+// dart-dbus generate-remote-object data/factory-reset-tools-object.xml
+
+import 'package:dbus/dbus.dart';
+
+class ComCanonicalOemFactoryResetTools extends DBusRemoteObject {
+  ComCanonicalOemFactoryResetTools(
+    super.client,
+    String destination, {
+    super.path = const DBusObjectPath.unchecked(
+      '/com/canonical/oem/FactoryResetTools',
+    ),
+  }) : super(name: destination);
+
+  /// Gets com.canonical.oem.FactoryResetTools.Version
+  Future<String> getVersion() async {
+    final value = await getProperty(
+      'com.canonical.oem.FactoryResetTools',
+      'Version',
+      signature: DBusSignature('s'),
+    );
+    return value.asString();
+  }
+
+  /// Invokes com.canonical.oem.FactoryResetTools.Reboot()
+  Future<void> callReboot(
+    String rebootOption, {
+    bool noAutoStart = false,
+    bool allowInteractiveAuthorization = false,
+  }) async {
+    await callMethod(
+      'com.canonical.oem.FactoryResetTools',
+      'Reboot',
+      [DBusString(rebootOption)],
+      replySignature: DBusSignature(''),
+      noAutoStart: noAutoStart,
+      allowInteractiveAuthorization: allowInteractiveAuthorization,
+    );
+  }
+}

--- a/packages/factory_reset_tools/lib/main.dart
+++ b/packages/factory_reset_tools/lib/main.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:factory_reset_tools/pages/home.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:ubuntu_localizations/ubuntu_localizations.dart';
+import 'package:yaru/yaru.dart';
+
+const int minimumRequiredDiskSize = 12 << 30;
+
+Future<void> main() async {
+  await YaruWindowTitleBar.ensureInitialized();
+
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return YaruTheme(
+      builder: (context, yaru, child) {
+        return MaterialApp(
+          title: 'Yaru',
+          theme: yaru.theme,
+          darkTheme: yaru.darkTheme,
+          highContrastTheme: yaruHighContrastLight,
+          highContrastDarkTheme: yaruHighContrastDark,
+          home: const Home(),
+          scrollBehavior: const MaterialScrollBehavior().copyWith(
+            dragDevices: {
+              PointerDeviceKind.mouse,
+              PointerDeviceKind.touch,
+              PointerDeviceKind.stylus,
+              PointerDeviceKind.unknown,
+              PointerDeviceKind.trackpad,
+            },
+          ),
+          localizationsDelegates: UbuntuLocalizations.localizationsDelegates,
+          supportedLocales: UbuntuLocalizations.supportedLocales,
+        );
+      },
+    );
+  }
+}

--- a/packages/factory_reset_tools/lib/pages/home.dart
+++ b/packages/factory_reset_tools/lib/pages/home.dart
@@ -1,0 +1,42 @@
+import 'package:factory_reset_tools/pages/reboot.dart';
+import 'package:factory_reset_tools/pages/reset_media.dart';
+import 'package:flutter/material.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
+
+class Home extends StatelessWidget {
+  const Home({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WizardPage(
+      title: const YaruWindowTitleBar(title: Text('Factory Reset Tool')),
+      header: const Text('What would you like to do?'),
+      content: Wrap(
+        alignment: WrapAlignment.spaceAround,
+        children: [
+          FilledButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const SelectRemovableMedia(),
+                ),
+              );
+            },
+            child: const Text('Create Reset Media'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const FactoryReset(),
+                ),
+              );
+            },
+            child: const Text('Start Factory Reset'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/factory_reset_tools/lib/pages/reboot.dart
+++ b/packages/factory_reset_tools/lib/pages/reboot.dart
@@ -1,0 +1,131 @@
+import 'package:factory_reset_tools/reboot.dart';
+import 'package:flutter/material.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
+
+const defaultOptionKey = 'factory-reset';
+
+class FactoryReset extends StatefulWidget {
+  const FactoryReset({super.key});
+
+  @override
+  State<FactoryReset> createState() => _FactoryResetState();
+}
+
+class _FactoryResetState extends State<FactoryReset> {
+  String _selectedOption = defaultOptionKey;
+  List<BootOption> options = [];
+
+  @override
+  void initState() {
+    super.initState();
+
+    options = getResetOptions();
+    _selectedOption = options.first.key;
+  }
+
+  Future<void> doExecute(BuildContext context) async {
+    try {
+      await startCommandViaDbus(_selectedOption);
+      // ignore: avoid_catches_without_on_clauses
+    } catch (e) {
+      if (!context.mounted) return;
+      await showDialog<String>(
+        context: context,
+        builder: (context) => AlertDialog(
+          titlePadding: EdgeInsets.zero,
+          title: const YaruDialogTitleBar(
+            title: Text('Failed to run command'),
+          ),
+          content: Text(e.toString()),
+          actions: <Widget>[
+            OutlinedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  Widget buildWithMultipleOptions(BuildContext context) {
+    final optionsWidgets = options.map((option) {
+      return RadioListTile<String>(
+        key: Key(option.key),
+        value: option.key,
+        groupValue: _selectedOption,
+        onChanged: (value) =>
+            setState(() => _selectedOption = value ?? options.first.key),
+        title: Text(option.title),
+        subtitle:
+            option.description != null ? Text(option.description ?? '') : null,
+      );
+    }).toList();
+
+    return WizardPage(
+      title: const YaruWindowTitleBar(title: Text('Factory Reset Tool')),
+      header: const Text('Select an option to start factory reset:'),
+      content: Column(
+        children: optionsWidgets,
+      ),
+      bottomBar: WizardBar(
+        leading: OutlinedButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('Back'),
+        ),
+        trailing: [
+          NextWizardButton(
+            highlighted: true,
+            label: 'Start',
+            onExecute: () => doExecute(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildWithSingleOption(BuildContext context) {
+    final option = options.first;
+    return WizardPage(
+      title: const YaruWindowTitleBar(title: Text('Factory Reset Tool')),
+      header: const Text('Are you sure to start the factory reset?'),
+      content: Column(
+        children: [
+          ListTile(
+            key: Key(option.key),
+            title: Text(option.title),
+            subtitle: option.description != null
+                ? Text(option.description ?? '')
+                : null,
+          ),
+        ],
+      ),
+      bottomBar: WizardBar(
+        leading: OutlinedButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('Back'),
+        ),
+        trailing: [
+          NextWizardButton(
+            highlighted: true,
+            label: 'Reboot',
+            onExecute: () => doExecute(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (options.length > 1) {
+      return buildWithMultipleOptions(context);
+    }
+    return buildWithSingleOption(context);
+  }
+}

--- a/packages/factory_reset_tools/lib/pages/reset_media.dart
+++ b/packages/factory_reset_tools/lib/pages/reset_media.dart
@@ -1,0 +1,392 @@
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:dbus/dbus.dart';
+import 'package:factory_reset_tools/reset_media.dart';
+import 'package:flutter/material.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
+import 'package:yaru/yaru.dart';
+
+const int minimumRequiredDiskSize = 12 << 30;
+
+class Drive {
+  Drive(
+    this.name,
+    this.id,
+    this.size,
+    this.devicePath,
+    this.driveObjectPath,
+    this.blockDeviceObjectPath,
+  );
+  final String name;
+  final String id;
+  final int size;
+  final String devicePath;
+  final DBusObjectPath driveObjectPath;
+  final DBusObjectPath blockDeviceObjectPath;
+
+  @override
+  String toString() => name;
+}
+
+class SelectRemovableMedia extends StatefulWidget {
+  const SelectRemovableMedia({super.key});
+
+  @override
+  State<SelectRemovableMedia> createState() => _SelectRemovableMediaState();
+}
+
+class _SelectRemovableMediaState extends State<SelectRemovableMedia> {
+  List<Drive> drives = [];
+  final _dbusClient = DBusClient.system();
+  Timer? _debounce;
+  StreamSubscription<DBusSignal>? _subscription;
+  String? _selectedDrive;
+
+  Future<void> _onDrivesChanged() async {
+    if (_debounce?.isActive ?? false) {
+      _debounce?.cancel();
+    }
+    _debounce = Timer(const Duration(milliseconds: 100), () async {
+      final newDrives = await _getListOfDrives();
+      _clearUnavailableSelectedDrive(newDrives);
+      setState(() {
+        drives = newDrives;
+      });
+    });
+  }
+
+  Future<List<Drive>> _getListOfDrives() async {
+    final blockDevicesObject = DBusRemoteObject(
+      _dbusClient,
+      name: 'org.freedesktop.UDisks2',
+      path: DBusObjectPath('/org/freedesktop/UDisks2/block_devices'),
+    );
+    final introspect = await blockDevicesObject.introspect();
+
+    // map of blockDeviceObjectPath: driveObjectPath
+    final blockDevs = <DBusObjectPath, DBusObjectPath>{};
+
+    // iterate through block devices, to find out devices that
+    // 1. has a Drive backing it
+    // 2. has enough Size (we assume 16G)
+    // 3. its HintPartitionable is true
+    for (final node in introspect.children) {
+      final blockDeviceObjectPath =
+          DBusObjectPath('/org/freedesktop/UDisks2/block_devices/${node.name}');
+      final blockDeviceObject = DBusRemoteObject(
+        _dbusClient,
+        name: 'org.freedesktop.UDisks2',
+        path: blockDeviceObjectPath,
+      );
+
+      final drive = await blockDeviceObject.getProperty(
+        'org.freedesktop.UDisks2.Block',
+        'Drive',
+        signature: DBusSignature('o'),
+      );
+      final driveObjectPath = drive.asObjectPath();
+      if (driveObjectPath == DBusObjectPath.root) {
+        continue;
+      }
+
+      final size = await blockDeviceObject.getProperty(
+        'org.freedesktop.UDisks2.Block',
+        'Size',
+        signature: DBusSignature('t'),
+      );
+      if (size.asUint64() < minimumRequiredDiskSize) {
+        continue;
+      }
+
+      final hintPartitionable = await blockDeviceObject.getProperty(
+        'org.freedesktop.UDisks2.Block',
+        'HintPartitionable',
+        signature: DBusSignature('b'),
+      );
+      if (hintPartitionable.asBoolean() == false) {
+        continue;
+      }
+
+      blockDevs[blockDeviceObjectPath] = driveObjectPath;
+    }
+
+    // iterate through block devices' partition table, to find out devices that
+    // no PartitionTable is mentioning, this should get all root block devs of
+    // the drive, and drives without partition tables are represented as well
+    for (final node in introspect.children) {
+      final blockDeviceObjectPath =
+          DBusObjectPath('/org/freedesktop/UDisks2/block_devices/${node.name}');
+      final blockDeviceObject = DBusRemoteObject(
+        _dbusClient,
+        name: 'org.freedesktop.UDisks2',
+        path: blockDeviceObjectPath,
+      );
+
+      try {
+        final partitions = await blockDeviceObject.getProperty(
+          'org.freedesktop.UDisks2.PartitionTable',
+          'Partitions',
+          signature: DBusSignature('ao'),
+        );
+        for (final partition in partitions.asObjectPathArray()) {
+          blockDevs.remove(partition);
+        }
+      } on DBusInvalidArgsException {
+        // partition table might not be in the block device
+        continue;
+      }
+    }
+
+    // finally we got a list of drives, find those who's ConnectionBus is "usb",
+    // or is Removable, since USB NVMe drives does not show Removable
+    final drives = <Drive>[];
+    for (final entry in blockDevs.entries) {
+      final blockDeviceObjectPath = entry.key;
+      final driveObjectPath = entry.value;
+
+      final driveObject = DBusRemoteObject(
+        _dbusClient,
+        name: 'org.freedesktop.UDisks2',
+        path: driveObjectPath,
+      );
+      final connectionBus = await driveObject.getProperty(
+        'org.freedesktop.UDisks2.Drive',
+        'ConnectionBus',
+        signature: DBusSignature('s'),
+      );
+      final isRemovable = await driveObject.getProperty(
+        'org.freedesktop.UDisks2.Drive',
+        'Removable',
+        signature: DBusSignature('b'),
+      );
+
+      if (!(connectionBus.asString() == 'usb' || isRemovable.asBoolean())) {
+        continue;
+      }
+
+      final blockDeviceObject = DBusRemoteObject(
+        _dbusClient,
+        name: 'org.freedesktop.UDisks2',
+        path: blockDeviceObjectPath,
+      );
+      final id = await driveObject.getProperty(
+        'org.freedesktop.UDisks2.Drive',
+        'Id',
+        signature: DBusSignature('s'),
+      );
+      final vendor = await driveObject.getProperty(
+        'org.freedesktop.UDisks2.Drive',
+        'Vendor',
+        signature: DBusSignature('s'),
+      );
+      final model = await driveObject.getProperty(
+        'org.freedesktop.UDisks2.Drive',
+        'Model',
+        signature: DBusSignature('s'),
+      );
+      final size = await driveObject.getProperty(
+        'org.freedesktop.UDisks2.Drive',
+        'Size',
+        signature: DBusSignature('t'),
+      );
+      final devicePath = await blockDeviceObject.getProperty(
+        'org.freedesktop.UDisks2.Block',
+        'Device',
+        signature: DBusSignature('ay'),
+      );
+      // Note that Device property is an array of unsigned bytes, containing
+      // null-terminated C-style string, therefore needs to filter out 0 from
+      // the byte array.
+      final devicePathString = String.fromCharCodes(
+        devicePath.asByteArray().where((e) => e != 0),
+        0,
+        128,
+      );
+      drives.add(
+        Drive(
+          '${vendor.asString()} ${model.asString()}'.trim(),
+          id.asString(),
+          size.asUint64(),
+          devicePathString,
+          driveObjectPath,
+          blockDeviceObjectPath,
+        ),
+      );
+    }
+    drives.sort((a, b) => a.id.compareTo(b.id));
+    return drives;
+  }
+
+  void _clearUnavailableSelectedDrive(List<Drive> drives) {
+    for (final drive in drives) {
+      if (drive.id == _selectedDrive) {
+        return;
+      }
+    }
+    _selectedDrive = null;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    final object = DBusRemoteObject(
+      _dbusClient,
+      name: 'org.freedesktop.UDisks2',
+      path: DBusObjectPath('/org/freedesktop/UDisks2'),
+    );
+
+    final addedStream = DBusRemoteObjectSignalStream(
+      object: object,
+      interface: 'org.freedesktop.DBus.ObjectManager',
+      name: 'InterfacesAdded',
+    );
+    final removedStream = DBusRemoteObjectSignalStream(
+      object: object,
+      interface: 'org.freedesktop.DBus.ObjectManager',
+      name: 'InterfacesRemoved',
+    );
+    _subscription ??= StreamGroup.merge([addedStream, removedStream])
+        .listen((_) => _onDrivesChanged());
+
+    _onDrivesChanged();
+  }
+
+  @override
+  void deactivate() {
+    _subscription!.cancel();
+    super.deactivate();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var drivesWidgets = <Widget>[
+      const ListTile(
+        title: Text('No removable storage is detected'),
+        subtitle:
+            Text('You need a USB storage to create a Factory Reset Media.'),
+      ),
+    ];
+    if (drives.isNotEmpty) {
+      drivesWidgets = drives.map((drive) {
+        final sizeInGiB = drive.size.toDouble() / (1 << 30).toDouble();
+        final sizeString = '${sizeInGiB.toStringAsFixed(1)} GiB';
+        return RadioListTile<String>(
+          key: Key(drive.id),
+          value: drive.id,
+          groupValue: _selectedDrive,
+          onChanged: (value) => setState(() => _selectedDrive = value),
+          title: Text(drive.name),
+          subtitle: Text('${drive.devicePath} $sizeString'),
+        );
+      }).toList();
+    }
+
+    return WizardPage(
+      title: const YaruWindowTitleBar(title: Text('Factory Reset Tool')),
+      header: const Text('Select a disk to create a Factory Reset Media:'),
+      content: Column(
+        children: drivesWidgets,
+      ),
+      bottomBar: WizardBar(
+        leading: OutlinedButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('Back'),
+        ),
+        trailing: [
+          NextWizardButton(
+            enabled: _selectedDrive != null,
+            highlighted: true,
+            onExecute: () async {
+              final devicePath = drives
+                  .firstWhere((drive) => drive.id == _selectedDrive)
+                  .devicePath;
+              await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => CreateResetMedia(devicePath),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CreateResetMedia extends StatefulWidget {
+  const CreateResetMedia(this.devicePath, {super.key});
+  final String devicePath;
+
+  @override
+  State<CreateResetMedia> createState() => _CreateResetMediaState();
+}
+
+class _CreateResetMediaState extends State<CreateResetMedia> {
+  Stream<ResetMediaCreationProgress>? createResetMediaAsyncStream;
+  var _progress = ResetMediaCreationProgress(
+    ResetMediaCreationStatus.initializing,
+    null,
+    null,
+  );
+
+  void onStatusChanged(ResetMediaCreationProgress progress) {
+    setState(() {
+      _progress = progress;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    createResetMediaAsyncStream ??= createResetMedia(widget.devicePath);
+    createResetMediaAsyncStream!.listen(onStatusChanged);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var msgText = _progress.status.name;
+    if (_progress.percent != null) {
+      msgText =
+          '${((_progress.percent ?? 0.0) * 100).toStringAsFixed(2)}% $msgText';
+    }
+    if (_progress.errMsg != null) {
+      msgText = '${_progress.status.name} ${_progress.errMsg}';
+    }
+
+    return WizardPage(
+      title: const YaruWindowTitleBar(title: Text('Factory Reset Tool')),
+      header: const Text('Creating reset media...'),
+      content: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          LinearProgressIndicator(value: _progress.percent),
+          Text(msgText),
+        ],
+      ),
+    );
+  }
+}
+
+Stream<ResetMediaCreationProgress> dummyCreateResetMedia(
+  String targetDevicePath,
+) async* {
+  await Future.delayed(const Duration(seconds: 3));
+
+  for (var i = 0.0; i < 1.0; i += 0.01) {
+    yield ResetMediaCreationProgress(ResetMediaCreationStatus.copying, i, null);
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  yield ResetMediaCreationProgress(
+    ResetMediaCreationStatus.finalizing,
+    1,
+    null,
+  );
+  await Future.delayed(const Duration(seconds: 3));
+
+  yield ResetMediaCreationProgress(ResetMediaCreationStatus.finished, 1, null);
+}

--- a/packages/factory_reset_tools/lib/reboot.dart
+++ b/packages/factory_reset_tools/lib/reboot.dart
@@ -1,0 +1,162 @@
+import 'dart:developer';
+import 'dart:io';
+
+import 'package:dbus/dbus.dart';
+import 'package:factory_reset_tools/dbus_remote_object.dart';
+import 'package:retry/retry.dart';
+import 'package:yaml/yaml.dart';
+
+const defaultFilePath = '/usr/share/desktop-provision/reset.yaml';
+
+sealed class BootOption {
+  BootOption(this.key, this.title, this.description);
+  final String key;
+  final String title;
+  final String? description;
+
+  Future<void> run();
+}
+
+class GrubBootOption extends BootOption {
+  GrubBootOption(super.key, super.title, super.description, this.optionName);
+  final String optionName;
+
+  @override
+  Future<void> run() async {
+    final result = await Process.run('grub-editenv', [
+      '/var/lib/snapd/hostfs/boot/grub/grubenv',
+      'set',
+      'next_entry=$optionName',
+    ]);
+    stdout.write(result.stdout);
+    stderr.write(result.stderr);
+    if (result.exitCode != 0) {
+      throw Exception(result.stderr);
+    }
+
+    final dbusClient = DBusClient.system();
+
+    final loginObject = DBusRemoteObject(
+      dbusClient,
+      name: 'org.freedesktop.login1',
+      path: DBusObjectPath('/org/freedesktop/login1'),
+    );
+    await loginObject.callMethod(
+      'org.freedesktop.login1.Manager',
+      'Reboot',
+      [const DBusBoolean(true)],
+    );
+  }
+}
+
+class RunCommandBootOption extends BootOption {
+  RunCommandBootOption(super.key, super.title, super.description, this.command);
+  final List<String> command;
+
+  @override
+  Future<void> run() async {
+    final result = await Process.run(command[0], command.sublist(1));
+    stdout.write(result.stdout);
+    stderr.write(result.stderr);
+    if (result.exitCode == 126) {
+      throw 'unauthorized';
+    }
+  }
+}
+
+final List<BootOption> defaultBootOption = [
+  GrubBootOption(
+    'factory-reset',
+    'Restore Ubuntu to factory state',
+    'This option will restore Ubuntu to factory default, removing all files stored in this system during the process.',
+    'Restore Ubuntu to factory state',
+  ),
+  GrubBootOption(
+    'fwsetup',
+    'UEFI Firmware Settings',
+    'Reboot into UEFI Firmware (BIOS) Settings menu',
+    'UEFI Firmware Settings',
+  ),
+];
+
+List<BootOption> getResetOptions({String path = defaultFilePath}) {
+  try {
+    final rawConfig = File(path).readAsStringSync();
+    final config = loadYaml(rawConfig, sourceUrl: Uri.file(path));
+    final options = config['reset_tool_options'] as YamlList;
+    final bootOptions = <BootOption>[];
+    for (final item in options) {
+      if (item is! YamlMap) {
+        continue;
+      }
+      if (item.containsKey('grub_option')) {
+        bootOptions.add(
+          GrubBootOption(
+            item['key'] as String,
+            item['title'] as String,
+            item['description'] as String?,
+            item['grub_option'] as String,
+          ),
+        );
+      } else if (item.containsKey('run_command')) {
+        final rawCommand = item['run_command'];
+        List<String> command;
+        if (rawCommand is YamlList) {
+          command = rawCommand.cast<String>();
+        } else {
+          command = ['/usr/bin/bash', '-c', rawCommand as String];
+        }
+
+        bootOptions.add(
+          RunCommandBootOption(
+            item['key'] as String,
+            item['title'] as String,
+            item['description'] as String?,
+            command,
+          ),
+        );
+      }
+    }
+    assert(bootOptions.isNotEmpty);
+    return bootOptions;
+    // ignore: avoid_catches_without_on_clauses
+  } catch (e) {
+    // Generic catch-all exception
+    log('reading $path for options failed', error: e);
+    return defaultBootOption;
+  }
+}
+
+Future<void> startCommand(String key, {String path = defaultFilePath}) {
+  BootOption option;
+  final options = getResetOptions(path: path);
+
+  try {
+    option = options.firstWhere((option) => option.key == key);
+  } on StateError {
+    throw StateError('option not found');
+  }
+
+  return option.run();
+}
+
+Future<void> startCommandViaDbus(
+  String key, {
+  String path = defaultFilePath,
+}) async {
+  final dbusClient = DBusClient.system();
+  final object = ComCanonicalOemFactoryResetTools(
+    dbusClient,
+    'com.canonical.oem.FactoryResetTools',
+  );
+
+  // as service is activated by dbus call, we should try to rerun if dbus gives
+  // error
+  const retryRunner = RetryOptions(maxAttempts: 5);
+  await retryRunner.retry(
+    () => object.callReboot(key),
+    retryIf: (e) =>
+        e is DBusMethodResponseException &&
+        e.errorName == 'org.freedesktop.DBus.Error.UnknownObject',
+  );
+}

--- a/packages/factory_reset_tools/lib/reset_media.dart
+++ b/packages/factory_reset_tools/lib/reset_media.dart
@@ -1,0 +1,396 @@
+import 'dart:io';
+import 'package:async/async.dart';
+import 'package:dbus/dbus.dart';
+import 'package:retry/retry.dart';
+
+const fsuuidFilePathDefault = '/etc/reset_partition_fsuuid';
+
+enum ResetMediaCreationStatus {
+  initializing,
+  copying,
+  finalizing,
+  finished,
+  failed
+}
+
+class ResetMediaCreationProgress {
+  ResetMediaCreationProgress(this.status, this.percent, this.errMsg);
+  final ResetMediaCreationStatus status;
+  final double? percent;
+  final String? errMsg;
+}
+
+class Drive {
+  Drive(this.object);
+  late final DBusRemoteObject object;
+
+  Future<Partition> format() async {
+    final formatTableParams = [
+      const DBusString('gpt'),
+      DBusDict.stringVariant({}),
+    ];
+    await object.callMethod(
+      'org.freedesktop.UDisks2.Block',
+      'Format',
+      formatTableParams,
+    );
+
+    final createPartitionParams = [
+      const DBusUint64(1048576),
+      const DBusUint64(0),
+      const DBusString(''),
+      const DBusString(''),
+      DBusDict.stringVariant({}),
+      const DBusString('vfat'),
+      DBusDict.stringVariant({
+        'label': const DBusString('RESET_MEDIA'),
+      }),
+    ];
+    final response = await object.callMethod(
+      'org.freedesktop.UDisks2.PartitionTable',
+      'CreatePartitionAndFormat',
+      createPartitionParams,
+      replySignature: DBusSignature.objectPath,
+    );
+
+    final objectPath = response.returnValues[0].asObjectPath();
+    final partition = Partition(
+      DBusRemoteObject(
+        DBusClient.system(),
+        name: 'org.freedesktop.UDisks2',
+        path: objectPath,
+      ),
+    );
+    return partition;
+  }
+
+  Future<void> unmountAndRemoveAll() async {
+    final dbusClient = DBusClient.system();
+    try {
+      final partitions = await object.getProperty(
+        'org.freedesktop.UDisks2.PartitionTable',
+        'Partitions',
+        signature: DBusSignature('ao'),
+      );
+      for (final partitionObjectPath in partitions.asObjectPathArray()) {
+        final partition = Partition(
+          DBusRemoteObject(
+            dbusClient,
+            name: 'org.freedesktop.UDisks2',
+            path: partitionObjectPath,
+          ),
+        );
+        try {
+          await partition.unmount();
+        } on DBusErrorException {
+          // Partition might not have filesystem, or is already unmounted
+        }
+        await partition.delete();
+      }
+    } on DBusInvalidArgsException {
+      // partition table might not be in the block device
+    }
+  }
+
+  static Future<Drive> fromDevicePath(String devicePath) async {
+    final dbusClient = DBusClient.system();
+
+    final blockDevicesObject = DBusRemoteObject(
+      dbusClient,
+      name: 'org.freedesktop.UDisks2',
+      path: DBusObjectPath('/org/freedesktop/UDisks2/block_devices'),
+    );
+    final introspect = await blockDevicesObject.introspect();
+
+    // iterate through block devices, to find the reset partition
+    for (final node in introspect.children) {
+      final objectPath =
+          DBusObjectPath('/org/freedesktop/UDisks2/block_devices/${node.name}');
+      final object = DBusRemoteObject(
+        dbusClient,
+        name: 'org.freedesktop.UDisks2',
+        path: objectPath,
+      );
+
+      final dp = await object.getProperty(
+        'org.freedesktop.UDisks2.Block',
+        'Device',
+        signature: DBusSignature('ay'),
+      );
+      final dpString =
+          String.fromCharCodes(dp.asByteArray().where((e) => e != 0), 0, 128);
+
+      if (dpString == devicePath) {
+        return Drive(object);
+      }
+    }
+    throw Exception('cannot find target device');
+  }
+}
+
+class Partition {
+  Partition(this.object);
+  final DBusRemoteObject object;
+  String? _devicePath;
+
+  Future<String> mount() async {
+    final result = await object.callMethod(
+      'org.freedesktop.UDisks2.Filesystem',
+      'Mount',
+      [
+        DBusDict.stringVariant({}),
+      ],
+      replySignature: DBusSignature.string,
+    );
+    final resultPath = result.returnValues[0].asString();
+
+    return resultPath;
+  }
+
+  Future<void> unmount() async {
+    const retryRunner = RetryOptions(maxAttempts: 5);
+    await retryRunner.retry(
+      () => object.callMethod(
+        'org.freedesktop.UDisks2.Filesystem',
+        'Unmount',
+        [DBusDict.stringVariant({})],
+      ),
+      retryIf: (e) =>
+          e is DBusMethodResponseException &&
+          e.errorName == 'org.freedesktop.UDisks2.Error.DeviceBusy',
+    );
+  }
+
+  Future<void> delete() async {
+    await object.callMethod(
+      'org.freedesktop.UDisks2.Partition',
+      'Delete',
+      [
+        DBusDict.stringVariant({}),
+      ],
+    );
+  }
+
+  Future<String> devicePath() async {
+    if (_devicePath != null) {
+      return _devicePath!;
+    }
+    final dp = await object.getProperty(
+      'org.freedesktop.UDisks2.Block',
+      'Device',
+      signature: DBusSignature('ay'),
+    );
+    _devicePath =
+        String.fromCharCodes(dp.asByteArray().where((e) => e != 0), 0, 128);
+    return _devicePath!;
+  }
+
+  Future<String> getMountPoint() async {
+    final mp = await object.getProperty(
+      'org.freedesktop.UDisks2.Filesystem',
+      'MountPoints',
+      signature: DBusSignature('aay'),
+    );
+    final firstMPCString = mp.asArray().first.asByteArray();
+    final mountPoint =
+        String.fromCharCodes(firstMPCString.where((e) => e != 0), 0, 128);
+    return mountPoint;
+  }
+}
+
+Future<Partition> getResetPartition({String? fsuuid}) async {
+  var targetFSUUID = fsuuid ?? '';
+  if (fsuuid == null) {
+    targetFSUUID = await File(fsuuidFilePathDefault).readAsString();
+    targetFSUUID = targetFSUUID.trim();
+  }
+  final dbusClient = DBusClient.system();
+
+  final blockDevicesObject = DBusRemoteObject(
+    dbusClient,
+    name: 'org.freedesktop.UDisks2',
+    path: DBusObjectPath('/org/freedesktop/UDisks2/block_devices'),
+  );
+  final introspect = await blockDevicesObject.introspect();
+
+  // iterate through block devices, to find the reset partition
+  DBusRemoteObject? targetObject;
+  for (final node in introspect.children) {
+    final blockDeviceObjectPath =
+        DBusObjectPath('/org/freedesktop/UDisks2/block_devices/${node.name}');
+    final blockDeviceObject = DBusRemoteObject(
+      dbusClient,
+      name: 'org.freedesktop.UDisks2',
+      path: blockDeviceObjectPath,
+    );
+
+    final fsuuid = await blockDeviceObject.getProperty(
+      'org.freedesktop.UDisks2.Block',
+      'IdUUID',
+      signature: DBusSignature('s'),
+    );
+    if (fsuuid.asString() == targetFSUUID) {
+      targetObject = blockDeviceObject;
+      break;
+    }
+  }
+
+  if (targetObject == null) {
+    throw Exception('reset partition not found');
+  }
+
+  return Partition(targetObject);
+}
+
+Future<int?> getFsUsedSize(String devicePath) async {
+  final process =
+      await Process.run('lsblk', ['-b', '-n', '-o', 'FSUSED', devicePath]);
+  return int.tryParse(process.stdout as String);
+}
+
+Stream<double> copyPercentageUpdate(
+  Partition resetPartition,
+  Partition targetPartition,
+) async* {
+  final total = (await getFsUsedSize(await resetPartition.devicePath()))!;
+  var used = 0;
+  var percent = 0.0;
+  while (true) {
+    used = (await getFsUsedSize(await targetPartition.devicePath())) ?? used;
+    final newPercent = used / total;
+    if (newPercent > 1) {
+      percent = 1;
+    } else if (newPercent > percent) {
+      percent = newPercent;
+    }
+    yield percent;
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+}
+
+Stream<ResetMediaCreationProgress> copyAsyncJob(
+  Partition resetPartition,
+  Partition targetPartition,
+  String rpPath,
+  String targetPath, {
+  bool rpUnmount = true,
+}) async* {
+  yield ResetMediaCreationProgress(
+    ResetMediaCreationStatus.copying,
+    null,
+    null,
+  );
+
+  var result = await Process.start(
+    'rsync',
+    ['-a', '--no-links', '$rpPath/', targetPath],
+  );
+  final exitCode = await result.exitCode;
+  if (exitCode != 0) {
+    yield ResetMediaCreationProgress(
+      ResetMediaCreationStatus.failed,
+      null,
+      'failed to copy files',
+    );
+  }
+
+  yield ResetMediaCreationProgress(
+    ResetMediaCreationStatus.finalizing,
+    null,
+    null,
+  );
+
+  result = await Process.start(
+    '/bin/bash',
+    ['$targetPath/cloud-configs/on-create-media.sh', targetPath],
+  );
+  if (exitCode != 0) {
+    yield ResetMediaCreationProgress(
+      ResetMediaCreationStatus.failed,
+      null,
+      'failed to run script after media creation',
+    );
+  }
+  try {
+    if (rpUnmount) {
+      await resetPartition.unmount();
+    }
+    await targetPartition.unmount();
+    // ignore: avoid_catches_without_on_clauses
+  } catch (e) {
+    yield ResetMediaCreationProgress(
+      ResetMediaCreationStatus.failed,
+      null,
+      'failed to unmount: $e',
+    );
+  }
+
+  yield ResetMediaCreationProgress(
+    ResetMediaCreationStatus.finished,
+    null,
+    null,
+  );
+}
+
+Stream<ResetMediaCreationProgress> createResetMedia(
+  String targetDevicePath, {
+  String? fsuuid,
+}) async* {
+  var progress = ResetMediaCreationProgress(
+    ResetMediaCreationStatus.initializing,
+    null,
+    null,
+  );
+  yield progress;
+
+  final tmpDir = Directory('/tmp').createTempSync('reset-media-');
+
+  tmpDir.deleteSync();
+
+  final resetPartition = await getResetPartition(fsuuid: fsuuid);
+  String rpPath;
+  var rpUnmount = true;
+  try {
+    rpPath = await resetPartition.mount();
+  } on DBusMethodResponseException catch (e) {
+    if (e.errorName == 'org.freedesktop.UDisks2.Error.AlreadyMounted') {
+      rpUnmount = false;
+      rpPath = await resetPartition.getMountPoint();
+    } else {
+      rethrow;
+    }
+  }
+
+  final targetDrive = await Drive.fromDevicePath(targetDevicePath);
+  await targetDrive.unmountAndRemoveAll();
+  final targetPartition = await targetDrive.format();
+  final targetPath = await targetPartition.mount();
+
+  final copyJob = copyAsyncJob(
+    resetPartition,
+    targetPartition,
+    rpPath,
+    targetPath,
+    rpUnmount: rpUnmount,
+  );
+  final copyPercentage = copyPercentageUpdate(resetPartition, targetPartition);
+  final mergedStreams = StreamGroup.merge([copyJob, copyPercentage]);
+
+  await for (final r in mergedStreams) {
+    if (r is double) {
+      // copyPercentage
+      progress =
+          ResetMediaCreationProgress(progress.status, r, progress.errMsg);
+      yield progress;
+    } else if (r is ResetMediaCreationProgress) {
+      // copyJob
+      progress =
+          ResetMediaCreationProgress(r.status, progress.percent, r.errMsg);
+      yield progress;
+      if (r.status == ResetMediaCreationStatus.finished ||
+          r.status == ResetMediaCreationStatus.failed) {
+        break;
+      }
+    }
+  }
+}

--- a/packages/factory_reset_tools/linux/.gitignore
+++ b/packages/factory_reset_tools/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/packages/factory_reset_tools/linux/CMakeLists.txt
+++ b/packages/factory_reset_tools/linux/CMakeLists.txt
@@ -1,0 +1,145 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.10)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "factory-reset-tools")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+	set(APPLICATION_ID "com.canonical.oem.factory-reset-tools")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Define the application target. To change its name, change BINARY_NAME above,
+# not the value here, or `flutter run` will no longer work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/packages/factory_reset_tools/linux/flutter/CMakeLists.txt
+++ b/packages/factory_reset_tools/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/packages/factory_reset_tools/linux/main.cc
+++ b/packages/factory_reset_tools/linux/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/packages/factory_reset_tools/linux/my_application.cc
+++ b/packages/factory_reset_tools/linux/my_application.cc
@@ -1,0 +1,124 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "factory_reset_tool");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "factory_reset_tool");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+  gtk_widget_show(GTK_WIDGET(window));
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application, gchar*** arguments, int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+     g_warning("Failed to register: %s", error->message);
+     *exit_status = 1;
+     return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  //MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  //MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line = my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID,
+                                     "flags", G_APPLICATION_NON_UNIQUE,
+                                     nullptr));
+}

--- a/packages/factory_reset_tools/linux/my_application.h
+++ b/packages/factory_reset_tools/linux/my_application.h
@@ -1,0 +1,18 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/packages/factory_reset_tools/pubspec.yaml
+++ b/packages/factory_reset_tools/pubspec.yaml
@@ -1,0 +1,31 @@
+name: factory_reset_tools
+description: "Tools for preinstalled systems for creating Reset Media and to reboot into a Reset Partition"
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+version: 1.0.0+1
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  args: ^2.4.2
+  async: ^2.11.0
+  dbus: ^0.7.10
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  flutter_riverpod: ^2.5.1
+  intl: ^0.18.1
+  retry: ^3.1.2
+  ubuntu_localizations: ^0.3.5
+  ubuntu_wizard: ^0.1.0
+  yaml: ^3.1.2
+  yaru: 4.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  ubuntu_lints: ^0.3.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
This moves over the [factory_reset_tools](https://github.com/canonical/factory-reset-tools) project to the monorepo and makes it adhere to the standards set for the monorepo.

A branch also needs to be created for the snap directory.