### PR TITLE
fix(init): restore hardware-observe plug

### DIFF
--- a/ci/snap/init/snapcraft.yaml
+++ b/ci/snap/init/snapcraft.yaml
@@ -19,6 +19,7 @@ apps:
     environment:
       LOG_LEVEL: debug
     plugs:
+      - hardware-observe
       - hostfs-usr-share-desktop-provision
       - run-provd-socket
       - network


### PR DESCRIPTION
This was mistakenly removed in #462. Turns out it was not only needed for the (now moved to provd) sysmetrics package, but also for the auto generation of the hostname. See https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2064092.
In the interest of time I suggest re-introducing the plug for now. We should consider handling this via an endpoint in provd as well, though.