### PR TITLE
feat(bootstrap): support local file:// URIs on autoinstall page

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_page.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_page.dart
@@ -83,6 +83,8 @@ class AutoinstallPage extends ConsumerWidget with ProvisioningPage {
                           final ArgumentError e => 'Invalid URL: ${e.message}',
                           final FormatException e =>
                             'Invalid Format: ${e.message}',
+                          final FileSystemException e =>
+                            'File system error: ${e.message}',
                           _ => 'Unknown Error',
                         };
                       },


### PR DESCRIPTION
Adds support for local file paths following the file URI scheme on the autoinstall page (e.g. `file:///home/ubuntu/foo.yaml`.

Successfully tested this with the 24.04 iso.

![image](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/f3aae18c-127a-4bce-9be2-4a5010dd4c08)

@anasereijo do we need to update the copy here? As far as I understand this feature is mainly needed for internal purposes.


Fix #754
UDENG-3038