### PR TITLE
fix(provd): unlock login keyring on startup

### DIFF
--- a/provd/cmd/provd/daemon/daemon.go
+++ b/provd/cmd/provd/daemon/daemon.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"runtime"
 
 	"github.com/canonical/ubuntu-desktop-provision/provd/internal/daemon"
@@ -20,7 +19,7 @@ const cmdName = "provd"
 // App encapsulate commands and options of the daemon, which can be controlled by env variables and config files.
 type App struct {
 	rootCmd    cobra.Command
-	keyringCmd exec.Cmd
+	keyringCmd keyringCommand
 	viper      *viper.Viper
 	config     daemonConfig
 
@@ -37,6 +36,11 @@ type systemPaths struct {
 // daemonConfig defines configuration parameters of the daemon.
 type daemonConfig struct {
 	Paths systemPaths
+}
+
+// keyringCommand is a command to unlock the login keyring.
+type keyringCommand struct {
+	Start func() error
 }
 
 // New registers commands and return a new App.
@@ -82,7 +86,7 @@ func New() *App {
 
 	installConfigFlag(&a.rootCmd)
 
-	a.keyringCmd = *getKeyringCmd()
+	a.keyringCmd = keyringCommand{getKeyringCmd().Start}
 
 	// subcommands
 	a.installVersion()

--- a/provd/cmd/provd/daemon/daemon_test.go
+++ b/provd/cmd/provd/daemon/daemon_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestHelp(t *testing.T) {
-	a := daemon.NewForTests(t, nil, nil, "--help")
+	a := daemon.NewForTestsWithConfig(t, nil, nil, "--help")
 
 	getStdout := captureStdout(t)
 
@@ -28,7 +28,7 @@ func TestHelp(t *testing.T) {
 }
 
 func TestCompletion(t *testing.T) {
-	a := daemon.NewForTests(t, nil, nil, "completion", "bash")
+	a := daemon.NewForTestsWithConfig(t, nil, nil, "completion", "bash")
 
 	getStdout := captureStdout(t)
 
@@ -37,7 +37,7 @@ func TestCompletion(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	a := daemon.NewForTests(t, nil, nil, "version")
+	a := daemon.NewForTestsWithConfig(t, nil, nil, "version")
 
 	getStdout := captureStdout(t)
 
@@ -56,7 +56,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestNoUsageError(t *testing.T) {
-	a := daemon.NewForTests(t, nil, nil, "completion", "bash")
+	a := daemon.NewForTestsWithConfig(t, nil, nil, "completion", "bash")
 
 	getStdout := captureStdout(t)
 	err := a.Run()
@@ -69,7 +69,7 @@ func TestNoUsageError(t *testing.T) {
 func TestUsageError(t *testing.T) {
 	t.Parallel()
 
-	a := daemon.NewForTests(t, nil, nil, "doesnotexist")
+	a := daemon.NewForTestsWithConfig(t, nil, nil, "doesnotexist")
 
 	err := a.Run()
 	require.Error(t, err, "Run should return an error, stdout: %v")
@@ -102,7 +102,7 @@ func TestAppCanQuitWithoutExecute(t *testing.T) {
 
 	t.Parallel()
 
-	a := daemon.NewForTests(t, nil, nil)
+	a := daemon.NewForTestsWithConfig(t, nil, nil)
 
 	requireGoroutineStarted(t, a.Quit)
 	err := a.Run()
@@ -153,7 +153,7 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 			default:
 				config.Paths.Socket = filepath.Join(shortTmp, "mysocket")
 			}
-			a := daemon.NewForTests(t, &config, nil)
+			a := daemon.NewForTestsWithConfig(t, &config, nil)
 			err = a.Run()
 			require.Error(t, err, "Run should exit with an error")
 			a.Quit()
@@ -210,7 +210,7 @@ func TestAppCanSigHupWithoutExecute(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err, "Setup: pipe shouldn't fail")
 
-	a := daemon.NewForTests(t, nil, nil)
+	a := daemon.NewForTestsWithConfig(t, nil, nil)
 
 	orig := os.Stdout
 	os.Stdout = w
@@ -229,7 +229,7 @@ func TestAppCanSigHupWithoutExecute(t *testing.T) {
 func TestAppGetRootCmd(t *testing.T) {
 	t.Parallel()
 
-	a := daemon.NewForTests(t, nil, nil)
+	a := daemon.NewForTestsWithConfig(t, nil, nil)
 	require.NotNil(t, a.RootCmd(), "Returns root command")
 }
 
@@ -259,7 +259,7 @@ func TestAutoDetectConfig(t *testing.T) {
 	// Remove configuration next binary for other tests to not pick it up.
 	defer os.Remove(configNextToBinaryPath)
 
-	a := daemon.New()
+	a := daemon.NewForTests(t, nil)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -279,7 +279,7 @@ func TestAutoDetectConfig(t *testing.T) {
 }
 
 func TestNoConfigSetDefaults(t *testing.T) {
-	a := daemon.New()
+	a := daemon.NewForTests(t, nil)
 	// Use version to still run preExec to load no config but without running server
 	a.SetArgs("version")
 
@@ -297,7 +297,7 @@ func TestBadConfigFile(t *testing.T) {
 	err := os.WriteFile(configPath, []byte("foo"), 0600)
 	require.NoError(t, err, "Failed to create config file with 'blah'")
 
-	a := daemon.New()
+	a := daemon.NewForTests(t, nil)
 	a.SetArgs("version", "--config", configPath)
 
 	err = a.Run()
@@ -305,7 +305,7 @@ func TestBadConfigFile(t *testing.T) {
 }
 
 func TestMissingConfigReturnsError(t *testing.T) {
-	a := daemon.New()
+	a := daemon.NewForTests(t, nil)
 	// Use version to still run preExec to load no config but without running server
 	a.SetArgs("version", "--config", "/does/not/exist.yaml")
 
@@ -342,7 +342,7 @@ func TestUnlockKeyring(t *testing.T) {
 				keyringCmd = nil
 			}
 
-			a := daemon.NewForTests(t, nil, keyringCmd)
+			a := daemon.NewForTestsWithConfig(t, nil, keyringCmd)
 
 			wg := sync.WaitGroup{}
 			wg.Add(1)
@@ -387,7 +387,7 @@ func startDaemon(t *testing.T, conf *daemon.DaemonConfig) (app *daemon.App, done
 	t.Helper()
 	t.Cleanup(testutils.StartLocalSystemBus())
 
-	a := daemon.NewForTests(t, conf, nil)
+	a := daemon.NewForTestsWithConfig(t, conf, nil)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/provd/cmd/provd/daemon/daemon_test.go
+++ b/provd/cmd/provd/daemon/daemon_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestHelp(t *testing.T) {
-	a := daemon.NewForTests(t, nil, "--help")
+	a := daemon.NewForTests(t, nil, nil, "--help")
 
 	getStdout := captureStdout(t)
 
@@ -28,7 +28,7 @@ func TestHelp(t *testing.T) {
 }
 
 func TestCompletion(t *testing.T) {
-	a := daemon.NewForTests(t, nil, "completion", "bash")
+	a := daemon.NewForTests(t, nil, nil, "completion", "bash")
 
 	getStdout := captureStdout(t)
 
@@ -37,7 +37,7 @@ func TestCompletion(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	a := daemon.NewForTests(t, nil, "version")
+	a := daemon.NewForTests(t, nil, nil, "version")
 
 	getStdout := captureStdout(t)
 
@@ -56,7 +56,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestNoUsageError(t *testing.T) {
-	a := daemon.NewForTests(t, nil, "completion", "bash")
+	a := daemon.NewForTests(t, nil, nil, "completion", "bash")
 
 	getStdout := captureStdout(t)
 	err := a.Run()
@@ -69,7 +69,7 @@ func TestNoUsageError(t *testing.T) {
 func TestUsageError(t *testing.T) {
 	t.Parallel()
 
-	a := daemon.NewForTests(t, nil, "doesnotexist")
+	a := daemon.NewForTests(t, nil, nil, "doesnotexist")
 
 	err := a.Run()
 	require.Error(t, err, "Run should return an error, stdout: %v")
@@ -102,7 +102,7 @@ func TestAppCanQuitWithoutExecute(t *testing.T) {
 
 	t.Parallel()
 
-	a := daemon.NewForTests(t, nil)
+	a := daemon.NewForTests(t, nil, nil)
 
 	requireGoroutineStarted(t, a.Quit)
 	err := a.Run()
@@ -153,7 +153,7 @@ func TestAppRunFailsOnComponentsCreationAndQuit(t *testing.T) {
 			default:
 				config.Paths.Socket = filepath.Join(shortTmp, "mysocket")
 			}
-			a := daemon.NewForTests(t, &config)
+			a := daemon.NewForTests(t, &config, nil)
 			err = a.Run()
 			require.Error(t, err, "Run should exit with an error")
 			a.Quit()
@@ -210,7 +210,7 @@ func TestAppCanSigHupWithoutExecute(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err, "Setup: pipe shouldn't fail")
 
-	a := daemon.NewForTests(t, nil)
+	a := daemon.NewForTests(t, nil, nil)
 
 	orig := os.Stdout
 	os.Stdout = w
@@ -229,7 +229,7 @@ func TestAppCanSigHupWithoutExecute(t *testing.T) {
 func TestAppGetRootCmd(t *testing.T) {
 	t.Parallel()
 
-	a := daemon.NewForTests(t, nil)
+	a := daemon.NewForTests(t, nil, nil)
 	require.NotNil(t, a.RootCmd(), "Returns root command")
 }
 
@@ -313,6 +313,47 @@ func TestMissingConfigReturnsError(t *testing.T) {
 	require.Error(t, err, "Run should return an error on config file")
 }
 
+func TestUnlockKeyring(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		commandError bool
+
+		wantErr bool
+	}{
+		"Successfully unlocks the keyring": {},
+
+		"Error unlocking the keyring": {commandError: true, wantErr: true},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var keyringCmd *daemon.KeyringCommand
+			if tc.commandError {
+				keyringCmd = &daemon.KeyringCommand{
+					Start: func() error {
+						return fmt.Errorf("error unlocking keyring")
+					},
+				}
+			} else {
+				keyringCmd = nil
+			}
+
+			a := daemon.NewForTests(t, nil, keyringCmd)
+			err := a.Run()
+
+			if tc.wantErr {
+				require.Error(t, err, "Run should return an error")
+				return
+			}
+			require.NoError(t, err, "Run should not return an error")
+		})
+	}
+}
+
 // requireGoroutineStarted starts a goroutine and blocks until it has been launched.
 func requireGoroutineStarted(t *testing.T, f func()) {
 	t.Helper()
@@ -333,7 +374,7 @@ func startDaemon(t *testing.T, conf *daemon.DaemonConfig) (app *daemon.App, done
 	t.Helper()
 	t.Cleanup(testutils.StartLocalSystemBus())
 
-	a := daemon.NewForTests(t, conf)
+	a := daemon.NewForTests(t, conf, nil)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/provd/cmd/provd/daemon/export_test.go
+++ b/provd/cmd/provd/daemon/export_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 type (
-	DaemonConfig = daemonConfig
-	SystemPaths  = systemPaths
+	DaemonConfig   = daemonConfig
+	SystemPaths    = systemPaths
+	KeyringCommand = keyringCommand
 )
 
-func NewForTests(t *testing.T, conf *DaemonConfig, args ...string) *App {
+func NewForTests(t *testing.T, conf *DaemonConfig, keyringCmd *keyringCommand, args ...string) *App {
 	t.Helper()
 
 	p := GenerateTestConfig(t, conf)
@@ -23,6 +24,16 @@ func NewForTests(t *testing.T, conf *DaemonConfig, args ...string) *App {
 
 	a := New()
 	a.rootCmd.SetArgs(argsWithConf)
+
+	if keyringCmd != nil {
+		a.keyringCmd = *keyringCmd
+	} else {
+		a.keyringCmd = keyringCommand{
+			Start: func() error {
+				return nil
+			},
+		}
+	}
 	return a
 }
 

--- a/provd/cmd/provd/daemon/export_test.go
+++ b/provd/cmd/provd/daemon/export_test.go
@@ -15,15 +15,23 @@ type (
 	KeyringCommand = keyringCommand
 )
 
-func NewForTests(t *testing.T, conf *DaemonConfig, keyringCmd *keyringCommand, args ...string) *App {
+func NewForTestsWithConfig(t *testing.T, conf *DaemonConfig, keyringCmd *keyringCommand, args ...string) *App {
 	t.Helper()
 
 	p := GenerateTestConfig(t, conf)
 	argsWithConf := []string{"--config", p}
 	argsWithConf = append(argsWithConf, args...)
 
-	a := New()
+	a := NewForTests(t, keyringCmd, args...)
 	a.rootCmd.SetArgs(argsWithConf)
+
+	return a
+}
+
+func NewForTests(t *testing.T, keyringCmd *keyringCommand, args ...string) *App {
+	t.Helper()
+
+	a := New()
 
 	if keyringCmd != nil {
 		a.keyringCmd = *keyringCmd

--- a/provd/cmd/provd/daemon/keyring.go
+++ b/provd/cmd/provd/daemon/keyring.go
@@ -1,0 +1,18 @@
+package daemon
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// tempKeyringPassword is the temporary password used to unlock the login keyring.
+const tempKeyringPassword = "gis"
+
+// getKeyringCmd returns a command to unlock the login keyring.
+func getKeyringCmd() *exec.Cmd {
+	buf := bytes.Buffer{}
+	buf.Write([]byte(tempKeyringPassword))
+	cmd := exec.Command("gnome-keyring-daemon", "--unlock")
+	cmd.Stdin = &buf
+	return cmd
+}


### PR DESCRIPTION
This runs `gnome-keyring-daemon --unlock` with a temporary password before launching the provd daemon, so that network manager doesn't complain about missing agents. By default the network credentials will be stored in `/etc/netplan` instead of the user's keyring, though. To fix [lp:2063313](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2063313) we don't need to worry about copying the keyring to the new user's directory and updating the password. I'd open a separate issue for that. 

Fix #711