### PR TITLE
feat(provd): provd user and usergroup now created by deb

### DIFF
--- a/provd/debian/changelog
+++ b/provd/debian/changelog
@@ -1,6 +1,7 @@
-provd (0.1.5~ppa1) noble; urgency=medium
+provd (0.1.5~ppa2) noble; urgency=medium
 
   * Remove Ubuntu Pro and Chmod services
+  * Provd user and user group created on install
 
  -- Matthew Gary Hagemann <matt.hagemann@canonical.com>  Mon, 1 Jul 2024 14:23:46 +0200
 

--- a/provd/debian/provd.postinst
+++ b/provd/debian/provd.postinst
@@ -4,8 +4,16 @@ set -e
 
 case "$1" in
     configure)
-        # Create the provd group and add gnome-initial-setup to it.
-        addgroup --system provd
+        # Create the provd user and group if they aren't already there
+        if ! getent passwd provd >/dev/null; then
+            adduser --system --group --force-badname --quiet \
+                --home /run/provd/ --no-create-home \
+                --shell /bin/false \
+                provd
+        fi
+
+        # TODO: Replace gis user with provd user when session is updated. 
+        # Add gnome-initial-setup to the provd group
         usermod -G provd gnome-initial-setup
 
         # Set ownership and permissions for launch-desktop-provision-init.sh
@@ -20,3 +28,4 @@ esac
 #DEBHELPER#
 
 exit 0
+

--- a/provd/debian/provd.postrm
+++ b/provd/debian/provd.postrm
@@ -5,10 +5,21 @@ set -e
 case "$1" in
     purge)
         # Revert gnome-initial-setup to nogroup
-        usermod -G nogroup gnome-initial-setup
-        
-        # Remove provd group
-        groupdel provd
+        if getent passwd gnome-initial-setup >/dev/null; then
+            usermod -G nogroup gnome-initial-setup
+        fi
+
+        # Remove provd user if it exists
+        if getent passwd provd >/dev/null; then
+            if which deluser >/dev/null 2>&1; then
+                deluser --system provd || echo "Could not remove provd user."
+            fi
+        fi
+
+        # Remove provd group if it exists
+        if getent group provd >/dev/null; then
+            groupdel provd || echo "Could not remove provd group."
+        fi
         ;;
 esac
 


### PR DESCRIPTION
This is a step towards us replacing GIS by creating the provd user and group in the `postint` and `postrm` stages, though it will be in a future pr to swap to using them entirely (we need to write our own session files first)

- Added `provd` user creation to deb packaging
- Better conditional handling of the creation and removal of groups and `provd` user
- Appended to `debian/changelog`

Closes UDENG-3392