### PR TITLE
test(subiquity_client): fix escape sequences in generator test

### DIFF
--- a/packages/subiquity_client/generator/test_generator.py
+++ b/packages/subiquity_client/generator/test_generator.py
@@ -157,7 +157,7 @@ class BazQux:
 TestUnion = Union[Foo, Bar, BazQux]
 """)
         self.assertEqual(generator.to_dart(), """
-@Freezed(unionKey: '\$type', unionValueCase: FreezedUnionCase.pascal)
+@Freezed(unionKey: '\\$type', unionValueCase: FreezedUnionCase.pascal)
 class TestUnion with _$TestUnion {
 
   @FreezedUnionValue('Foo')
@@ -193,7 +193,7 @@ class TestClass:
     foo: Union[Foo, BarBaz]
 """)
         self.assertEqual(generator.to_dart(), """
-@Freezed(unionKey: '\$type', unionValueCase: FreezedUnionCase.pascal)
+@Freezed(unionKey: '\\$type', unionValueCase: FreezedUnionCase.pascal)
 class FooOrBarBaz with _$FooOrBarBaz {
 
   @FreezedUnionValue('Foo')
@@ -232,7 +232,7 @@ class TestClass:
     foo: Union[TestUnionFoo, TestUnionBarBaz]
 """)
         self.assertEqual(generator.to_dart(), """
-@Freezed(unionKey: '\$type', unionValueCase: FreezedUnionCase.pascal)
+@Freezed(unionKey: '\\$type', unionValueCase: FreezedUnionCase.pascal)
 class TestUnion with _$TestUnion {
 
   @FreezedUnionValue('TestUnionFoo')
@@ -307,7 +307,7 @@ class Bar:
 TestUnion = Union[Foo, Bar]
 """)
         self.assertEqual(generator.to_dart(), """
-@Freezed(unionKey: '\$type', unionValueCase: FreezedUnionCase.pascal)
+@Freezed(unionKey: '\\$type', unionValueCase: FreezedUnionCase.pascal)
 class TestUnion with _$TestUnion {
 
   @FreezedUnionValue('Foo')


### PR DESCRIPTION
```
python3 -m unittest
/home/loose/projects/canonical/git/ubuntu-desktop-provision/packages/subiquity_client/generator/test_generator.py:159: SyntaxWarning: invalid escape sequence '\$'
  self.assertEqual(generator.to_dart(), """
/home/loose/projects/canonical/git/ubuntu-desktop-provision/packages/subiquity_client/generator/test_generator.py:195: SyntaxWarning: invalid escape sequence '\$'
  self.assertEqual(generator.to_dart(), """
/home/loose/projects/canonical/git/ubuntu-desktop-provision/packages/subiquity_client/generator/test_generator.py:234: SyntaxWarning: invalid escape sequence '\$'
  self.assertEqual(generator.to_dart(), """
/home/loose/projects/canonical/git/ubuntu-desktop-provision/packages/subiquity_client/generator/test_generator.py:309: SyntaxWarning: invalid escape sequence '\$'
  self.assertEqual(generator.to_dart(), """
```

The backslash needs to be escaped in the test assertions.