### PR TITLE
fix: Use flavor name in slides

### DIFF
--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_am_ET.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ar_EG.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_be_BY.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_bg_BG.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_bn_BD.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_bo_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_bs_BA.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ca_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_cs_CZ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_cy_GB.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_da_DK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_de_DE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_dz_BT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_el_GR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_en_US.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_eo_AQ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_es_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_et_EE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_eu_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_fa_IR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_fi_FI.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_fr_FR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ga_IE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_gl_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_gu_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_he_IL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_hi_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_hr_HR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_hu_HU.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_id_ID.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_is_IS.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_it_IT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ja_JP.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ka_GE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_kk_KZ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_km_KH.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_kn_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ko_KR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ku_TR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_lo_LA.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_lt_LT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_lv_LV.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_mk_MK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ml_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_mr_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_my_MM.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_nb_NO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ne_NP.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_nl_NL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_nn_NO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_oc_FR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_pa_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_pl_PL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_pt_BR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_pt_PT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ro_RO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ru_RU.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_se_NO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_si_LK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_sk_SK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_sl_SI.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_sq_AL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_sr_RS.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_sv_SE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ta_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_te_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_tg_TJ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_th_TH.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_tl_PH.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_tr_TR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_ug_CN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_uk_UA.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_vi_VN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_zh_CN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/2/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/2/slide_zh_TW.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">All the applications you need</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Install, manage and update all your apps in Ubuntu Software, including thousands of applications from both the Snap Store and the Ubuntu archive.</p>
+          <p class="spacing">Install, manage and update all your apps in the App Center, including thousands of applications from both the Snap Store and the {{ DISTRO }} archive.</p>
           <img class="icon" src="../icons/spotify.png" />
           <p class="pad-right">Spotify</p>
           <img class="icon" src="../icons/shotcut.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_am_ET.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ar_EG.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_be_BY.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_bg_BG.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_bn_BD.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_bo_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_bs_BA.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ca_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_cs_CZ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_cy_GB.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_da_DK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_de_DE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_dz_BT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_el_GR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_en_US.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_eo_AQ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_es_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_et_EE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_eu_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_fa_IR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_fi_FI.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_fr_FR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ga_IE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_gl_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_gu_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_he_IL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_hi_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_hr_HR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_hu_HU.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_id_ID.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_is_IS.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_it_IT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ja_JP.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ka_GE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_kk_KZ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_km_KH.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_kn_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ko_KR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ku_TR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_lo_LA.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_lt_LT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_lv_LV.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_mk_MK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ml_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_mr_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_my_MM.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_nb_NO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ne_NP.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_nl_NL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_nn_NO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_oc_FR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_pa_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_pl_PL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_pt_BR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_pt_PT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ro_RO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ru_RU.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_se_NO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_si_LK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_sk_SK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_sl_SI.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_sq_AL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_sr_RS.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_sv_SE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ta_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_te_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_tg_TJ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_th_TH.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_tl_PH.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_tr_TR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_ug_CN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_uk_UA.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_vi_VN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_zh_CN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/3/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/3/slide_zh_TW.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Develop with the best of open source</p>
