### PR TITLE
fix: Add possiblity to tab out of list on wifi page

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -43,7 +43,7 @@ command:
       ubuntu_logger: ^0.1.1
       ubuntu_service: ^0.3.1
       ubuntu_session: ^0.0.4
-      ubuntu_widgets: ^0.5.3
+      ubuntu_widgets: ^0.5.4
       udev: ^0.0.3
       upower: ^0.7.0
       url_launcher: ^6.2.5

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   ubuntu_provision: ^0.1.0
   ubuntu_service: ^0.3.1
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.5.3
+  ubuntu_widgets: ^0.5.4
   ubuntu_wizard: ^0.1.0
   yaml: ^3.1.2
   yaru: 4.1.0

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   ubuntu_service: ^0.3.1
   ubuntu_session: ^0.0.4
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.5.3
+  ubuntu_widgets: ^0.5.4
   ubuntu_wizard: ^0.1.0
   yaru: 4.1.0
 

--- a/packages/ubuntu_provision/lib/src/interfaces/provisioning_page.dart
+++ b/packages/ubuntu_provision/lib/src/interfaces/provisioning_page.dart
@@ -9,4 +9,12 @@ mixin ProvisioningPage on Widget {
   /// If it returns true it will be added to the wizard, otherwise it will be
   /// skipped.
   FutureOr<bool> load(BuildContext context, WidgetRef ref) async => true;
+
+  static AutoDisposeProvider<FocusNode> createNextFocusNodeProvider() {
+    return Provider.autoDispose<FocusNode>((ref) {
+      final focusNode = FocusNode();
+      ref.onDispose(focusNode.dispose);
+      return focusNode;
+    });
+  }
 }

--- a/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
@@ -4,12 +4,6 @@ import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
-final _nextFocusNodeProvider = Provider.autoDispose<FocusNode>((ref) {
-  final focusNode = FocusNode();
-  ref.onDispose(focusNode.dispose);
-  return focusNode;
-});
-
 class KeyboardPage extends ConsumerWidget with ProvisioningPage {
   const KeyboardPage({super.key});
 
@@ -99,3 +93,5 @@ class KeyboardPage extends ConsumerWidget with ProvisioningPage {
     );
   }
 }
+
+final _nextFocusNodeProvider = ProvisioningPage.createNextFocusNodeProvider();

--- a/packages/ubuntu_provision/lib/src/locale/locale_page.dart
+++ b/packages/ubuntu_provision/lib/src/locale/locale_page.dart
@@ -7,12 +7,6 @@ import 'package:ubuntu_service/ubuntu_service.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
-final _nextFocusNodeProvider = Provider.autoDispose<FocusNode>((ref) {
-  final focusNode = FocusNode();
-  ref.onDispose(focusNode.dispose);
-  return focusNode;
-});
-
 class LocalePage extends ConsumerWidget with ProvisioningPage {
   const LocalePage({super.key});
 
@@ -74,3 +68,5 @@ class LocalePage extends ConsumerWidget with ProvisioningPage {
     );
   }
 }
+
+final _nextFocusNodeProvider = ProvisioningPage.createNextFocusNodeProvider();

--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -55,6 +55,7 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
             onNext: model.cleanup,
             // resume network activity if/when returning back to this page
             onReturn: model.init,
+            focusNode: ref.watch(_nextFocusNodeProvider),
           ),
         ],
       ),
@@ -79,6 +80,7 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
           expanded: model.connectMode == ConnectMode.wifi,
           onEnabled: () => model.selectConnectMode(ConnectMode.wifi),
           onSelected: (_, __) => model.selectConnectMode(ConnectMode.wifi),
+          tabFocusNode: ref.watch(_nextFocusNodeProvider),
         ),
         HiddenWifiRadioButton(
           value: model.connectMode,
@@ -95,3 +97,5 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
     );
   }
 }
+
+final _nextFocusNodeProvider = ProvisioningPage.createNextFocusNodeProvider();

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_provision/src/network/connect_model.dart';
 import 'package:ubuntu_provision/src/network/network_l10n.dart';
@@ -48,12 +49,14 @@ class WifiView extends ConsumerStatefulWidget {
     required this.expanded,
     required this.onEnabled,
     required this.onSelected,
+    this.tabFocusNode,
     super.key,
   });
 
   final bool expanded;
   final VoidCallback onEnabled;
   final OnWifiSelected onSelected;
+  final FocusNode? tabFocusNode;
 
   @override
   ConsumerState<WifiView> createState() => _WifiViewState();
@@ -96,7 +99,10 @@ class _WifiViewState extends ConsumerState<WifiView> {
       expanded: widget.expanded,
       child: Padding(
         padding: kWizardIndentation,
-        child: WifiListView(onSelected: widget.onSelected),
+        child: WifiListView(
+          onSelected: widget.onSelected,
+          tabFocusNode: widget.tabFocusNode,
+        ),
       ),
     );
   }
@@ -105,6 +111,7 @@ class _WifiViewState extends ConsumerState<WifiView> {
 class WifiListView extends ConsumerWidget {
   const WifiListView({
     required this.onSelected,
+    this.tabFocusNode,
     super.key,
   });
 

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   ubuntu_service: ^0.3.1
   ubuntu_session: ^0.0.4
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.5.3
+  ubuntu_widgets: ^0.5.4
   ubuntu_wizard: ^0.1.0
   udev: ^0.0.3
   upower: ^0.7.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   ubuntu_flavor: ^0.4.0
   ubuntu_localizations: ^0.3.5
-  ubuntu_widgets: ^0.5.3
+  ubuntu_widgets: ^0.5.4
   wizard_router: ^1.2.0
   yaru: 4.1.0
 


### PR DESCRIPTION
This also refactors the wifi page to use providers groups instead of the static providers that it was overriding through the providerscope previously.