### PR TITLE
ci: temporarily skip CLA check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cla:
-    if: contains(fromJson('["weblate"]'), github.event.pull_request.user.login) == false
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed


### PR DESCRIPTION
While issues with the CLA check are still being sorted out, let's skip it in the PR workflow.