### PR TITLE
provd: resolve build issues when using sbuild

### DIFF
--- a/provd/debian/control
+++ b/provd/debian/control
@@ -9,6 +9,7 @@ Build-Depends: debhelper-compat (= 13),
                libgtk-3-dev,
                dbus,
                gsettings-desktop-schemas,
+               ca-certificates,
 Standards-Version: 4.6.2.0
 XS-Go-Import-Path: github.com/canonical/ubuntu-desktop-provision/provd
 Homepage: https://github.com/canonical/ubuntu-desktop-provision/tree/main/provd

--- a/provd/debian/rules
+++ b/provd/debian/rules
@@ -11,11 +11,17 @@ export DEB_BUILD_MAINT_OPTIONS := optimize=-lto
 # as long as it matches the go.mod go stenza which is the language requirement.
 export GOTOOLCHAIN := local
 
+# Set GOCACHE and GOMODCACHE in the build dir instead of home directory, which
+# may not be writable in sbuild.
+export GOCACHE=$(CURDIR)/.gocache
+export GOMODCACHE=$(CURDIR)/.gomodcache
+
 %:
 	dh $@ --buildsystem=golang --with=golang
 
 execute_after_dh_auto_clean:
 	# Create the vendor directory when building the source package
+	rm -rf $(GOCACHE) $(GOMODCACHE)
 	[ -d vendor/ ] || go mod vendor
 
 override_dh_auto_install:


### PR DESCRIPTION
Tried using sbuild to build provd, found it is using home directory as cache which sbuild does not allow.

I followed patch similar to https://bugs.launchpad.net/ubuntu/+source/calamares-settings-ubuntu/+bug/2060151 so that GOCACHE and GOMODCACHE does not use home directory.

Also, ca-certificates is not part of sbuild chroot, so it is added to Build-Depends as well.