### PR TITLE
generator: update to match Subiquity moved API types

### DIFF
--- a/packages/subiquity_client/generator/Makefile
+++ b/packages/subiquity_client/generator/Makefile
@@ -1,4 +1,5 @@
-types_py = ../subiquity/subiquity/common/types.py
+types_py = ../subiquity/subiquity/common/types/__init__.py \
+	   ../subiquity/subiquity/common/types/storage.py
 types_dart = ../lib/src/types.dart
 
 generate:


### PR DESCRIPTION
Subiquity is moving API types away from subiquity/common/types.py into subiquity/common/types/{__init__,storage}.py. Ensure the makefile follows the new architecture.

Marking as a draft for now. This will be needed once https://github.com/canonical/subiquity/pull/2010 lands in udi.