### PR TITLE
feat(bootstrap): don't reboot after failed installation

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -230,7 +230,7 @@ class _InstallerApp extends ConsumerWidget {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const LoadingPage();
               } else if (snapshot.hasError) {
-                return const ErrorPage(allowRestart: true);
+                return const ErrorPage(allowRestart: false);
               }
               return InstallerWizard(key: ValueKey(ref.watch(restartProvider)));
             }),

--- a/packages/ubuntu_bootstrap/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_bootstrap/lib/installer/installer_wizard.dart
@@ -77,7 +77,7 @@ class _InstallWizard extends ConsumerWidget {
           onLoad: (_) => const InstallPage().load(context, ref),
         ),
         InstallationStep.error.route: WizardRoute(
-          builder: (_) => const ErrorPage(allowRestart: true),
+          builder: (_) => const ErrorPage(allowRestart: false),
         ),
       },
       predicate: (route) {
@@ -137,7 +137,7 @@ class _AutoinstallWizard extends ConsumerWidget {
           onLoad: (_) => const InstallPage().load(context, ref),
         ),
         InstallationStep.error.route: WizardRoute(
-          builder: (_) => const ErrorPage(allowRestart: true),
+          builder: (_) => const ErrorPage(allowRestart: false),
         ),
       },
     );
@@ -152,7 +152,7 @@ class _ErrorWizard extends StatelessWidget {
     return Wizard(
       routes: <String, WizardRoute>{
         InstallationStep.error.route: WizardRoute(
-          builder: (_) => const ErrorPage(allowRestart: true),
+          builder: (_) => const ErrorPage(allowRestart: false),
         ),
       },
     );


### PR DESCRIPTION
The generic error page currently relies on subiquity to restart the machine. Depending on the cause of the installation failure, subiquity might not be able to receive requests anymore, though. Let's show a 'close' button instead, and let the user take care of a reboot themselves, if they decide to follow the hint shown on the page.

https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2060749