### PR TITLE
feat(reset-tools): change the boot option "type" to "key" string

### DIFF
--- a/packages/factory_reset_tools/lib/dbus/cmdline.dart
+++ b/packages/factory_reset_tools/lib/dbus/cmdline.dart
@@ -81,7 +81,7 @@ class RebootCommand extends Command<void> {
       final options = getResetOptions();
       stdout.writeln('List of available options:\n');
       for (final option in options) {
-        stdout.writeln('${option.type}: ${option.title}');
+        stdout.writeln('${option.key}: ${option.title}');
         if (option.description != null) {
           stdout.writeln('  ${option.description}');
         }
@@ -89,7 +89,7 @@ class RebootCommand extends Command<void> {
       }
       return;
     }
-    await startCommandViaDbus(ResetOptionType.fromString(argResults.rest[0]));
+    await startCommandViaDbus(argResults.rest[0]);
     exit(0);
   }
 }

--- a/packages/factory_reset_tools/lib/dbus/dbus_daemon.dart
+++ b/packages/factory_reset_tools/lib/dbus/dbus_daemon.dart
@@ -10,7 +10,7 @@ class FactoryResetToolsObject extends ComCanonicalOemFactoryResetTools {
 
   @override
   Future<DBusMethodResponse> doReboot(String rebootOption) async {
-    await startCommand(ResetOptionType.fromString(rebootOption));
+    await startCommand(rebootOption);
     return DBusMethodSuccessResponse();
   }
 }

--- a/packages/factory_reset_tools/lib/dbus/factory_reset.dart
+++ b/packages/factory_reset_tools/lib/dbus/factory_reset.dart
@@ -8,28 +8,9 @@ import 'package:yaml/yaml.dart';
 
 const defaultFilePath = '/usr/share/desktop-provision/reset.yaml';
 
-enum ResetOptionType {
-  factoryReset('factory-reset'),
-  fwSetup('fwsetup');
-
-  const ResetOptionType(this.value);
-  final String value;
-
-  static ResetOptionType fromString(String value) {
-    switch (value) {
-      case 'factory-reset':
-        return factoryReset;
-      case 'fwsetup':
-        return fwSetup;
-      default:
-        throw ArgumentError('Invalid value: $value');
-    }
-  }
-}
-
 sealed class BootOption {
-  BootOption(this.type, this.title, this.description);
-  final ResetOptionType type;
+  BootOption(this.key, this.title, this.description);
+  final String key;
   final String title;
   final String? description;
 
@@ -85,13 +66,13 @@ class RunCommandBootOption extends BootOption {
 
 final List<BootOption> defaultBootOption = [
   GrubBootOption(
-    ResetOptionType.factoryReset,
+    'factory-reset',
     'Restore Ubuntu to factory state',
     'This option will restore Ubuntu to factory default, removing all files stored in this system during the process.',
     'Restore Ubuntu to factory state',
   ),
   GrubBootOption(
-    ResetOptionType.fwSetup,
+    'fwsetup',
     'UEFI Firmware Settings',
     'Restart into UEFI Firmware (BIOS) Settings menu.',
     'UEFI Firmware Settings',
@@ -111,7 +92,7 @@ List<BootOption> getResetOptions({String path = defaultFilePath}) {
       if (item.containsKey('grub_option')) {
         bootOptions.add(
           GrubBootOption(
-            ResetOptionType.fromString(item['key'] as String),
+            item['key'] as String,
             item['title'] as String,
             item['description'] as String?,
             item['grub_option'] as String,
@@ -128,7 +109,7 @@ List<BootOption> getResetOptions({String path = defaultFilePath}) {
 
         bootOptions.add(
           RunCommandBootOption(
-            ResetOptionType.fromString(item['key'] as String),
+            item['key'] as String,
             item['title'] as String,
             item['description'] as String?,
             command,
@@ -147,14 +128,14 @@ List<BootOption> getResetOptions({String path = defaultFilePath}) {
 }
 
 Future<void> startCommand(
-  ResetOptionType type, {
+  String key, {
   String path = defaultFilePath,
 }) {
   BootOption option;
   final options = getResetOptions(path: path);
 
   try {
-    option = options.firstWhere((option) => option.type == type);
+    option = options.firstWhere((option) => option.key == key);
   } on StateError {
     throw StateError('option not found');
   }
@@ -163,7 +144,7 @@ Future<void> startCommand(
 }
 
 Future<void> startCommandViaDbus(
-  ResetOptionType type, {
+  String key, {
   String path = defaultFilePath,
 }) async {
   final dbusClient = DBusClient.system();
@@ -176,7 +157,7 @@ Future<void> startCommandViaDbus(
   // error
   const retryRunner = RetryOptions(maxAttempts: 5);
   await retryRunner.retry(
-    () => object.callReboot(type.value),
+    () => object.callReboot(key),
     retryIf: (e) =>
         e is DBusMethodResponseException &&
         e.errorName == 'org.freedesktop.DBus.Error.UnknownObject',

--- a/packages/factory_reset_tools/lib/pages/factory_reset_page.dart
+++ b/packages/factory_reset_tools/lib/pages/factory_reset_page.dart
@@ -8,10 +8,10 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
-const defaultOptionKey = ResetOptionType.factoryReset;
+const defaultOptionKey = 'factory-reset';
 
 final _selectedResetOptionProvider =
-    StateProvider<ResetOptionType>((ref) => defaultOptionKey);
+    StateProvider<String>((ref) => defaultOptionKey);
 final _resetOptionsProvider =
     Provider<List<BootOption>>((ref) => getResetOptions());
 
@@ -20,7 +20,7 @@ class FactoryResetPage extends ConsumerWidget {
 
   Future<void> doExecute(
     BuildContext context,
-    ResetOptionType selectedOption,
+    String selectedOption,
   ) async {
     try {
       await startCommandViaDbus(selectedOption);
@@ -55,20 +55,15 @@ class FactoryResetPage extends ConsumerWidget {
     final optionsWidgets = options.map((option) {
       return OptionButton(
         title: Text(option.title),
-        value: option.type,
+        value: option.key,
         groupValue: selectedOption,
         onChanged: (value) => ref
             .read(_selectedResetOptionProvider.notifier)
-            .state = value ?? options.first.type,
+            .state = value ?? options.first.key,
         subtitle:
             option.description != null ? Text(option.description ?? '') : null,
       );
     }).withSpacing(kWizardSpacing / 2);
-
-    final buttonLabel = switch (selectedOption) {
-      ResetOptionType.factoryReset => lang.restore,
-      ResetOptionType.fwSetup => lang.restart,
-    };
 
     return HorizontalPage(
       windowTitle: lang.windowTitle,
@@ -78,7 +73,7 @@ class FactoryResetPage extends ConsumerWidget {
         leading: const BackWizardButton(),
         trailing: [
           WizardButton(
-            label: buttonLabel,
+            label: lang.restart,
             highlighted: true,
             onActivated: () => doExecute(context, selectedOption),
           ),


### PR DESCRIPTION
This feature was intended to use string type key, as it is configurable from the file in /usr/share/desktop-provision/reset.yaml to add some customizable configurations for OEM. Using enum type breaks this design but I am wondering whether we have other concerns from Desktop Team.