### PR TITLE
feat(bootstrap): include subiquity late commands fix

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -29,7 +29,7 @@ command:
       gsettings: ^0.2.8
       handy_window: ^0.4.0
       intl: ^0.18.1
-      json_annotation: ^4.8.1
+      json_annotation: ^4.9.0
       meta: ^1.11.0
       nm: ^0.5.0
       package_config: ^2.1.0

--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -1,5 +1,5 @@
 // TODO(Lukas): Rename enums to dart style
-// ignore_for_file: constant_identifier_names
+// ignore_for_file: constant_identifier_names, always_put_required_named_parameters_first
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -94,7 +94,7 @@ enum ApplicationState {
   WAITING,
   RUNNING,
   UU_RUNNING,
-  UU_CANCELLING,
+  LATE_COMMANDS,
   DONE,
   ERROR,
   EXITED,
@@ -555,7 +555,6 @@ class GuidedChoiceV2 with _$GuidedChoiceV2 {
     RecoveryKey? recoveryKey,
     // TODO(Lukas): Change `generator.py` to accommodate for putting the
     // SizingPolicy parameter together with the other required parameters.
-    // ignore: always_put_required_named_parameters_first
     required SizingPolicy? sizingPolicy,
     @Default(false) bool resetPartition,
     int? resetPartitionSize,
@@ -1021,6 +1020,7 @@ class MirrorPost with _$MirrorPost {
     String? elected,
     List<String>? candidates,
     String? staged,
+    bool? useDuringInstallation,
   }) = _MirrorPost;
 
   factory MirrorPost.fromJson(Map<String, dynamic> json) =>
@@ -1039,6 +1039,7 @@ class MirrorGet with _$MirrorGet {
     required String? elected,
     required List<String> candidates,
     required String? staged,
+    required bool useDuringInstallation,
   }) = _MirrorGet;
 
   factory MirrorGet.fromJson(Map<String, dynamic> json) =>

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -7992,7 +7992,6 @@ mixin _$GuidedChoiceV2 {
   RecoveryKey? get recoveryKey =>
       throw _privateConstructorUsedError; // TODO(Lukas): Change `generator.py` to accommodate for putting the
 // SizingPolicy parameter together with the other required parameters.
-// ignore: always_put_required_named_parameters_first
   SizingPolicy? get sizingPolicy => throw _privateConstructorUsedError;
   bool get resetPartition => throw _privateConstructorUsedError;
   int? get resetPartitionSize => throw _privateConstructorUsedError;
@@ -8196,7 +8195,6 @@ class _$GuidedChoiceV2Impl implements _GuidedChoiceV2 {
   final RecoveryKey? recoveryKey;
 // TODO(Lukas): Change `generator.py` to accommodate for putting the
 // SizingPolicy parameter together with the other required parameters.
-// ignore: always_put_required_named_parameters_first
   @override
   final SizingPolicy? sizingPolicy;
   @override
@@ -8273,7 +8271,6 @@ abstract class _GuidedChoiceV2 implements GuidedChoiceV2 {
   RecoveryKey? get recoveryKey;
   @override // TODO(Lukas): Change `generator.py` to accommodate for putting the
 // SizingPolicy parameter together with the other required parameters.
-// ignore: always_put_required_named_parameters_first
   SizingPolicy? get sizingPolicy;
   @override
   bool get resetPartition;
@@ -14375,6 +14372,7 @@ mixin _$MirrorPost {
   String? get elected => throw _privateConstructorUsedError;
   List<String>? get candidates => throw _privateConstructorUsedError;
   String? get staged => throw _privateConstructorUsedError;
+  bool? get useDuringInstallation => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -14388,7 +14386,11 @@ abstract class $MirrorPostCopyWith<$Res> {
           MirrorPost value, $Res Function(MirrorPost) then) =
       _$MirrorPostCopyWithImpl<$Res, MirrorPost>;
   @useResult
-  $Res call({String? elected, List<String>? candidates, String? staged});
+  $Res call(
+      {String? elected,
+      List<String>? candidates,
+      String? staged,
+      bool? useDuringInstallation});
 }
 
 /// @nodoc
@@ -14407,6 +14409,7 @@ class _$MirrorPostCopyWithImpl<$Res, $Val extends MirrorPost>
     Object? elected = freezed,
     Object? candidates = freezed,
     Object? staged = freezed,
+    Object? useDuringInstallation = freezed,
   }) {
     return _then(_value.copyWith(
       elected: freezed == elected
@@ -14421,6 +14424,10 @@ class _$MirrorPostCopyWithImpl<$Res, $Val extends MirrorPost>
           ? _value.staged
           : staged // ignore: cast_nullable_to_non_nullable
               as String?,
+      useDuringInstallation: freezed == useDuringInstallation
+          ? _value.useDuringInstallation
+          : useDuringInstallation // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 }
@@ -14433,7 +14440,11 @@ abstract class _$$MirrorPostImplCopyWith<$Res>
       __$$MirrorPostImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String? elected, List<String>? candidates, String? staged});
+  $Res call(
+      {String? elected,
+      List<String>? candidates,
+      String? staged,
+      bool? useDuringInstallation});
 }
 
 /// @nodoc
@@ -14450,6 +14461,7 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
     Object? elected = freezed,
     Object? candidates = freezed,
     Object? staged = freezed,
+    Object? useDuringInstallation = freezed,
   }) {
     return _then(_$MirrorPostImpl(
       elected: freezed == elected
@@ -14464,6 +14476,10 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
           ? _value.staged
           : staged // ignore: cast_nullable_to_non_nullable
               as String?,
+      useDuringInstallation: freezed == useDuringInstallation
+          ? _value.useDuringInstallation
+          : useDuringInstallation // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -14472,7 +14488,10 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$MirrorPostImpl implements _MirrorPost {
   const _$MirrorPostImpl(
-      {this.elected, final List<String>? candidates, this.staged})
+      {this.elected,
+      final List<String>? candidates,
+      this.staged,
+      this.useDuringInstallation})
       : _candidates = candidates;
 
   factory _$MirrorPostImpl.fromJson(Map<String, dynamic> json) =>
@@ -14492,10 +14511,12 @@ class _$MirrorPostImpl implements _MirrorPost {
 
   @override
   final String? staged;
+  @override
+  final bool? useDuringInstallation;
 
   @override
   String toString() {
-    return 'MirrorPost(elected: $elected, candidates: $candidates, staged: $staged)';
+    return 'MirrorPost(elected: $elected, candidates: $candidates, staged: $staged, useDuringInstallation: $useDuringInstallation)';
   }
 
   @override
@@ -14506,13 +14527,19 @@ class _$MirrorPostImpl implements _MirrorPost {
             (identical(other.elected, elected) || other.elected == elected) &&
             const DeepCollectionEquality()
                 .equals(other._candidates, _candidates) &&
-            (identical(other.staged, staged) || other.staged == staged));
+            (identical(other.staged, staged) || other.staged == staged) &&
+            (identical(other.useDuringInstallation, useDuringInstallation) ||
+                other.useDuringInstallation == useDuringInstallation));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, elected,
-      const DeepCollectionEquality().hash(_candidates), staged);
+  int get hashCode => Object.hash(
+      runtimeType,
+      elected,
+      const DeepCollectionEquality().hash(_candidates),
+      staged,
+      useDuringInstallation);
 
   @JsonKey(ignore: true)
   @override
@@ -14532,7 +14559,8 @@ abstract class _MirrorPost implements MirrorPost {
   const factory _MirrorPost(
       {final String? elected,
       final List<String>? candidates,
-      final String? staged}) = _$MirrorPostImpl;
+      final String? staged,
+      final bool? useDuringInstallation}) = _$MirrorPostImpl;
 
   factory _MirrorPost.fromJson(Map<String, dynamic> json) =
       _$MirrorPostImpl.fromJson;
