### PR TITLE
fix(bootstrap): map subiquity sections to pages in autoinstall

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer/installation_step.dart
+++ b/packages/ubuntu_bootstrap/lib/installer/installation_step.dart
@@ -7,10 +7,11 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
 enum InstallationStep with RouteName {
-  loading(LoadingPage.new, discreteStep: false, wizardStep: false),
+  loading(LoadingPage.new,
+      discreteStep: false, wizardStep: false, required: true),
   locale(LocalePage.new),
   accessibility(AccessibilityPage.new, allowedToHide: true),
-  rst(RstPage.new, discreteStep: false),
+  rst(RstPage.new, discreteStep: false, required: true),
   keyboard(KeyboardPage.new),
   network(NetworkPage.new),
   refresh(RefreshPage.new, allowedToHide: true),
@@ -19,20 +20,23 @@ enum InstallationStep with RouteName {
   sourceSelection(SourceSelectionPage.new, allowedToHide: true),
   codecsAndDrivers(CodecsAndDriversPage.new),
   notEnoughDiskSpace(NotEnoughDiskSpacePage.new, discreteStep: false),
-  secureBoot(SecureBootPage.new),
+  secureBoot(SecureBootPage.new, discreteStep: false, required: true),
   storage(StorageWizard.new, discreteStep: false),
   identity(IdentityPage.new),
   activeDirectory(ActiveDirectoryPage.new),
   timezone(TimezonePage.new),
-  confirm(ConfirmPage.new),
-  install(InstallPage.new, discreteStep: false, wizardStep: false),
-  error(_errorPageFactory, discreteStep: false, wizardStep: false);
+  confirm(ConfirmPage.new, required: true),
+  install(InstallPage.new,
+      discreteStep: false, wizardStep: false, required: true),
+  error(_errorPageFactory,
+      discreteStep: false, wizardStep: false, required: true);
 
   const InstallationStep(
     this.pageFactory, {
     this.discreteStep = true,
     this.wizardStep = true,
     this.allowedToHide = false,
+    this.required = false,
   });
 
   final ProvisioningPage Function() pageFactory;
@@ -46,9 +50,15 @@ enum InstallationStep with RouteName {
   /// Whether the page can be hidden.
   final bool allowedToHide;
 
+  /// Whether the page is required.
+  final bool required;
+
   /// Gets all the pages that should be handled by the wizard.
   static Iterable<InstallationStep> get wizardSteps =>
       values.where((e) => e.wizardStep);
+
+  static Iterable<String> get requiredRoutes =>
+      values.where((e) => e.required).map((e) => e.route);
 
   WizardRoute toRoute(BuildContext context, WidgetRef ref) {
     final page = pageFactory();

--- a/packages/ubuntu_bootstrap/lib/installer/installer_wizard.dart
+++ b/packages/ubuntu_bootstrap/lib/installer/installer_wizard.dart
@@ -81,11 +81,7 @@ class _InstallWizard extends ConsumerWidget {
         ),
       },
       predicate: (route) {
-        if ([
-          InstallationStep.loading.route,
-          InstallationStep.confirm.route,
-          InstallationStep.install.route,
-        ].contains(route)) {
+        if (InstallationStep.requiredRoutes.contains(route)) {
           return true;
         } else {
           return hasRoute(route);

--- a/packages/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -1,4 +1,6 @@
+import 'package:collection/collection.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_bootstrap/installer/installation_step.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
 import 'package:ubuntu_provision/services.dart';
 
@@ -10,7 +12,6 @@ class InstallerService {
   final SubiquityClient _client;
   final PageConfigService pageConfig;
   late Set<String> _pages;
-  Set<String>? _subiquityPages;
 
   Future<void> init() async {
     await _client.setVariant(Variant.DESKTOP);
@@ -31,23 +32,18 @@ class InstallerService {
 
   Future<void> load() async {
     await monitorStatus().firstWhere((s) => s?.isLoading == false);
-    _subiquityPages = (await _client.getInteractiveSections())?.toSet();
-    final oemPages = {'eula'};
-    final requiredPages = _subiquityPages ?? (pageConfig.isOem ? oemPages : {});
 
-    _pages = pageConfig.pages.keys.toSet();
-    if (pageConfig.isOem) {
-      _pages.remove('identity');
-      _pages.remove('timezone');
-      await _client.markConfigured(['identity', 'timezone']);
-    }
-
-    final excludedRequiredPages = requiredPages.toSet()..removeAll(_pages);
-    if (excludedRequiredPages.isNotEmpty) {
-      _log.warning(
-        '$excludedRequiredPages are required and cannot be excluded!',
-      );
-      _pages.addAll(excludedRequiredPages);
+    final subiquityPages = await _getSubiquityPages();
+    if (subiquityPages.isNotEmpty) {
+      _log.info('Showing only pages requested by subiquity: $subiquityPages');
+      _pages = subiquityPages;
+    } else {
+      _pages = pageConfig.pages.keys.toSet();
+      if (pageConfig.isOem) {
+        _pages.remove('identity');
+        _pages.remove('timezone');
+        await _client.markConfigured(['identity', 'timezone']);
+      }
     }
   }
 
@@ -59,11 +55,32 @@ class InstallerService {
   /// If subiquity gives back interactive pages then it will only show those
   /// pages, otherwise it will show all pages according to the config.
   bool hasRoute(String route) {
-    if (_subiquityPages?.isNotEmpty ?? false) {
-      return _subiquityPages!.contains(route.replaceFirst('/', ''));
-    }
     return _pages.contains(route.replaceFirst('/', ''));
   }
+
+  Future<Set<String>> _getSubiquityPages() async =>
+      (await _client.getInteractiveSections())
+          ?.map((section) => switch (section) {
+                // Sections that match the page names
+                final page
+                    when [
+                      'locale',
+                      'keyboard',
+                      'network',
+                      'storage',
+                      'identity',
+                      'timezone',
+                    ].contains(page) =>
+                  page,
+                // Sections that don't match the page names
+                'refresh-installer' => InstallationStep.refresh.name,
+                'source' => InstallationStep.sourceSelection.name,
+                'codecs' || 'drivers' => InstallationStep.codecsAndDrivers.name,
+                _ => 'unknown',
+              })
+          .whereNot((page) => page == 'unknown')
+          .toSet() ??
+      {};
 }
 
 extension ApplicationStatusX on ApplicationStatus {

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -61,6 +61,8 @@ void main() {
     registerMockService<TelemetryService>(MockTelemetryService());
   });
 
+  tearDown(resetAllServices);
+
   testWidgets('try ubuntu', (tester) async {
     final accessibilityModel = buildAccessibilityModel();
     final keyboardModel = buildKeyboardModel();
@@ -388,6 +390,8 @@ void main() {
   testWidgets('exclude pages', (tester) async {
     final accessibilityModel = buildAccessibilityModel();
     final keyboardModel = buildKeyboardModel();
+    final sourceModel = buildSourceModel();
+    final storageModel = buildStorageModel();
     final confirmModel = buildConfirmModel();
     final installModel = buildInstallModel(isDone: true);
 
@@ -397,6 +401,8 @@ void main() {
           autoinstallModelProvider.overrideWith((_) => buildAutoinstallModel()),
           accessibilityModelProvider.overrideWith((_) => accessibilityModel),
           keyboardModelProvider.overrideWith((_) => keyboardModel),
+          sourceModelProvider.overrideWith((_) => sourceModel),
+          storageModelProvider.overrideWith((_) => storageModel),
           confirmModelProvider.overrideWith((_) => confirmModel),
           installModelProvider.overrideWith((_) => installModel),
           slidesProvider.overrideWith((_) => MockSlidesModel()),

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -390,6 +390,7 @@ void main() {
   testWidgets('exclude pages', (tester) async {
     final accessibilityModel = buildAccessibilityModel();
     final keyboardModel = buildKeyboardModel();
+    final secureBootModel = buildSecureBootModel();
     final sourceModel = buildSourceModel();
     final storageModel = buildStorageModel();
     final confirmModel = buildConfirmModel();
@@ -401,6 +402,7 @@ void main() {
           autoinstallModelProvider.overrideWith((_) => buildAutoinstallModel()),
           accessibilityModelProvider.overrideWith((_) => accessibilityModel),
           keyboardModelProvider.overrideWith((_) => keyboardModel),
+          secureBootModelProvider.overrideWith((_) => secureBootModel),
           sourceModelProvider.overrideWith((_) => sourceModel),
           storageModelProvider.overrideWith((_) => storageModel),
           confirmModelProvider.overrideWith((_) => confirmModel),

--- a/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/installer_service_test.dart
@@ -129,7 +129,8 @@ void main() {
 
   test('interactive sections', () async {
     final client = MockSubiquityClient();
-    when(client.getInteractiveSections()).thenAnswer((_) async => ['a', 'b']);
+    when(client.getInteractiveSections())
+        .thenAnswer((_) async => ['locale', 'keyboard']);
     when(client.monitorStatus()).thenAnswer(
         (_) => Stream.value(fakeApplicationStatus(ApplicationState.WAITING)));
 
@@ -137,9 +138,9 @@ void main() {
     final service = InstallerService(client, pageConfig: pageConfigService);
     await service.load();
 
-    expect(service.hasRoute('a'), isTrue);
-    expect(service.hasRoute('b'), isTrue);
-    expect(service.hasRoute('c'), isFalse);
+    expect(service.hasRoute('locale'), isTrue);
+    expect(service.hasRoute('keyboard'), isTrue);
+    expect(service.hasRoute('identity'), isFalse);
   });
 
   test('no interactive sections', () async {
@@ -197,7 +198,6 @@ void main() {
     final service = InstallerService(client, pageConfig: pageConfigService);
     await service.load();
 
-    expect(service.hasRoute('eula'), isTrue);
     expect(service.hasRoute('identity'), isFalse);
   });
 }


### PR DESCRIPTION
This simplifies the page setup logic:
* Get list of interactive sections from subiquity and map them to pages in the installer. If the result isn't empty, populate the wizard with those pages and ignore any `visible: false` from the config.
* If subiquity didn't provide any interactive sections, show all pages provided in the whitelabel.yaml, respecting `visible: false`.

I've also added a `required` property to the `InstallationStep` to simplify the logic in the wizard's `predicate` and keep everything in one place. Required pages are `loading`, `error`, `confirm`, `install` (for obvious reasons) and also `rst` and `secureBoot`, which weren't included before.

Fixes [autoinstall: interactive-sections: "*" causes the UI to hang](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2060862)