### PR TITLE
chore(bootstrap): add bugtracker url to snapcraft.yaml

### DIFF
--- a/ci/snap/bootstrap/snapcraft.yaml
+++ b/ci/snap/bootstrap/snapcraft.yaml
@@ -4,6 +4,7 @@ summary: Ubuntu Desktop Bootstrap
 description: |
   A modern implementation of the Ubuntu Desktop installer.
   It comprises a Flutter-based UI and uses subiquity as the backend.
+contact: https://bugs.launchpad.net/ubuntu-desktop-provision
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
When running `ubuntu-bug ubuntu-desktop-bootstrap` the following error is shown:

![image](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/7a42bd35-13a0-4645-8a58-3da45b7b1843)

I suspect we need to add the corresponding URL to the snapcraft.yaml

Will make the link on the error page invoke `ubuntu-bug` in a separate PR, once this works :)