### PR TITLE
chore(provd): go toolchain bump 1.22.3

### DIFF
--- a/provd/go.mod
+++ b/provd/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/ubuntu-desktop-provision/provd
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf


### PR DESCRIPTION
Fixes the vulnerability causing the ci to fail by bumping the version of the go toolchain that is used to build provd. 