### PR TITLE
 Allow to hide pages don't needed in core desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ theme:
 # - error: The page that shows when something goes wrong
 #
 # Init pages (for oem only)
-# - identity: Create the first-user account 
-# - ubuntu-pro: Enable Ubuntu Pro
+# - identity: Create the first-user account
+# - ubuntu-pro-onboarding: Enable Ubuntu Pro
 # - eula: Accept the OEM provided EULA
 # - privacy: Enable location services
 # - timezone: Set the timezone
 # - telemetry: Enable sending telemetry
 #
-# Do note that currently only accessibility, try-or-install, refresh and source-selection can be hidden.
+# Do note that currently only ubuntu-pro-onboarding, eula, accessibility, try-or-install, refresh and source-selection can be hidden.
 pages:
   <page-name>:
     image: <image-name>

--- a/packages/ubuntu_init/lib/src/init_step.dart
+++ b/packages/ubuntu_init/lib/src/init_step.dart
@@ -8,12 +8,12 @@ import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
 enum InitStep with RouteName {
   locale(LocalePage.new),
-  accessibility(AccessibilityPage.new),
+  accessibility(AccessibilityPage.new, allowedToHide: true),
   keyboard(KeyboardPage.new),
   network(NetworkPage.new),
   eula(EulaPage.new, allowedToHide: true),
   identity(IdentityPage.new),
-  ubuntuProOnboarding(UbuntuProOnboardingPage.new),
+  ubuntuProOnboarding(UbuntuProOnboardingPage.new, allowedToHide: true),
   ubuntuPro(UbuntuProPage.new, discreteStep: false),
   ubuntuProSuccess(UbuntuProSuccessAttachPage.new,
       hasPrevious: false, discreteStep: false),


### PR DESCRIPTION
 Core desktop doesn't require the UbuntuPro page. Also, at the moment, the Accessibility doesn't work. So those two pages must be allowed to be hiden.