### PR TITLE
feat(bootstrap): don't check for updates in `_initInstallerApp`

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -254,7 +254,6 @@ Future<void> _initInstallerApp(Endpoint endpoint) async {
   final services = [
     getService<InstallerService>().init(),
     tryGetService<DesktopService>()?.inhibit() ?? Future.value(),
-    getService<RefreshService>().check(),
     getService<PageConfigService>().load(),
     geo.init(),
     telemetry.init({

--- a/packages/ubuntu_bootstrap/lib/installer/installer_model.dart
+++ b/packages/ubuntu_bootstrap/lib/installer/installer_model.dart
@@ -10,30 +10,23 @@ final restartProvider = StateProvider((_) => 0);
 final installerModelProvider = ChangeNotifierProvider.autoDispose(
   (_) => InstallerModel(
     getService<InstallerService>(),
-    getService<RefreshService>(),
   ),
 );
 
 class InstallerModel extends SafeChangeNotifier {
-  InstallerModel(this._installer, this._refresh);
+  InstallerModel(this._installer);
 
   final InstallerService _installer;
-  final RefreshService _refresh;
 
   ApplicationStatus? _status;
   StreamSubscription<ApplicationStatus?>? _statusChange;
-  StreamSubscription<RefreshState>? _refreshChange;
 
   ApplicationStatus? get status => _status;
   bool get isInstalling => status?.isInstalling ?? false;
-  bool get isRefreshing => _refresh.state.busy;
 
   Future<void> init() async {
     _statusChange = _installer.monitorStatus().listen((status) {
       _status = status;
-      notifyListeners();
-    });
-    _refreshChange = _refresh.stateChanged.listen((_) {
       notifyListeners();
     });
   }
@@ -44,8 +37,6 @@ class InstallerModel extends SafeChangeNotifier {
   Future<void> dispose() async {
     await _statusChange?.cancel();
     _statusChange = null;
-    await _refreshChange?.cancel();
-    _refreshChange = null;
     super.dispose();
   }
 }

--- a/packages/ubuntu_bootstrap/test/installer_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_model_test.dart
@@ -6,32 +6,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_bootstrap/installer/installer_model.dart';
-import 'package:ubuntu_bootstrap/services/refresh_service.dart';
 
 import 'test_utils.dart';
 
 void main() {
   test('init', () async {
     final statusController = StreamController<ApplicationStatus>();
-    final refreshController = StreamController<RefreshState>();
 
     final installer = MockInstallerService();
     when(installer.monitorStatus()).thenAnswer((_) => statusController.stream);
 
-    final refresh = MockRefreshService();
-    when(refresh.state).thenReturn(const RefreshState.checking());
-    when(refresh.stateChanged).thenAnswer((_) => refreshController.stream);
-
-    final model = InstallerModel(installer, refresh);
+    final model = InstallerModel(installer);
     await model.init();
     verify(installer.monitorStatus()).called(1);
     expect(statusController.hasListener, isTrue);
-    verify(refresh.stateChanged).called(1);
-    expect(refreshController.hasListener, isTrue);
 
     await model.dispose();
     expect(statusController.hasListener, isFalse);
-    expect(refreshController.hasListener, isFalse);
   });
 
   test('has route', () async {
@@ -39,7 +30,7 @@ void main() {
     when(installer.hasRoute('a')).thenReturn(true);
     when(installer.hasRoute('b')).thenReturn(false);
 
-    final model = InstallerModel(installer, MockRefreshService());
+    final model = InstallerModel(installer);
 
     expect(model.hasRoute('a'), isTrue);
     expect(model.hasRoute('b'), isFalse);


### PR DESCRIPTION
This is a follow-up to #589, also concerning the delay during subiquity's startup.
As Olivier pointed out [here](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2056160/comments/9), we're currently checking for snap updates before launching the installer wizard. If there's no network connection at this point, the blocking call takes 30 seconds to time out.
I think the simplest solution is to remove that call from there entirely, as it is done [later on](https://github.com/canonical/ubuntu-desktop-provision/blob/c7967e539a90ddad181dbdb1456fd51cb092fa44/packages/ubuntu_bootstrap/lib/pages/refresh/refresh_model.dart#L24) anyways.

~~Even though the refresh page is shown after the network page, the user could still choose not to connect to the internet, so I added a connectivity check to the refresh page's `load()` function - skipping it in case there's no connection.~~