### PR TITLE
fix(bootstrap): reset storage model when navigating back

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
@@ -49,7 +49,7 @@ class GuidedReformatPage extends ConsumerWidget {
             // If the user returns back to select another disk, the previously
             // configured guided storage must be reset to avoid multiple disks
             // being configured for guided partitioning.
-            onExecute: model.resetGuidedStorage,
+            onReturn: model.resetGuidedStorage,
           ),
         ],
       ),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
@@ -53,7 +53,7 @@ class GuidedResizePage extends ConsumerWidget {
         trailing: [
           NextWizardButton(
             onNext: model.selectedStorage != null ? model.save : null,
-            onExecute: model.reset,
+            onReturn: model.reset,
           ),
         ],
       ),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
@@ -95,6 +95,7 @@ class _ManualStoragePageState extends ConsumerState<ManualStoragePage> {
           NextWizardButton(
             enabled: model.isValid,
             onNext: model.setStorage,
+            onReturn: model.resetStorage,
           ),
         ],
       ),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
@@ -32,7 +32,7 @@ class PassphrasePage extends ConsumerWidget {
             enabled: ref.watch(
                 passphraseModelProvider.select((model) => model.isValid)),
             onNext: ref.read(passphraseModelProvider).savePassphrase,
-            onExecute: ref.read(passphraseModelProvider).loadPassphrase,
+            onReturn: ref.read(passphraseModelProvider).loadPassphrase,
           ),
         ],
       ),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -52,15 +52,22 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: lang.installationTypeTitle,
       title: lang.installationTypeHeader(flavor.displayName),
-      isNextEnabled: model.canEraseDisk ||
-          model.canInstallAlongside ||
-          model.canManualPartition,
-      nextArguments: model.type,
-      onNext: model.save,
-      // If the user returns back to select another installation type, the
-      // previously configured storage must be reset to make all guided
-      // partitioning targets available.
-      onBack: model.resetStorage,
+      bottomBar: WizardBar(
+        leading: const BackWizardButton(),
+        trailing: [
+          NextWizardButton(
+            onNext: model.save,
+            enabled: model.canEraseDisk ||
+                model.canInstallAlongside ||
+                model.canManualPartition,
+            arguments: model.type,
+            // If the user returns back to select another installation type, the
+            // previously configured storage must be reset to make all guided
+            // partitioning targets available.
+            onReturn: model.resetStorage,
+          ),
+        ],
+      ),
       children: [
         if (model.canInstallAlongside || model.hasBitLocker)
           _InstallationTypeTile(

--- a/packages/ubuntu_bootstrap/test/storage/storage_page_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_page_test.dart
@@ -488,6 +488,17 @@ void main() {
     await tester.tapNext();
     verify(model.save()).called(1);
   });
+
+  testWidgets('reset storage on return', (tester) async {
+    final model = buildStorageModel();
+    await tester.pumpApp((_) => buildPage(model));
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
+    await tester.tapBack();
+    await tester.pumpAndSettle();
+    verify(model.resetStorage()).called(1);
+  });
 }
 
 extension on CommonFinders {

--- a/packages/ubuntu_bootstrap/test/test_utils.dart
+++ b/packages/ubuntu_bootstrap/test/test_utils.dart
@@ -39,7 +39,12 @@ extension WidgetTesterX on WidgetTester {
             onNext: (settings) => '/next',
           ),
           '/next': WizardRoute(
-            builder: (_) => const Text('Next page'),
+            builder: (_) => const Row(
+              children: [
+                Text('Next page'),
+                BackWizardButton(),
+              ],
+            ),
           ),
         },
       ),

--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -54,7 +54,7 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
             // suspend network activity when proceeding on the next page
             onNext: model.cleanup,
             // resume network activity if/when returning back to this page
-            onExecute: model.init,
+            onReturn: model.init,
           ),
         ],
       ),

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -12,7 +12,6 @@ class HorizontalPage extends ConsumerWidget {
     required this.title,
     required this.children,
     this.onNext,
-    this.onBack,
     this.nextArguments,
     this.trailingTitleWidget,
     this.isNextEnabled = true,
@@ -31,6 +30,12 @@ class HorizontalPage extends ConsumerWidget {
           !managedScrolling || contentFlex == null,
           'contentFlex has no effect unless managedScrolling is set to false.',
         ),
+        assert(
+            (bottomBar == null) ||
+                (onNext == null &&
+                    nextArguments == null &&
+                    isNextEnabled == true),
+            'either provide a custom `bottomBar` or use the `onNext`, `nextArguments`, and `isNextEnabled` properties.'),
         _contentFlex = contentFlex ?? 1;
 
   /// The title for the title bar.
@@ -47,9 +52,6 @@ class HorizontalPage extends ConsumerWidget {
 
   /// A callback for when the user presses the "Next" button.
   final FutureOr<void> Function()? onNext;
-
-  /// A callback for when the user presses the "Back" button.
-  final FutureOr<void> Function()? onBack;
 
   /// Arguments passed along to the [NextWizardButton].
   final Object? nextArguments;

--- a/packages/ubuntu_wizard/lib/src/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_button.dart
@@ -218,7 +218,7 @@ class NextWizardButton extends StatelessWidget {
     this.highlighted = false,
     this.arguments,
     this.onNext,
-    this.onExecute,
+    this.onReturn,
   });
 
   final String? label;
@@ -228,7 +228,10 @@ class NextWizardButton extends StatelessWidget {
   final bool highlighted;
   final Object? arguments;
   final WizardCallback? onNext;
-  final WizardCallback? onExecute;
+
+  /// Called when returning to the current route after navigating to the next one.
+  /// (e.g. when pressing the back button on the next page)
+  final WizardCallback? onReturn;
 
   @override
   Widget build(BuildContext context) {
@@ -267,7 +270,7 @@ class NextWizardButton extends StatelessWidget {
               await rootWizard?.next(arguments: arguments);
             }
           }
-          onExecute?.call();
+          onReturn?.call();
         },
       ),
     );


### PR DESCRIPTION
This ensures that the storage model is reset if the user decides to go back in the flow and select a different option.

I've tried to clarify the meaning of `NextWizardButton`'s `onReturn` parameter (which was previously called `onExecute` and `onBack` before that). We should definitely spend some time on refactoring `ubuntu_wizard` in the future, since some of the mechanisms involved are quite tricky and hard to understand.

Another issue is that there are multiple ways of modifying the behavior of the buttons in the bottom bar of the new `HorizontalPage`: either by overriding the entire `bottomBar` or by passing arguments such as `isNextEnabled` that modify the *default* bar. I've added an assertion to assure that those parameters aren't specified at the same time. I'd rather remove one of those options in the future, though.