@@ -14543,6 +14571,8 @@ abstract class _MirrorPost implements MirrorPost {
   List<String>? get candidates;
   @override
   String? get staged;
+  @override
+  bool? get useDuringInstallation;
   @override
   @JsonKey(ignore: true)
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
@@ -14559,6 +14589,7 @@ mixin _$MirrorGet {
   String? get elected => throw _privateConstructorUsedError;
   List<String> get candidates => throw _privateConstructorUsedError;
   String? get staged => throw _privateConstructorUsedError;
+  bool get useDuringInstallation => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -14575,7 +14606,8 @@ abstract class $MirrorGetCopyWith<$Res> {
       {bool relevant,
       String? elected,
       List<String> candidates,
-      String? staged});
+      String? staged,
+      bool useDuringInstallation});
 }
 
 /// @nodoc
@@ -14595,6 +14627,7 @@ class _$MirrorGetCopyWithImpl<$Res, $Val extends MirrorGet>
     Object? elected = freezed,
     Object? candidates = null,
     Object? staged = freezed,
+    Object? useDuringInstallation = null,
   }) {
     return _then(_value.copyWith(
       relevant: null == relevant
@@ -14613,6 +14646,10 @@ class _$MirrorGetCopyWithImpl<$Res, $Val extends MirrorGet>
           ? _value.staged
           : staged // ignore: cast_nullable_to_non_nullable
               as String?,
+      useDuringInstallation: null == useDuringInstallation
+          ? _value.useDuringInstallation
+          : useDuringInstallation // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -14629,7 +14666,8 @@ abstract class _$$MirrorGetImplCopyWith<$Res>
       {bool relevant,
       String? elected,
       List<String> candidates,
-      String? staged});
+      String? staged,
+      bool useDuringInstallation});
 }
 
 /// @nodoc
