### PR TITLE
feat(subiquity_client): log errors in status monitor

### DIFF
--- a/packages/subiquity_client/lib/src/status_monitor.dart
+++ b/packages/subiquity_client/lib/src/status_monitor.dart
@@ -52,9 +52,10 @@ class SubiquityStatusMonitor {
 
   Future<void> _listen() async {
     while (_status != null && _statusController?.isClosed == false) {
-      await _fetchStatus()
-          .then(_updateStatus)
-          .onError((_, __) => _updateStatus(null));
+      await _fetchStatus().then(_updateStatus).onError((e, __) {
+        _log.error('Failed to fetch status: $e');
+        _updateStatus(null);
+      });
     }
   }
 


### PR DESCRIPTION
While looking into [this bug](https://bugs.launchpad.net/subiquity/+bug/2063124) I noticed that we're not logging any errors when fetching subiquity's status fails.