### PR TITLE
chore(deps): upgrade ubuntu_widgets to ^0.5.5

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -44,7 +44,7 @@ command:
       ubuntu_logger: ^0.1.1
       ubuntu_service: ^0.3.1
       ubuntu_session: ^0.0.4
-      ubuntu_widgets: ^0.5.4
+      ubuntu_widgets: ^0.5.5
       udev: ^0.0.3
       upower: ^0.7.0
       url_launcher: ^6.2.5

--- a/packages/ubuntu_bootstrap/pubspec.lock
+++ b/packages/ubuntu_bootstrap/pubspec.lock
@@ -1154,10 +1154,10 @@ packages:
     dependency: "direct main"
     description:
       name: ubuntu_localizations
-      sha256: "13f92d6fbf7729a9db10d61a726f8b0913285807d2b63ec966396cc94b324616"
+      sha256: eca4f43453339acca16b4b23a70b93315ab92b1500f98156a8f95af5e5078def
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.3.6"
   ubuntu_logger:
     dependency: "direct main"
     description:
@@ -1215,10 +1215,10 @@ packages:
     dependency: "direct main"
     description:
       name: ubuntu_widgets
-      sha256: dd17a77f35500b5e9491b595ec75f4bfe9351a43cba7674064e345f9c36db9a4
+      sha256: f0672b0218d91642e06375685d45113efe325209fe2a00dbc9f360183c854228
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.4"
+    version: "0.5.5"
   ubuntu_wizard:
     dependency: "direct main"
     description:

--- a/packages/ubuntu_bootstrap/pubspec.yaml
+++ b/packages/ubuntu_bootstrap/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   ubuntu_provision: ^0.1.0
   ubuntu_service: ^0.3.1
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.5.4
+  ubuntu_widgets: ^0.5.5
   ubuntu_wizard: ^0.1.0
   yaml: ^3.1.2
   yaru: 4.1.0

--- a/packages/ubuntu_init/pubspec.lock
+++ b/packages/ubuntu_init/pubspec.lock
@@ -1200,10 +1200,10 @@ packages:
     dependency: "direct main"
     description:
       name: ubuntu_widgets
-      sha256: dd17a77f35500b5e9491b595ec75f4bfe9351a43cba7674064e345f9c36db9a4
+      sha256: f0672b0218d91642e06375685d45113efe325209fe2a00dbc9f360183c854228
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.4"
+    version: "0.5.5"
   ubuntu_wizard:
     dependency: "direct main"
     description:

--- a/packages/ubuntu_init/pubspec.yaml
+++ b/packages/ubuntu_init/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   ubuntu_service: ^0.3.1
   ubuntu_session: ^0.0.4
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.5.4
+  ubuntu_widgets: ^0.5.5
   ubuntu_wizard: ^0.1.0
   yaru: 4.1.0
 

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   ubuntu_service: ^0.3.1
   ubuntu_session: ^0.0.4
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.5.4
+  ubuntu_widgets: ^0.5.5
   ubuntu_wizard: ^0.1.0
   udev: ^0.0.3
   upower: ^0.7.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   ubuntu_flavor: ^0.4.0
   ubuntu_localizations: ^0.3.5
-  ubuntu_widgets: ^0.5.4
+  ubuntu_widgets: ^0.5.5
   wizard_router: ^1.2.0
   yaru: 4.1.0
 


### PR DESCRIPTION
Upgrading `ubuntu_widgets` seems to resolve the RTL issue in `ListWidget`:

|Before|After|
|-|-|
|![Screenshot from 2024-05-08 16-33-25](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/81e2209b-fa0e-4918-b09d-fe32e1b1a8f7)|![Screenshot from 2024-05-08 16-31-35](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/cc6b31d8-284d-4632-92ea-737e20f141bd)|

Ref: [lp:2064700](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2064700), [lp:2064701](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2064701)