@@ -14647,6 +14685,7 @@ class __$$MirrorGetImplCopyWithImpl<$Res>
     Object? elected = freezed,
     Object? candidates = null,
     Object? staged = freezed,
+    Object? useDuringInstallation = null,
   }) {
     return _then(_$MirrorGetImpl(
       relevant: null == relevant
@@ -14665,6 +14704,10 @@ class __$$MirrorGetImplCopyWithImpl<$Res>
           ? _value.staged
           : staged // ignore: cast_nullable_to_non_nullable
               as String?,
+      useDuringInstallation: null == useDuringInstallation
+          ? _value.useDuringInstallation
+          : useDuringInstallation // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -14676,7 +14719,8 @@ class _$MirrorGetImpl implements _MirrorGet {
       {required this.relevant,
       required this.elected,
       required final List<String> candidates,
-      required this.staged})
+      required this.staged,
+      required this.useDuringInstallation})
       : _candidates = candidates;
 
   factory _$MirrorGetImpl.fromJson(Map<String, dynamic> json) =>
@@ -14696,10 +14740,12 @@ class _$MirrorGetImpl implements _MirrorGet {
 
   @override
   final String? staged;
+  @override
+  final bool useDuringInstallation;
 
   @override
   String toString() {
-    return 'MirrorGet(relevant: $relevant, elected: $elected, candidates: $candidates, staged: $staged)';
+    return 'MirrorGet(relevant: $relevant, elected: $elected, candidates: $candidates, staged: $staged, useDuringInstallation: $useDuringInstallation)';
   }
 
   @override
@@ -14712,13 +14758,20 @@ class _$MirrorGetImpl implements _MirrorGet {
             (identical(other.elected, elected) || other.elected == elected) &&
             const DeepCollectionEquality()
                 .equals(other._candidates, _candidates) &&
-            (identical(other.staged, staged) || other.staged == staged));
+            (identical(other.staged, staged) || other.staged == staged) &&
+            (identical(other.useDuringInstallation, useDuringInstallation) ||
+                other.useDuringInstallation == useDuringInstallation));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, relevant, elected,
-      const DeepCollectionEquality().hash(_candidates), staged);
+  int get hashCode => Object.hash(
+      runtimeType,
+      relevant,
+      elected,
+      const DeepCollectionEquality().hash(_candidates),
+      staged,
+      useDuringInstallation);
 
   @JsonKey(ignore: true)
   @override
@@ -14739,7 +14792,8 @@ abstract class _MirrorGet implements MirrorGet {
       {required final bool relevant,
       required final String? elected,
       required final List<String> candidates,
-      required final String? staged}) = _$MirrorGetImpl;
+      required final String? staged,
+      required final bool useDuringInstallation}) = _$MirrorGetImpl;
 
   factory _MirrorGet.fromJson(Map<String, dynamic> json) =
       _$MirrorGetImpl.fromJson;
