### PR TITLE
fix: Move validate button to next button placement

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_page.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/autoinstall/autoinstall_model.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
+import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaru/yaru.dart';
@@ -21,17 +22,19 @@ class AutoinstallPage extends ConsumerWidget with ProvisioningPage {
     final lang = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(autoinstallModelProvider);
     final flavor = ref.watch(flavorProvider);
+
     return HorizontalPage(
       windowTitle: lang.autoinstallTitle,
       title: lang.autoinstallHeader(flavor.displayName),
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
         trailing: [
-          WizardButton(
-            visible: !model.autoinstall,
-            label: UbuntuLocalizations.of(context).nextLabel,
-            onActivated: Wizard.of(context).next,
-          )
+          model.autoinstall
+              ? _ValidateButton(model: model)
+              : WizardButton(
+                  label: UbuntuLocalizations.of(context).nextLabel,
+                  onActivated: Wizard.of(context).next,
+                ),
         ],
       ),
       children: [
@@ -86,32 +89,47 @@ class AutoinstallPage extends ConsumerWidget with ProvisioningPage {
                       orElse: () => null,
                     ),
                   ),
-                  const SizedBox(height: kWizardSpacing),
-                  ElevatedButton(
-                    onPressed: model.apply,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (model.state.isLoading) ...[
-                          SizedBox.square(
-                            dimension: 16.0,
-                            child: YaruCircularProgressIndicator(
-                              color: Theme.of(context).colorScheme.onPrimary,
-                              strokeWidth: 2,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                        ],
-                        Text(lang.validate),
-                      ],
-                    ),
-                  ),
                 ],
               ),
             ),
           ),
         ),
       ],
+    );
+  }
+}
+
+class _ValidateButton extends StatelessWidget {
+  const _ValidateButton({required this.model});
+
+  final AutoinstallModel model;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final lang = UbuntuBootstrapLocalizations.of(context);
+
+    return ElevatedButton(
+      style: theme.elevatedButtonTheme.style?.copyWith(
+        minimumSize: MaterialStateProperty.all(kPushButtonSize),
+      ),
+      onPressed: model.apply,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (model.state.isLoading) ...[
+            SizedBox.square(
+              dimension: 16.0,
+              child: YaruCircularProgressIndicator(
+                color: Theme.of(context).colorScheme.onPrimary,
+                strokeWidth: 2,
+              ),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Text(lang.validate),
+        ],
+      ),
     );
   }
 }

--- a/packages/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_page.dart
@@ -113,7 +113,7 @@ class _ValidateButton extends StatelessWidget {
       style: theme.elevatedButtonTheme.style?.copyWith(
         minimumSize: MaterialStateProperty.all(kPushButtonSize),
       ),
-      onPressed: model.apply,
+      onPressed: model.url.isNotEmpty ? model.apply : null,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [


### PR DESCRIPTION
Previously:
![Screenshot from 2024-04-08 14-52-51](https://github.com/canonical/ubuntu-desktop-provision/assets/744771/d22564d7-05df-426c-b59d-671c3a6a5116)

Now:
![Screenshot from 2024-04-08 15-05-33](https://github.com/canonical/ubuntu-desktop-provision/assets/744771/826155a2-c5fd-4346-b4e8-bef7affcd499)