-          <p class="spacing">Ubuntu is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every Ubuntu release includes the latest toolchains and supports all major IDEs.</p>
+          <p class="spacing">{{ DISTRO }} is the ideal workstation for app or web development, data science and AI/ML as well as devops and administration. Every {{ DISTRO }} release includes the latest toolchains and supports all major IDEs.</p>
           <img class="icon" src="../icons/vscode.png" />
           <p class="pad-right">Visual Studio Code</p>
           <img class="icon" src="../icons/intellij.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_am_ET.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ar_EG.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_be_BY.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_bg_BG.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_bn_BD.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_bo_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_bs_BA.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ca_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_cs_CZ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_cy_GB.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_da_DK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_de_DE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_dz_BT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_el_GR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_en_US.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_eo_AQ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_es_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_et_EE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_eu_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_fa_IR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_fi_FI.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_fr_FR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ga_IE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_gl_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_gu_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_he_IL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_hi_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_hr_HR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_hu_HU.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_id_ID.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_is_IS.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_it_IT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ja_JP.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ka_GE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_kk_KZ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_km_KH.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_kn_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ko_KR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ku_TR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_lo_LA.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_lt_LT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_lv_LV.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_mk_MK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ml_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_mr_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_my_MM.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_nb_NO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ne_NP.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_nl_NL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_nn_NO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_oc_FR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_pa_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_pl_PL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_pt_BR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_pt_PT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ro_RO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ru_RU.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_se_NO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_si_LK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_sk_SK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_sl_SI.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_sq_AL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_sr_RS.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_sv_SE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ta_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_te_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_tg_TJ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_th_TH.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_tl_PH.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_tr_TR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_ug_CN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_uk_UA.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_vi_VN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_zh_CN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/4/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/4/slide_zh_TW.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Enhance your creativity</p>
-          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to Ubuntu with support for open source and industry standard software and applications.</p>
+          <p class="spacing">If you're an animator, designer, video creator or game developer it's easy to bring your workflows to {{ DISTRO }} with support for open source and industry standard software and applications.</p>
           <img class="icon" src="../icons/blender.png" />
           <p class="pad-right">Blender</p>
           <img class="icon" src="../icons/audacity.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_am_ET.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ar_EG.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_be_BY.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_bg_BG.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_bn_BD.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_bo_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_bs_BA.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ca_ES.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_cs_CZ.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_cy_GB.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_da_DK.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_de_DE.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_dz_BT.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_el_GR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_en_US.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_eo_AQ.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_es_ES.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_et_EE.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_eu_ES.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_fa_IR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_fi_FI.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_fr_FR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ga_IE.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_gl_ES.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_gu_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_he_IL.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_hi_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_hr_HR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_hu_HU.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_id_ID.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_is_IS.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_it_IT.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ja_JP.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ka_GE.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_kk_KZ.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_km_KH.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_kn_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ko_KR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ku_TR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_lo_LA.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_lt_LT.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_lv_LV.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_mk_MK.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ml_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_mr_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_my_MM.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_nb_NO.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ne_NP.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_nl_NL.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_nn_NO.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_oc_FR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_pa_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_pl_PL.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_pt_BR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_pt_PT.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ro_RO.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ru_RU.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_se_NO.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_si_LK.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_sk_SK.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_sl_SI.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_sq_AL.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_sr_RS.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_sv_SE.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ta_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_te_IN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_tg_TJ.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_th_TH.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_tl_PH.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_tr_TR.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_ug_CN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_uk_UA.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_vi_VN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_zh_CN.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/5/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/5/slide_zh_TW.html
