### PR TITLE
Revert "Stage the gobject introspection packages needed for ubuntu-bug"

### DIFF
--- a/ci/snap/bootstrap/snapcraft.yaml
+++ b/ci/snap/bootstrap/snapcraft.yaml
@@ -198,7 +198,6 @@ parts:
       - libgl1
       - libglib2.0-0
       - libglib2.0-dev
-      - libgirepository-1.0-1
       - libgtk-3-0
       - libpango-1.0-0
       - libpangocairo-1.0-0
@@ -216,7 +215,6 @@ parts:
       - shared-mime-info
       - libglib2.0-bin
       - libibus-1.0-5
-      - python3-gi
     prime:
       - usr/lib/*/libEGL*.so.*
       - usr/lib/*/libGL*.so.*
@@ -244,7 +242,6 @@ parts:
       - usr/lib/*/libpciaccess*.so.*
       - usr/lib/*/libsensors*.so.*
       - usr/lib/*/libvulkan*.so.*
-      - usr/lib/python3/dist-packages/gi
       - usr/share/glvnd/egl_vendor.d
       - usr/lib/*/gdk-pixbuf-2.0
       - usr/lib/*/


### PR DESCRIPTION
This reverts commit 08144484541bdfb2d794d31fa1fb1ed544c9e17e.

Getting ubuntu-bug to work would require more work so we are going for an alternative solution