@@ -14752,6 +14806,8 @@ abstract class _MirrorGet implements MirrorGet {
   List<String> get candidates;
   @override
   String? get staged;
+  @override
+  bool get useDuringInstallation;
   @override
   @JsonKey(ignore: true)
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -101,7 +101,7 @@ const _$ApplicationStateEnumMap = {
   ApplicationState.WAITING: 'WAITING',
   ApplicationState.RUNNING: 'RUNNING',
   ApplicationState.UU_RUNNING: 'UU_RUNNING',
-  ApplicationState.UU_CANCELLING: 'UU_CANCELLING',
+  ApplicationState.LATE_COMMANDS: 'LATE_COMMANDS',
   ApplicationState.DONE: 'DONE',
   ApplicationState.ERROR: 'ERROR',
   ApplicationState.EXITED: 'EXITED',
@@ -1389,6 +1389,7 @@ _$MirrorPostImpl _$$MirrorPostImplFromJson(Map<String, dynamic> json) =>
           ?.map((e) => e as String)
           .toList(),
       staged: json['staged'] as String?,
+      useDuringInstallation: json['use_during_installation'] as bool?,
     );
 
 Map<String, dynamic> _$$MirrorPostImplToJson(_$MirrorPostImpl instance) =>
@@ -1396,6 +1397,7 @@ Map<String, dynamic> _$$MirrorPostImplToJson(_$MirrorPostImpl instance) =>
       'elected': instance.elected,
       'candidates': instance.candidates,
       'staged': instance.staged,
+      'use_during_installation': instance.useDuringInstallation,
     };
 
 _$MirrorGetImpl _$$MirrorGetImplFromJson(Map<String, dynamic> json) =>
@@ -1406,6 +1408,7 @@ _$MirrorGetImpl _$$MirrorGetImplFromJson(Map<String, dynamic> json) =>
           .map((e) => e as String)
           .toList(),
       staged: json['staged'] as String?,
+      useDuringInstallation: json['use_during_installation'] as bool,
     );
 
 Map<String, dynamic> _$$MirrorGetImplToJson(_$MirrorGetImpl instance) =>
@@ -1414,6 +1417,7 @@ Map<String, dynamic> _$$MirrorGetImplToJson(_$MirrorGetImpl instance) =>
       'elected': instance.elected,
       'candidates': instance.candidates,
       'staged': instance.staged,
+      'use_during_installation': instance.useDuringInstallation,
     };
 
 _$AdConnectionInfoImpl _$$AdConnectionInfoImplFromJson(

--- a/packages/subiquity_client/pubspec.yaml
+++ b/packages/subiquity_client/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   freezed_annotation: ^2.4.1
-  json_annotation: ^4.8.1
+  json_annotation: ^4.9.0
   meta: ^1.11.0
   package_config: ^2.1.0
   path: ^1.8.3

--- a/packages/subiquity_client/test/status_monitor_test.dart
+++ b/packages/subiquity_client/test/status_monitor_test.dart
@@ -33,7 +33,6 @@ ApplicationStatus testStatus(ApplicationState state) {
 final isWaiting = testStatus(ApplicationState.WAITING);
 final isRunning = testStatus(ApplicationState.RUNNING);
 final isDone = testStatus(ApplicationState.DONE);
-final isCancelling = testStatus(ApplicationState.UU_CANCELLING);
 
 @GenerateMocks([HttpClient, HttpClientRequest, HttpClientResponse])
 void main() {
@@ -104,8 +103,6 @@ void main() {
         .thenAnswer((_) async => statusResponse(isRunning));
     when(client.openUrl('GET', wasRunning))
         .thenAnswer((_) async => statusResponse(isDone));
-    when(client.openUrl('GET', wasDone))
-        .thenAnswer((_) async => statusResponse(isCancelling));
 
     final monitor = SubiquityStatusMonitor(client);
 
@@ -115,7 +112,6 @@ void main() {
       monitor.onStatusChanged,
       emitsInOrder([isRunning, isDone]),
     );
-    await expectLater(monitor.onStatusChanged, neverEmits(isCancelling));
   });
 
   test('error', () async {

--- a/packages/ubuntu_bootstrap/test/install/install_model_test.dart
+++ b/packages/ubuntu_bootstrap/test/install/install_model_test.dart
@@ -111,6 +111,10 @@ void main() async {
     expect(model.isInstalling, isTrue);
     expect(model.isDone, isFalse);
 
+    await waitForState(ApplicationState.LATE_COMMANDS);
+    expect(model.isInstalling, isTrue);
+    expect(model.isDone, isFalse);
+
     await waitForState(ApplicationState.DONE);
     expect(model.isInstalling, isFalse);
     expect(model.isDone, isTrue);


### PR DESCRIPTION
This includes the subiquity [fix](https://github.com/canonical/subiquity/pull/2013) for [lp:2065958](https://bugs.launchpad.net/subiquity/+bug/2065958) in the desktop installer.

I've added a test case that ensures the `LATE_COMMANDS` status is treated correctly, i.e. leaves the installation page in the "installing" state.

Supersedes #781
UDENG-3382