@@ -43,7 +43,7 @@ body {
           <p class="h1">Great for gaming</p>
         </td>
         <td class="content-margin" colspan="2">
-          <p class="spacing">Ubuntu supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on Ubuntu via applications like Steam with no additional configuration.</p>
+          <p class="spacing">{{ DISTRO }} supports the latest NVIDIA and Mesa drivers to improve performance and compatibility. Thousands of Windows titles play great on {{ DISTRO }} via applications like Steam with no additional configuration.</p>
           <img class="icon" src="../icons/gamemode.png" />
           <p class="pad-right">Feral GameMode</p>
           <img class="icon" src="../icons/steam.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_am_ET.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ar_EG.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_be_BY.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_bg_BG.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_bn_BD.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_bo_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_bs_BA.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ca_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_cs_CZ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_cy_GB.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_da_DK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_de_DE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_dz_BT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_el_GR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_en_US.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_eo_AQ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_es_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_et_EE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_eu_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_fa_IR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_fi_FI.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_fr_FR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ga_IE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_gl_ES.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_gu_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_he_IL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_hi_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_hr_HR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_hu_HU.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_id_ID.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_is_IS.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_it_IT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ja_JP.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ka_GE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_kk_KZ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_km_KH.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_kn_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ko_KR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ku_TR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_lo_LA.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_lt_LT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_lv_LV.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_mk_MK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ml_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_mr_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_my_MM.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_nb_NO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ne_NP.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_nl_NL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_nn_NO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_oc_FR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_pa_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_pl_PL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_pt_BR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_pt_PT.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ro_RO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ru_RU.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_se_NO.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_si_LK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_sk_SK.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_sl_SI.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_sq_AL.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_sr_RS.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_sv_SE.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ta_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_te_IN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_tg_TJ.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_th_TH.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_tl_PH.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_tr_TR.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_ug_CN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_uk_UA.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_vi_VN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_zh_CN.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/6/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/6/slide_zh_TW.html
@@ -42,7 +42,7 @@ p {
       <tr>
         <td class="content-margin">
           <p class="h1">Private and secure</p>
-          <p class="spacing">Ubuntu provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
+          <p class="spacing">{{ DISTRO }} provides all of the tools you need to stay private and secure online. With built in firewall and VPN support and a host of privacy-centric applications to ensure you are in full control of your data.</p>
           <img class="icon" src="../icons/firefox.png" />
           <p class="pad-right">Firefox</p>
           <img class="icon" src="../icons/wireguard.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_am_ET.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ar_EG.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_be_BY.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_bg_BG.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_bn_BD.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_bo_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_bs_BA.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ca_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_cs_CZ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_cy_GB.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_da_DK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_de_DE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_dz_BT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_el_GR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_en_US.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_eo_AQ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_es_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_et_EE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_eu_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_fa_IR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_fi_FI.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_fr_FR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ga_IE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_gl_ES.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_gu_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_he_IL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_hi_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_hr_HR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_hu_HU.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_id_ID.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_is_IS.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_it_IT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ja_JP.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ka_GE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_kk_KZ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_km_KH.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_kn_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ko_KR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ku_TR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_lo_LA.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_lt_LT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_lv_LV.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_mk_MK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ml_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_mr_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_my_MM.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_nb_NO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ne_NP.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_nl_NL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_nn_NO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_oc_FR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_pa_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_pl_PL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_pt_BR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_pt_PT.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ro_RO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ru_RU.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_se_NO.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_si_LK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_sk_SK.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_sl_SI.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_sq_AL.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_sr_RS.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_sv_SE.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ta_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_te_IN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_tg_TJ.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_th_TH.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_tl_PH.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_tr_TR.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_ug_CN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_uk_UA.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_vi_VN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_zh_CN.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/7/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/7/slide_zh_TW.html
@@ -48,7 +48,7 @@ body {
           <p class="h1">Power up your productivity</p>
         </td>
         <td class="content-margin" colspan="3">
-          <p class="spacing">Ubuntu Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
+          <p class="spacing">{{ DISTRO }} Desktop includes LibreOffice, a suite of Microsoft Office compatible open source applications for documents, spreadsheets and presentations. Popular collaboration tools are also available.</p>
           <img class="icon" src="../icons/thunderbird.png" />
           <p class="pad-right">Thunderbird</p>
           <img class="icon" src="../icons/libreoffice.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_am_ET.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_am_ET.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ar_EG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ar_EG.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_be_BY.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_be_BY.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_bg_BG.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_bg_BG.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_bn_BD.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_bn_BD.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_bo_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_bo_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_bs_BA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_bs_BA.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ca_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ca_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_cs_CZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_cs_CZ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_cy_GB.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_cy_GB.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_da_DK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_da_DK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_de_DE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_de_DE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_dz_BT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_dz_BT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_el_GR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_el_GR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_en_US.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_en_US.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_eo_AQ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_eo_AQ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_es_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_es_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_et_EE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_et_EE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_eu_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_eu_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_fa_IR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_fa_IR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_fi_FI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_fi_FI.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_fr_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_fr_FR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ga_IE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ga_IE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_gl_ES.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_gl_ES.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_gu_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_gu_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_he_IL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_he_IL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_hi_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_hi_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_hr_HR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_hr_HR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_hu_HU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_hu_HU.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_id_ID.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_id_ID.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_is_IS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_is_IS.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_it_IT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_it_IT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ja_JP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ja_JP.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ka_GE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ka_GE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_kk_KZ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_kk_KZ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_km_KH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_km_KH.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_kn_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_kn_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ko_KR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ko_KR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ku_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ku_TR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_lo_LA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_lo_LA.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_lt_LT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_lt_LT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_lv_LV.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_lv_LV.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_mk_MK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_mk_MK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ml_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ml_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_mr_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_mr_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_my_MM.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_my_MM.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_nb_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_nb_NO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ne_NP.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ne_NP.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_nl_NL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_nl_NL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_nn_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_nn_NO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_oc_FR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_oc_FR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_pa_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_pa_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_pl_PL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_pl_PL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_pt_BR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_pt_BR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_pt_PT.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_pt_PT.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ro_RO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ro_RO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ru_RU.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ru_RU.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_se_NO.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_se_NO.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_si_LK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_si_LK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_sk_SK.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_sk_SK.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_sl_SI.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_sl_SI.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_sq_AL.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_sq_AL.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_sr_RS.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_sr_RS.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_sv_SE.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_sv_SE.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ta_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ta_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_te_IN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_te_IN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_tg_TJ.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_tg_TJ.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_th_TH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_th_TH.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_tl_PH.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_tl_PH.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_tr_TR.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_tr_TR.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_ug_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_ug_CN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_uk_UA.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_uk_UA.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_vi_VN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_vi_VN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_zh_CN.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_zh_CN.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/assets/slides/8/slide_zh_TW.html
+++ b/packages/ubuntu_bootstrap/assets/slides/8/slide_zh_TW.html
@@ -39,7 +39,7 @@ p {
         </td>
         <td class="content-margin">
           <p class="h1">Access for everyone</p>
-          <p class="spacing">At the heart of the Ubuntu philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, Ubuntu makes computing easy - whoever and wherever you are.</p>
+          <p class="spacing">At the heart of the {{ DISTRO }} philosophy is the belief that computing is for everyone. With advanced accessibility tools and options to change language, colours and text size, {{ DISTRO }} makes computing easy - whoever and wherever you are.</p>
           <img class="icon" src="../icons/languages.png" />
           <p class="pad-right">Language support</p>
           <img class="icon" src="../icons/orca.png" />

--- a/packages/ubuntu_bootstrap/lib/slides/slides_provider.dart
+++ b/packages/ubuntu_bootstrap/lib/slides/slides_provider.dart
@@ -12,12 +12,17 @@ import 'package:ubuntu_bootstrap/slides/slide_html.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 
-final slidesProvider = Provider((ref) => SlidesModel());
+final slidesProvider = Provider(
+  (ref) => SlidesModel(flavorName: ref.watch(flavorProvider).displayName),
+);
 
 final _log = Logger('slides');
 
 /// Pre-caches and holds the HTML slides.
 class SlidesModel {
+  SlidesModel({required this.flavorName});
+
+  final String flavorName;
   final List<SlideHtml> slides = [];
 
   SlideHtml? get(int index) => slides[index];
@@ -80,8 +85,11 @@ class SlidesModel {
         content = await file.readAsString();
       }
 
+      final flavorSpecificContent =
+          content.replaceAll('{{ DISTRO }}', flavorName);
+
       final bundledHtml = await _replaceImages(
-        content,
+        flavorSpecificContent,
         index,
         fromAssets: fromAssets,
       );


### PR DESCRIPTION
* This PR uses {{ DISTRO }} as a placeholder in the html slides instead of hardcoding Ubuntu.
* Changes Ubuntu Software -> App Center.
* It doesn't replace anything in the help slide since that is about AskUbuntu etc, so I'm guessing the flavor folks will override that one