### PR TITLE
feat(bootstrap): set keyboard via setxkbmap

### DIFF
--- a/packages/ubuntu_bootstrap/lib/services/keyboard_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/keyboard_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dbus/dbus.dart';
@@ -34,7 +35,7 @@ class SubiquityKeyboardService implements KeyboardService {
 
   @override
   Future<void> setInputSource(KeyboardSetting setting, {String? user}) async {
-    await _setXkbInputSource(setting);
+    unawaited(_setXkbInputSource(setting));
     await _setGsettingsInputSource(setting);
     return _subiquity.setInputSource(setting, user: user);
   }

--- a/packages/ubuntu_bootstrap/lib/services/keyboard_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/keyboard_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dbus/dbus.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:meta/meta.dart';
@@ -12,11 +14,15 @@ class SubiquityKeyboardService implements KeyboardService {
   SubiquityKeyboardService(
     this._subiquity, {
     @visibleForTesting GSettings? inputSourceSettings,
-  }) : _inputSourceSettings = inputSourceSettings ??
-            createService<GSettings, String>('org.gnome.desktop.input-sources');
+    @visibleForTesting
+    Future<ProcessResult> Function(String, List<String>)? runProcess,
+  })  : _inputSourceSettings = inputSourceSettings ??
+            createService<GSettings, String>('org.gnome.desktop.input-sources'),
+        _runProcess = runProcess ?? Process.run;
 
   final SubiquityClient _subiquity;
   final GSettings _inputSourceSettings;
+  final Future<ProcessResult> Function(String, List<String>) _runProcess;
 
   @override
   Future<KeyboardSetup> getKeyboard() => _subiquity.getKeyboard();
@@ -28,6 +34,7 @@ class SubiquityKeyboardService implements KeyboardService {
 
   @override
   Future<void> setInputSource(KeyboardSetting setting, {String? user}) async {
+    await _setXkbInputSource(setting);
     await _setGsettingsInputSource(setting);
     return _subiquity.setInputSource(setting, user: user);
   }
@@ -55,6 +62,20 @@ class SubiquityKeyboardService implements KeyboardService {
       );
     } on Exception catch (e) {
       _log.error('Failed to set input source via gsettings', e);
+    }
+  }
+
+  Future<void> _setXkbInputSource(KeyboardSetting setting) async {
+    final result = await _runProcess(
+      'setxkbmap',
+      [
+        '-layout',
+        setting.layout,
+        if (setting.variant.isNotEmpty) ...['-variant', setting.variant],
+      ],
+    );
+    if (result.exitCode != 0) {
+      _log.error('Failed to set input source via setxkbmap', result.stderr);
     }
   }
 }

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -501,6 +503,7 @@ extension on WidgetTester {
     final keyboardService = SubiquityKeyboardService(
       subiquityClient,
       inputSourceSettings: inputSettings,
+      runProcess: (_, __) async => ProcessResult(0, 0, '', ''),
     );
     registerMockService<KeyboardService>(keyboardService);
     when(keyboardService.getKeyboard()).thenAnswer((_) async => keyboardSetup);


### PR DESCRIPTION
Follow-up to #627 
Fixes https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2058503 by additionally invoking `setxkbmap`. It introduces a tiny amount of lag after selecting the keyboard layout, as the UI waits for the command to return. We could instead mark this as `unawaited`, since it's unlikely that the user manages to type in the test field before the command returns - any thoughts?

I've checked that this works on the latest Xubuntu image and that it doesn't do any harm on Ubuntu (besides the small lag).