### PR TITLE
fix(bootstrap): use udisks2-inhibit.service

### DIFF
--- a/ci/snap/bootstrap/local/launcher
+++ b/ci/snap/bootstrap/local/launcher
@@ -41,10 +41,6 @@ fi
 [ "$needs_update" = true ] && echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > "$SNAP_USER_DATA/.last_revision"
 
 # Disable storage automounting (/usr/lib/udisks2/udisks2-inhibit)
-sudo mkdir -p /run/udev/rules.d
-sudo sh -c 'echo "SUBSYSTEM==\"block\", ENV{UDISKS_IGNORE}=\"1\"" > /run/udev/rules.d/90-udisks-inhibit.rules'
-trap "sudo rm -f /run/udev/rules.d/90-udisks-inhibit.rules; sudo udevadm control --reload; sudo udevadm trigger --subsystem-match=block" EXIT HUP INT QUIT ILL ABRT FPE KILL SEGV PIPE ALRM TERM BUS
-sudo udevadm control --reload
-sudo udevadm trigger --subsystem-match=block
-
+trap "sudo systemctl stop udisks2-inhibit.service" EXIT HUP INT QUIT ILL ABRT FPE KILL SEGV PIPE ALRM TERM BUS
+sudo systemctl start udisks2-inhibit.service
 "$@"


### PR DESCRIPTION
udisks2-inhibit is being moved in the live environment to a service. Interact with that instead, instead of hardcoding the rules.

Depends on https://code.launchpad.net/~dbungert/livecd-rootfs/+git/livecd-rootfs/+merge/464842 is merged.

LP: #2063192