### PR TITLE
fix(subiquity_client): ignore library annotation for WSL

### DIFF
--- a/packages/subiquity_client/test/windows_only_wsl_tests.dart
+++ b/packages/subiquity_client/test/windows_only_wsl_tests.dart
@@ -1,3 +1,4 @@
+// ignore: library_annotations
 @TestOn('windows')
 // The tests below require a Windows host with WSL 2 enabled and some Linux
 // distribution already installed (by default Ubuntu-22.04 but can be overridden


### PR DESCRIPTION
The analyzer complains since the release of the new ubuntu_lints. I think it's safe to ignore here, and we probably should remove that file altogether.