### PR TITLE
fix(bootstrap): restore TPM FDE messaging

### DIFF
--- a/packages/ubuntu_bootstrap/lib/installer.dart
+++ b/packages/ubuntu_bootstrap/lib/installer.dart
@@ -41,6 +41,7 @@ Future<void> runInstallerApp(
       'dry-run-config',
       valueHelp: 'path',
       help: 'Path of the dry-run config file',
+      defaultsTo: 'examples/dry-run-configs/tpm.yaml',
     );
     parser.addOption(
       'machine-config',
@@ -150,7 +151,6 @@ Future<void> runInstallerApp(
     if (options['source-catalog'] != null)
       '--source-catalog=${options['source-catalog']}',
     '--storage-version=2',
-    '--dry-run-config=examples/dry-run-configs/tpm.yaml',
     ...options.rest,
   ];
 

--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_dialogs.dart
@@ -141,6 +141,9 @@ class TpmOption extends ConsumerWidget {
 
     final tpmInfo =
         lang.installationTypeTPMInfo(flavor.displayName, model.tpmInfoUrl);
+    final disallowedCapability = target.disallowed.firstWhereOrNull((e) =>
+        e.capability == GuidedCapability.CORE_BOOT_ENCRYPTED ||
+        e.capability == GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED);
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -153,11 +156,12 @@ class TpmOption extends ConsumerWidget {
               InfoBadge(title: experimentalBadgeText),
             ],
           ),
+          subtitle: disallowedCapability?.message == null
+              ? null
+              : Text(disallowedCapability!.message!),
           value: GuidedCapability.CORE_BOOT_ENCRYPTED,
           groupValue: guidedCapability.value,
-          onChanged: target.disallowed.isEmpty
-              ? (v) => guidedCapability.value = v!
-              : null,
+          onChanged: model.hasTpm ? (v) => guidedCapability.value = v! : null,
         ),
         if (guidedCapability.value == GuidedCapability.CORE_BOOT_ENCRYPTED) ...[
           const SizedBox(height: kWizardSpacing),

--- a/packages/ubuntu_bootstrap/test/installer_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_test.dart
@@ -88,10 +88,10 @@ void main() {
     await tester
         .runAsync(() => runInstallerApp(['--dry-run', '--', '--foo', 'bar']));
     verify(server.start(args: [
+      '--dry-run-config=examples/dry-run-configs/tpm.yaml',
       '--machine-config=examples/machines/simple.json',
       '--source-catalog=examples/sources/desktop.yaml',
       '--storage-version=2',
-      '--dry-run-config=examples/dry-run-configs/tpm.yaml',
       '--foo',
       'bar',
     ])).called(1);

--- a/packages/ubuntu_bootstrap/test/storage/storage_dialogs_test.dart
+++ b/packages/ubuntu_bootstrap/test/storage/storage_dialogs_test.dart
@@ -112,7 +112,6 @@ void main() {
 
   testWidgets('tpm requires uefi and secure boot', (tester) async {
     final model = buildStorageModel(
-      hasTpm: true,
       scenario: SecureBootScenarios.bios,
     );
     await tester.pumpWidget(buildPage(tester, model));
@@ -124,6 +123,8 @@ void main() {
     final finder = find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED);
     expect(finder, findsOneWidget);
     expect(finder, isDisabled);
+
+    expect(find.text('uefi & secure boot required'), findsOneWidget);
 
     await tester.pump();
     await tester.tapCancel();
@@ -146,6 +147,8 @@ void main() {
     expect(finder, findsOneWidget);
     expect(finder, isDisabled);
 
+    expect(find.text('tpm required'), findsOneWidget);
+
     await tester.pump();
     await tester.tapCancel();
 
@@ -155,7 +158,6 @@ void main() {
 
   testWidgets('tpm incompatible with third party drivers', (tester) async {
     final model = buildStorageModel(
-      hasTpm: true,
       scenario: SecureBootScenarios.thirdPartyDrivers,
     );
     await tester.pumpWidget(buildPage(tester, model));
@@ -167,6 +169,8 @@ void main() {
     final finder = find.radio(GuidedCapability.CORE_BOOT_ENCRYPTED);
     expect(finder, findsOneWidget);
     expect(finder, isDisabled);
+
+    expect(find.text('third party drivers incompatible'), findsOneWidget);
 
     await tester.pump();
     await tester.tapCancel();

--- a/packages/ubuntu_bootstrap/test/storage/test_storage.dart
+++ b/packages/ubuntu_bootstrap/test/storage/test_storage.dart
@@ -79,10 +79,10 @@ const noTpm = GuidedStorageTargetReformat(
   diskId: 'disk-vda',
   disallowed: [
     GuidedDisallowedCapability(
-        capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
-        reason:
-            GuidedDisallowedCapabilityReason.CORE_BOOT_ENCRYPTION_UNAVAILABLE,
-        message: 'tpm required')
+      capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+      reason: GuidedDisallowedCapabilityReason.CORE_BOOT_ENCRYPTION_UNAVAILABLE,
+      message: 'tpm required',
+    )
   ],
 );
 
@@ -90,9 +90,10 @@ const bios = GuidedStorageTargetReformat(
   diskId: 'disk-vda',
   disallowed: [
     GuidedDisallowedCapability(
-        capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
-        reason: GuidedDisallowedCapabilityReason.NOT_UEFI,
-        message: 'uefi & secure boot required')
+      capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+      reason: GuidedDisallowedCapabilityReason.NOT_UEFI,
+      message: 'uefi & secure boot required',
+    )
   ],
 );
 
@@ -100,8 +101,9 @@ const thirdPartyDrivers = GuidedStorageTargetReformat(
   diskId: 'disk-vda',
   disallowed: [
     GuidedDisallowedCapability(
-        capability: GuidedCapability.CORE_BOOT_UNENCRYPTED,
-        reason: GuidedDisallowedCapabilityReason.THIRD_PARTY_DRIVERS,
-        message: 'third party drivers incompatible')
+      capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+      reason: GuidedDisallowedCapabilityReason.THIRD_PARTY_DRIVERS,
+      message: 'third party drivers incompatible',
+    )
   ],
 );


### PR DESCRIPTION
![image](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/cc07bc48-6f86-41df-a0fe-141b2f420185)

@anasereijo this restores the message as a subtitle and looks the same as in 23.10. We can iterate on the design later if you have suggestions for improvements.

Fix #743
UDENG-2941