### PR TITLE
chore(bootstrap): define the issues url in snapcraft.yaml

### DIFF
--- a/ci/snap/bootstrap/snapcraft.yaml
+++ b/ci/snap/bootstrap/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   A modern implementation of the Ubuntu Desktop installer.
   It comprises a Flutter-based UI and uses subiquity as the backend.
 contact: https://bugs.launchpad.net/ubuntu-desktop-provision
+issues: https://bugs.launchpad.net/ubuntu-desktop-provision
 grade: stable
 confinement: classic
 base: core22


### PR DESCRIPTION
The change to add 'contact' doesn't to be enable ubuntu-bug to work, checking what was done for ubuntu-desktop-installer previous cycle 'issues' should also be set (described in https://snapcraft.io/docs/snapcraft-yaml-reference)