### PR TITLE
feat(init): make EULA page hidable

### DIFF
--- a/packages/ubuntu_init/lib/src/init_step.dart
+++ b/packages/ubuntu_init/lib/src/init_step.dart
@@ -11,7 +11,7 @@ enum InitStep with RouteName {
   accessibility(AccessibilityPage.new),
   keyboard(KeyboardPage.new),
   network(NetworkPage.new),
-  eula(EulaPage.new),
+  eula(EulaPage.new, allowedToHide: true),
   identity(IdentityPage.new),
   ubuntuProOnboarding(UbuntuProOnboardingPage.new),
   ubuntuPro(UbuntuProPage.new, discreteStep: false),


### PR DESCRIPTION
This makes it possible to hide the EULA page from the stage 4 init wizard via
```yaml
pages:
  eula:
    visible: false
```

Even though we don't parse the `mode` setting in stage 4 yet, OEMs should set
```yaml
mode: oem
```
in the config as well. In the future this will determine which pages are shown by default and affect the copy on some pages.