### PR TITLE
fix(ubuntu_wizard): remove yaru override

### DIFF
--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -23,9 +23,3 @@ dev_dependencies:
   ubuntu_lints: ^0.3.0
   ubuntu_test: ^0.1.0-beta.8
   yaru_test: ^0.1.6
-
-dependency_overrides:
-  yaru:
-    git:
-      url: https://github.com/ubuntu/yaru.dart.git
-      ref: main


### PR DESCRIPTION
I suspect this override got included by accident. It's causing [test failures](https://github.com/canonical/ubuntu-desktop-provision/actions/runs/9225981469/job/25384741300) now due to the recently updated yaru libs.