### PR TITLE
fix(reset-tools): fix listing options in reboot in cli

### DIFF
--- a/packages/factory_reset_tools/lib/dbus/cmdline.dart
+++ b/packages/factory_reset_tools/lib/dbus/cmdline.dart
@@ -81,7 +81,7 @@ class RebootCommand extends Command<void> {
       final options = getResetOptions();
       stdout.writeln('List of available options:\n');
       for (final option in options) {
-        stdout.writeln('${option.type}: ${option.title}');
+        stdout.writeln('${option.type.value}: ${option.title}');
         if (option.description != null) {
           stdout.writeln('  ${option.description}');
         }


### PR DESCRIPTION
When running `factory-reset-tools.cli reboot`, it shows the messages below:

```
List of available options:

ResetOptionType.factoryReset: Restore Ubuntu to factory state
  This option will restore Ubuntu to factory default, removing all files stored in this system during the process.

ResetOptionType.fwSetup: UEFI Firmware Settings
  Restart into UEFI Firmware (BIOS) Settings menu.
```

Of which `ResetOptionType.factoryReset` is the enum string, and this should be the enum value `factory-reset` so when entering `factory-reset-tools.cli reboot factory-reset` it should start the reset.