### PR TITLE
fix: Scroll of HorizontalPage should be primary

### DIFF
--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -118,18 +118,22 @@ class HorizontalPage extends ConsumerWidget {
                     flex: managedScrolling ? 1 : _contentFlex,
                     child: managedScrolling
                         ? Center(
-                            child: SingleChildScrollView(
-                              padding: hoverPadding +
-                                  EdgeInsets.only(right: scrollBarPadding),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  _Headline(
-                                    title: title,
-                                    trailingTitleWidget: trailingTitleWidget,
-                                  ),
-                                  ...children,
-                                ],
+                            child: Scrollbar(
+                              thumbVisibility: true,
+                              child: SingleChildScrollView(
+                                primary: true,
+                                padding: hoverPadding +
+                                    EdgeInsets.only(right: scrollBarPadding),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    _Headline(
+                                      title: title,
+                                      trailingTitleWidget: trailingTitleWidget,
+                                    ),
+                                    ...children,
+                                  ],
+                                ),
                               ),
                             ),
                           )


### PR DESCRIPTION
Also makes sure that the scrollbar is visible when there is content to scroll