### PR TITLE
fix(reset-tools): add uuid-runtime in snapcraft.yaml

### DIFF
--- a/ci/snap/reset-tools/snapcraft.yaml
+++ b/ci/snap/reset-tools/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
     stage-packages:
       - rsync
       - grub2-common
+      - uuid-runtime
     build-packages:
       - curl
 


### PR DESCRIPTION
The script in the image that runs after dumping the installer into the reset media uses `uuidgen` to generate a new UUID in order for casper to mount onto the correct partition.

This commit adds missing uuid-runtime dependency.