### PR TITLE
Fix: flaky TestQuit on arm

### DIFF
--- a/provd/internal/daemon/daemon_test.go
+++ b/provd/internal/daemon/daemon_test.go
@@ -247,7 +247,7 @@ func TestQuit(t *testing.T) {
 			}()
 
 			// make sure Serve() is called. Even std golang grpc has this timeout in tests
-			time.Sleep(time.Millisecond * 10)
+			time.Sleep(time.Millisecond * 1000)
 
 			var disconnectClient func()
 			if tc.activeConnection {
@@ -264,7 +264,7 @@ func TestQuit(t *testing.T) {
 				d.Quit(context.Background(), tc.force)
 			}()
 
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 
 			// Any new connection is disallowed
 			connected, _ := createClientConnection(t, socketPath)
@@ -308,14 +308,14 @@ func createClientConnection(t *testing.T, socketPath string) (success bool, disc
 	}()
 	select {
 	case <-connected:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(1000 * time.Millisecond):
 		return false, func() {}
 	}
 
 	ctx, disconnect := context.WithCancel(context.Background())
 	client := grpctestservice.NewTestServiceClient(conn)
 	go func() { _, _ = client.Blocking(ctx, &grpctestservice.Empty{}) }()
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 
 	return true, disconnect
 }


### PR DESCRIPTION
closes #610 

These time increases seemed to help solve the problem on the runners :crossed_fingers: 