### PR TITLE
fix: Remove untyped "next"-arguments

### DIFF
--- a/packages/factory_reset_tools/lib/horizontal_page.dart
+++ b/packages/factory_reset_tools/lib/horizontal_page.dart
@@ -12,7 +12,6 @@ class HorizontalPage extends StatelessWidget {
     this.image,
     this.onNext,
     this.onBack,
-    this.nextArguments,
     this.trailingTitleWidget,
     this.isNextEnabled = true,
     this.managedScrolling = true,
@@ -52,9 +51,6 @@ class HorizontalPage extends StatelessWidget {
 
   /// A callback for when the user presses the "Back" button.
   final FutureOr<void> Function()? onBack;
-
-  /// Arguments passed along to the [NextWizardButton].
-  final Object? nextArguments;
 
   /// Whether the next button should be enabled or not.
   final bool isNextEnabled;
@@ -153,7 +149,6 @@ class HorizontalPage extends StatelessWidget {
               NextWizardButton(
                 onNext: onNext,
                 enabled: isNextEnabled,
-                arguments: nextArguments,
               ),
             ],
           ),

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -60,7 +60,6 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
             enabled: model.canEraseDisk ||
                 model.canInstallAlongside ||
                 model.canManualPartition,
-            arguments: model.type,
             // If the user returns back to select another installation type, the
             // previously configured storage must be reset to make all guided
             // partitioning targets available.

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -12,7 +12,6 @@ class HorizontalPage extends ConsumerWidget {
     required this.title,
     required this.children,
     this.onNext,
-    this.nextArguments,
     this.trailingTitleWidget,
     this.isNextEnabled = true,
     this.managedScrolling = true,
@@ -30,12 +29,8 @@ class HorizontalPage extends ConsumerWidget {
           !managedScrolling || contentFlex == null,
           'contentFlex has no effect unless managedScrolling is set to false.',
         ),
-        assert(
-            (bottomBar == null) ||
-                (onNext == null &&
-                    nextArguments == null &&
-                    isNextEnabled == true),
-            'either provide a custom `bottomBar` or use the `onNext`, `nextArguments`, and `isNextEnabled` properties.'),
+        assert((bottomBar == null) || (onNext == null && isNextEnabled == true),
+            'either provide a custom `bottomBar` or use the `onNext`, and `isNextEnabled` properties.'),
         _contentFlex = contentFlex ?? 1;
 
   /// The title for the title bar.
@@ -52,9 +47,6 @@ class HorizontalPage extends ConsumerWidget {
 
   /// A callback for when the user presses the "Next" button.
   final FutureOr<void> Function()? onNext;
-
-  /// Arguments passed along to the [NextWizardButton].
-  final Object? nextArguments;
 
   /// Whether the next button should be enabled or not.
   final bool isNextEnabled;
@@ -154,7 +146,6 @@ class HorizontalPage extends ConsumerWidget {
               NextWizardButton(
                 onNext: onNext,
                 enabled: isNextEnabled,
-                arguments: nextArguments,
               ),
             ],
           ),

--- a/packages/ubuntu_wizard/lib/src/wizard_button.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_button.dart
@@ -216,7 +216,6 @@ class NextWizardButton extends StatelessWidget {
     this.enabled = true,
     this.flat = false,
     this.highlighted = false,
-    this.arguments,
     this.onNext,
     this.onReturn,
   });
@@ -226,7 +225,6 @@ class NextWizardButton extends StatelessWidget {
   final bool enabled;
   final bool flat;
   final bool highlighted;
-  final Object? arguments;
   final WizardCallback? onNext;
 
   /// Called when returning to the current route after navigating to the next one.
@@ -264,10 +262,10 @@ class NextWizardButton extends StatelessWidget {
           final effectiveWizard =
               (wizard?.hasNext ?? false) ? wizard : rootWizard;
           try {
-            await effectiveWizard?.next(arguments: arguments);
+            await effectiveWizard?.next();
           } on WizardException catch (_) {
             if (effectiveWizard != rootWizard) {
-              await rootWizard?.next(arguments: arguments);
+              await rootWizard?.next();
             }
           }
           onReturn?.call();


### PR DESCRIPTION
We don't use this feature anywhere and it is quite dirty to pass around untyped data, so better restrict the possibility to use it.

I found this while trying to work out a solution for pressing enter to go to the next page.