### PR TITLE
generator: accept multiple .py files as input

### DIFF
--- a/packages/subiquity_client/generator/Makefile
+++ b/packages/subiquity_client/generator/Makefile
@@ -2,7 +2,7 @@ types_py = ../subiquity/subiquity/common/types.py
 types_dart = ../lib/src/types.dart
 
 generate:
-	python3 generator.py $(types_py) $(types_dart)
+	python3 generator.py $(types_py) --output $(types_dart)
 	dart format $(types_dart)
 
 check:


### PR DESCRIPTION
The types.py file in the Subiquity tree is getting difficult to maintain and it would be ideal to split it into multiple files going forward.

Ensure that the generator script can parse content from multiple files.

NOTE: Previously the syntax `./generator.py file1 file2` would parse "file1" and output to "file2". Now, this syntax would parse "file1" and "file2" ; and would output to the standard output. The generator will look for specific file extensions when reading (i.e., *.py) and writing (i.e., *.dart) so there should be no risk of overwriting important files if using the generator incorrectly.