### PR TITLE
fix: set GIO_MODULE_DIR to the local directory also for subiquity

### DIFF
--- a/ci/snap/bootstrap/snapcraft.yaml
+++ b/ci/snap/bootstrap/snapcraft.yaml
@@ -17,6 +17,7 @@ apps:
     daemon: simple
     restart-condition: always
     environment:
+      GIO_MODULE_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gio/modules
       PATH_ORIG: $PATH
       PYTHONPATH_ORIG: $PYTHONPATH
       LD_LIBRARY_PATH_ORIG: $LD_LIBRARY_PATH


### PR DESCRIPTION
it is needed because the service calls to gsettings to set the keyboard layout and since the snap is classic without the environment set it will try to load the system's libdconfsettings.so which errors out because the noble version depends on a newer libglib that snap one

https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2060387