### PR TITLE
fix(screenshot_test): finish text editing on identity page

### DIFF
--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -222,6 +222,14 @@ extension UbuntuProvisionPageTester on WidgetTester {
         password,
       );
     }
+    if (identity?.realname != null ||
+        identity?.hostname != null ||
+        identity?.username != null ||
+        password != null) {
+      await pump();
+      await testTextInput.receiveAction(TextInputAction.done);
+      await pump();
+    }
     await pumpAndSettle();
 
     if (screenshot != null) {


### PR DESCRIPTION
This is an attempt to fix the constant regeneration of screenshots for the identity page (see e.g. https://github.com/canonical/ubuntu-desktop-provision-screenshots/pull/297), due to non-deterministic behavior.