### PR TITLE
Accept environment variable for whitelabel.yaml file path

### DIFF
--- a/packages/factory_reset_tools/pubspec.lock
+++ b/packages/factory_reset_tools/pubspec.lock
@@ -350,7 +350,7 @@ packages:
     source: hosted
     version: "0.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"

--- a/packages/factory_reset_tools/pubspec.yaml
+++ b/packages/factory_reset_tools/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   handy_window: ^0.4.0
   intl: ^0.18.1
   meta: ^1.11.0
+  path: ^1.8.3
   retry: ^3.1.2
   ubuntu_localizations: ^0.3.5
   ubuntu_utils: ^0.1.0

--- a/packages/ubuntu_provision/lib/src/eula/eula_page.dart
+++ b/packages/ubuntu_provision/lib/src/eula/eula_page.dart
@@ -12,9 +12,14 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
+const defaultFilePath = '/usr/share/desktop-provision';
+
 final eulaPageProvider = FutureProvider<File>((ref) async {
   final locale = Intl.defaultLocale ?? await findSystemLocale();
-  const directory = '/usr/share/desktop-provision/eula';
+  final directory = p.join(
+    Platform.environment['DESKTOP_PROVISION_PATH'] ?? defaultFilePath,
+    'eula',
+  );
   final localizedEula = File(p.join(directory, 'EULA_$locale.pdf'));
   late final fallbackEula = File(p.join(directory, 'EULA.pdf'));
   final eulaFile = localizedEula.existsSync() ? localizedEula : fallbackEula;
@@ -43,7 +48,14 @@ class _EulaPageState extends ConsumerState<EulaPage> {
           Logger('eula')
               .error('Error loading EULA file: $error', error, stackTrace);
           return _EulaPdfViewer(
-              path: File('/usr/share/desktop-provision/eula/EULA.pdf').path);
+            path: File(
+              p.join(
+                Platform.environment['DESKTOP_PROVISION_PATH'] ??
+                    defaultFilePath,
+                'eula/EULA.pdf',
+              ),
+            ).path,
+          );
         });
 
     return WizardPage(

--- a/packages/ubuntu_provision/lib/src/services/config_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/config_service.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: avoid_catches_without_on_clauses
 
+import 'dart:io';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/services.dart';
@@ -123,7 +124,10 @@ class ConfigService {
   @visibleForTesting
   static String? lookupPath(FileSystem fs) {
     for (final ext in _extensions) {
-      final path = join(whiteLabelDirectory, '$_filename.$ext');
+      final path = join(
+        Platform.environment['DESKTOP_PROVISION_PATH'] ?? whiteLabelDirectory,
+        '$_filename.$ext',
+      );
       if (fs.file(path).existsSync()) return path;
     }
     return null;


### PR DESCRIPTION
This patch allows to specify the path where the whitelabel file is stored by using an environment variable. This allows to avoid the problem of running ubuntu-desktop-init from outside a snap container.