### PR TITLE
provd: avoid chown to gnome-initial-setup group

### DIFF
--- a/provd/debian/provd.postinst
+++ b/provd/debian/provd.postinst
@@ -5,12 +5,12 @@ set -e
 case "$1" in
     configure)
         # Set ownership and permissions for launch-desktop-provision-init.sh
-        chown gnome-initial-setup:gnome-initial-setup /usr/libexec/launch-desktop-provision-init
+        chown gnome-initial-setup:root /usr/libexec/launch-desktop-provision-init
         chmod 750 /usr/libexec/launch-desktop-provision-init
 
         # Set ownership and permissions for bin's
-        chown root:gnome-initial-setup /usr/libexec/sprovd
-        chown root:gnome-initial-setup /usr/libexec/provd
+        chown root:root /usr/libexec/sprovd
+        chown root:root /usr/libexec/provd
         chmod u+s /usr/libexec/sprovd
         ;;
 esac


### PR DESCRIPTION
Although gnome-initial-setup user is created in postinst, gnome-initial-setup group only exists when the installed environment has been run once (I did not find out who created it, but it might be gdm3, not sure.)

This patchset avoids chown to gnome-initial-setup group so the installation can be done in livecd-rootfs.