### PR TITLE
C include path fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,6 @@ jobs:
             docker run --rm --platform linux/arm64 -v $(pwd):/workspace -w /workspace/provd ubuntu:noble bash -c "
               apt-get update &&
               apt-get install -y libgtk-3-dev libglib2.0-dev debhelper dh-golang golang-go &&
-              export C_INCLUDE_PATH=/usr/lib/aarch64-linux-gnu/glib-2.0/include/:$C_INCLUDE_PATH &&
               dpkg-buildpackage -us -uc -b &&
               mv ../provd_*.deb ../provd-${{ matrix.platform }}.deb
             "

--- a/provd/debian/changelog
+++ b/provd/debian/changelog
@@ -1,3 +1,9 @@
+provd (0.1.1) noble; urgency=medium
+
+  * Fixed non-amd64 builds failing from missing header file.
+
+ -- Matthew Gary Hagemann <matt.hagemann@canonical.com>  Tue, 09 Apr 2024 11:30:05 +0200
+
 provd (0.1.0) noble; urgency=medium
 
   * Initial release.

--- a/provd/internal/services/user/password_hash.go
+++ b/provd/internal/services/user/password_hash.go
@@ -2,7 +2,7 @@
 package user
 
 /*
-#cgo CFLAGS: -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include
+#cgo pkg-config: glib-2.0
 #cgo LDFLAGS: -lcrypt -lglib-2.0
 #include "password_hash.h"
 */


### PR DESCRIPTION
All the non-amd64 builds are failing on LP from the following error:
```
/usr/include/glib-2.0/glib/gtypes.h:34:10: fatal error: glibconfig.h: No such file or directory
   34 | #include <glibconfig.h>
      |          ^~~~~~~~~~~~~~
```
I've added a pkg-config line to fix this in all archs

packaging building on all on lp:
https://launchpad.net/~matt-hagemann/+archive/ubuntu/provd/+packages

closes #599 