### PR TITLE
fix(bootstrap): fix temporary postinstall config path

### DIFF
--- a/ci/snap/bootstrap/local/postinst.d/10_configure_auto_login
+++ b/ci/snap/bootstrap/local/postinst.d/10_configure_auto_login
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-installer_conf=/tmp/ubuntu_desktop_installer.conf
+installer_conf=/tmp/bootstrap-postinst.conf
 
 if ! source $installer_conf 2>/dev/null || [ -z "$AutoLoginUser" ]; then
     exit

--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -75,8 +75,6 @@ Future<void> runInstallerApp(
               .then((dir) => Directory(dir).existsSync() ? dir : null),
         );
 
-  final baseName = p.basename(Platform.resolvedExecutable);
-
   // conditional registration if not already registered by flavors or tests
   tryRegisterService<AccessibilityService>(GnomeAccessibilityService.new);
   tryRegisterService<ActiveDirectoryService>(
@@ -110,7 +108,7 @@ Future<void> runInstallerApp(
       allowedToHide: InstallationStep.allowedToHideKeys,
     ),
   );
-  tryRegisterService(() => PostInstallService('/tmp/$baseName.conf'));
+  tryRegisterService(() => PostInstallService('/tmp/bootstrap-postinst.conf'));
   tryRegisterService(PowerService.new);
   tryRegisterService(ProductService.new);
   tryRegisterService(() => RefreshService(getService<SubiquityClient>()));


### PR DESCRIPTION
#651 didn't fix the [broken autologin](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2037592) as I had hoped. Turns out the respective postinst script was reading data from `/tmp/ubuntu_desktop_installer.conf`, while we're now writing to `/tmp/ubuntu_bootstrap.conf`. To avoid future confusion I've hardcoded the file name now instead of determining it from the executable.