### PR TITLE
fix(bootstrap): reset storage model when going back

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
@@ -42,15 +42,12 @@ class GuidedReformatPage extends ConsumerWidget {
       title:
           lang.guidedStoragePageHeader(ref.watch(flavorProvider).displayName),
       bottomBar: WizardBar(
-        leading: const BackWizardButton(),
+        // If the user returns back to select another disk or another method,
+        // the previously configured guided storage must be reset to avoid
+        // multiple disks being configured for guided partitioning.
+        leading: BackWizardButton(onBack: model.resetGuidedStorage),
         trailing: [
-          NextWizardButton(
-            onNext: model.saveGuidedStorage,
-            // If the user returns back to select another disk, the previously
-            // configured guided storage must be reset to avoid multiple disks
-            // being configured for guided partitioning.
-            onExecute: model.resetGuidedStorage,
-          ),
+          NextWizardButton(onNext: model.saveGuidedStorage),
         ],
       ),
       children: <Widget>[

--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
@@ -49,11 +49,13 @@ class GuidedResizePage extends ConsumerWidget {
       title:
           lang.guidedStoragePageHeader(ref.watch(flavorProvider).displayName),
       bottomBar: WizardBar(
-        leading: const BackWizardButton(),
+        // If the user returns back to select another disk or another method,
+        // the previously configured guided storage must be reset to avoid
+        // multiple disks being configured for guided partitioning.
+        leading: BackWizardButton(onBack: model.reset),
         trailing: [
           NextWizardButton(
             onNext: model.selectedStorage != null ? model.save : null,
-            onExecute: model.reset,
           ),
         ],
       ),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
@@ -90,7 +90,10 @@ class _ManualStoragePageState extends ConsumerState<ManualStoragePage> {
         ],
       ),
       bottomBar: WizardBar(
-        leading: const BackWizardButton(),
+        // If the user returns back to select another disk or another method,
+        // the previously configured guided storage must be reset to avoid
+        // multiple disks being configured for guided partitioning.
+        leading: BackWizardButton(onBack: model.resetStorage),
         trailing: [
           NextWizardButton(
             enabled: model.isValid,

--- a/packages/ubuntu_bootstrap/test/storage/guided_reformat/guided_reformat_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/guided_reformat/guided_reformat_page_test.dart
@@ -10,6 +10,7 @@ import 'package:ubuntu_localizations/ubuntu_localizations.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
 import 'test_guided_reformat.dart';
 
@@ -106,5 +107,16 @@ void main() {
 
     await tester.tapNext();
     verify(model.saveGuidedStorage()).called(1);
+  });
+
+  testWidgets('reset when going back', (tester) async {
+    final model = buildGuidedReformatModel();
+    await tester.pumpApp((_) => buildPage(model));
+
+    final backButton = find.byType(BackWizardButton);
+    expect(backButton, findsOneWidget);
+    await tester.widget<BackWizardButton>(backButton).onBack!();
+
+    verify(model.resetGuidedStorage()).called(1);
   });
 }

--- a/packages/ubuntu_bootstrap/test/storage/guided_resize/guided_resize_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/guided_resize/guided_resize_page_test.dart
@@ -11,6 +11,7 @@ import 'package:ubuntu_bootstrap/pages/storage/guided_resize/guided_resize_page.
 import 'package:ubuntu_provision/providers.dart';
 import 'package:ubuntu_provision/services.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
 import 'guided_resize_model_test.dart';
 import 'test_guided_resize.dart';
@@ -154,5 +155,16 @@ void main() {
       find.text(l10n.installationTypeAlongsideMulti('Ubuntu 22.10')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('reset when going back', (tester) async {
+    final model = buildGuidedResizeModel();
+    await tester.pumpApp((_) => buildPage(model));
+
+    final backButton = find.byType(BackWizardButton);
+    expect(backButton, findsOneWidget);
+    await tester.widget<BackWizardButton>(backButton).onBack!();
+
+    verify(model.reset()).called(1);
   });
 }

--- a/packages/ubuntu_bootstrap/test/storage/manual/manual_storage_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/manual/manual_storage_page_test.dart
@@ -12,6 +12,7 @@ import 'package:ubuntu_bootstrap/pages/storage/manual/storage_types.dart';
 import 'package:ubuntu_bootstrap/services.dart';
 import 'package:ubuntu_provision/services.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
+import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/icons.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -322,5 +323,16 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('reset when going back', (tester) async {
+    final model = buildManualStorageModel();
+    await tester.pumpApp((_) => buildPage(model));
+
+    final backButton = find.byType(BackWizardButton);
+    expect(backButton, findsOneWidget);
+    await tester.widget<BackWizardButton>(backButton).onBack!();
+
+    verify(model.resetStorage()).called(1);
   });
 }


### PR DESCRIPTION
This ensures that the storage model is reset if the user decides to go back in the flow and select a different option.

The necessary callback was already present but somehow ended up in the *next* button (probably when we switched from the abstract "wizard actions" to buttons in https://github.com/canonical/ubuntu-desktop-installer/pull/1954).
I've moved them into the back buttons and added corresponding tests.