### PR TITLE
fix(reset-tools): really create reset media in the UI

### DIFF
--- a/packages/factory_reset_tools/lib/pages/creation_progress_page.dart
+++ b/packages/factory_reset_tools/lib/pages/creation_progress_page.dart
@@ -50,7 +50,7 @@ class _CreationProgressPageState extends ConsumerState<CreationProgressPage> {
   @override
   void initState() {
     super.initState();
-    createResetMediaAsyncStream ??= createFakeResetMedia(
+    createResetMediaAsyncStream ??= createResetMedia(
       ref.read(selectedMediaProvider)!.devicePath,
     );
     createResetMediaAsyncStream!.listen(onStatusChanged);


### PR DESCRIPTION
This uses actual `createResetMedia` to run the media creation