### PR TITLE
docs: add link to weblate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ These are mostly guidelines, not rules. Use your best judgment, and feel free to
   - [Code of Conduct](#code-of-conduct)
   - [Getting Started](#getting-started)
     - [Pull Requests](#pull-requests)
+  - [Translations](#translations)
   - [Contributing to the code](#contributing-to-the-code)
     - [Required dependencies](#required-dependencies)
     - [Building and running the binaries](#building-and-running-the-binaries)
@@ -48,6 +49,10 @@ In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susa
 1. Open a PR in our repository and follow the PR template so that we can efficiently review the changes.
 
 PRs will trigger unit and integration tests with and without race detection, linting and formatting validations, static and security checks, freshness of generated files verification. All the tests must pass before merging in main branch.
+
+## Translations
+
+Translations are managed using [Weblate](https://hosted.weblate.org/projects/ubuntu-desktop-translations/)
 
 ## Contributing to the code
 

--- a/README.md
+++ b/README.md
@@ -140,10 +140,6 @@ The UI is written in [Flutter](https://flutter.dev/) and consists of multiple Da
 
 TODO
 
-## Translations
-
-TODO
-
 ## Contributing
 
 See our [contributor guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
Due to weblate's quirks there are a bunch of different components linked to this repository. Is it enough to just link to the ubuntu-desktop-translations project?