### PR TITLE
reset-tools: fixes and improvements in snapcraft.yaml

### DIFF
--- a/ci/snap/reset-tools/snapcraft.yaml
+++ b/ci/snap/reset-tools/snapcraft.yaml
@@ -86,9 +86,7 @@ parts:
     build-attributes: [enable-patchelf]
     override-build: |
       set -eux
-      mkdir -p $CRAFT_PART_INSTALL/bin/lib -p $CRAFT_PART_INSTALL/usr/share/applications $CRAFT_PART_INSTALL/usr/share/icons/hicolor/256x256
-      cp ci/snap/reset-tools/local/factory-reset-tools.desktop $CRAFT_PART_INSTALL/usr/share/applications/
-      cp ci/snap/reset-tools/local/factory-reset-tools.png $CRAFT_PART_INSTALL/usr/share/icons/hicolor/256x256/
+      mkdir -p $CRAFT_PART_INSTALL/bin
       
       dart pub global activate melos
       dart pub global run melos bootstrap

--- a/ci/snap/reset-tools/snapcraft.yaml
+++ b/ci/snap/reset-tools/snapcraft.yaml
@@ -20,8 +20,8 @@ apps:
       - shutdown
       - removable-media
       - block-devices
-      - reset-partition-fsuuid
-      - reset-yaml
+      - etc-reset-partition-fsuuid
+      - usr-share-desktop-provision-reset-yaml
       - udisks2
       - hardware-observe
       - mount-observe
@@ -32,8 +32,8 @@ apps:
       - shutdown
       - removable-media
       - block-devices
-      - reset-partition-fsuuid
-      - reset-yaml
+      - etc-reset-partition-fsuuid
+      - usr-share-desktop-provision-reset-yaml
       - udisks2
       - hardware-observe
       - mount-observe
@@ -44,8 +44,8 @@ apps:
     activates-on: [dbus-service]
     plugs:
       - shutdown
-      - boot-grub
-      - reset-yaml
+      - hostfs-boot-grub
+      - usr-share-desktop-provision-reset-yaml
 
 parts:
   flutter-git:
@@ -121,15 +121,15 @@ slots:
     name: com.canonical.oem.FactoryResetTools
 
 plugs:
-  boot-grub:
+  hostfs-boot-grub:
     interface: system-files
     write:
     - /var/lib/snapd/hostfs/boot/grub
-  reset-partition-fsuuid:
+  etc-reset-partition-fsuuid:
     interface: system-files
     read:
     - /etc/reset_partition_fsuuid
-  reset-yaml:
+  usr-share-desktop-provision-reset-yaml:
     interface: system-files
     read:
     - /usr/share/desktop-provision/reset.yaml


### PR DESCRIPTION
The last PR has some bugs in building snapcraft.yaml, as I forgot to remove lines that copy desktop entry (`factory-reset-tools.desktop`) and icon (`factory-reset-tools.png`), since it is now using default path (snap/gui) for both of these files.

Also, according to a comment in manual review (https://forum.snapcraft.io/t/manual-review-autoconnect-request-for-factory-reset-tools/39404/7), I am asked to change a name of system-files interface in order to fit the convention.