### PR TITLE
fix(provd): use provd group, not gnome-initial-setup group

### DIFF
--- a/provd/debian/changelog
+++ b/provd/debian/changelog
@@ -1,3 +1,10 @@
+provd (0.1.2) noble; urgency=medium
+
+  * provd to use provd group, not gnome-initial-setup group.
+  * Fixed issues preventing use of sbuild.
+
+ -- Matthew Gary Hagemann <matt.hagemann@canonical.com>  Tue, 11 Apr 2024 07:48:45 +0200
+
 provd (0.1.1) noble; urgency=medium
 
   * provd now pre-depends on gnome-initial-setup for gnome-initial-setup group.

--- a/provd/debian/provd.postinst
+++ b/provd/debian/provd.postinst
@@ -4,13 +4,17 @@ set -e
 
 case "$1" in
     configure)
+        # Create the provd group and add gnome-initial-setup to it.
+        addgroup --system provd
+        usermod -G provd gnome-initial-setup
+
         # Set ownership and permissions for launch-desktop-provision-init.sh
-        chown gnome-initial-setup:gnome-initial-setup /usr/libexec/launch-desktop-provision-init
+        chown gnome-initial-setup:provd /usr/libexec/launch-desktop-provision-init
         chmod 750 /usr/libexec/launch-desktop-provision-init
 
         # Set ownership and permissions for bin's
-        chown root:gnome-initial-setup /usr/libexec/sprovd
-        chown root:gnome-initial-setup /usr/libexec/provd
+        chown root:provd /usr/libexec/sprovd
+        chown root:provd /usr/libexec/provd
         chmod u+s /usr/libexec/sprovd
         ;;
 esac

--- a/provd/debian/provd.postrm
+++ b/provd/debian/provd.postrm
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    purge)
+        # Revert gnome-initial-setup to nogroup
+        usermod -G nogroup gnome-initial-setup
+        
+        # Remove provd group
+        groupdel provd
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/provd/sprovd/sprovd.go
+++ b/provd/sprovd/sprovd.go
@@ -89,7 +89,7 @@ func chown(username string) error {
 	}
 
 	// #nosec:G204 // We are in control of the username and validate we can find it on the system before executing.
-	cmd := exec.Command("chown", fmt.Sprintf("%s:gnome-initial-setup", username), "/run/gnome-initial-setup")
+	cmd := exec.Command("chown", fmt.Sprintf("%s:provd", username), "/run/gnome-initial-setup")
 	_, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("executing chown command: %w", err)


### PR DESCRIPTION
Move away from using gnome-initial-setup group, which is owned and created by gnome-initial-setup, and make use of a provd group, including all its lifecycle management.