### PR TITLE
feat(provision): show message to run ubuntu-bug on error page

### DIFF
--- a/packages/ubuntu_provision/lib/src/error/error_page.dart
+++ b/packages/ubuntu_provision/lib/src/error/error_page.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_provision/src/error/error_model.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
@@ -35,6 +38,8 @@ class ErrorPage extends ConsumerWidget with ProvisioningPage {
     final linkText = match?.group(1);
     final endText = match?.end != null ? bodyText.substring(match!.end) : '';
     final model = ref.watch(errorModelProvider);
+
+    final snapName = Platform.environment['SNAP_NAME'];
 
     return WizardPage(
       headerPadding: EdgeInsets.zero,
@@ -72,6 +77,16 @@ class ErrorPage extends ConsumerWidget with ProvisioningPage {
                         ],
                       ),
                     ),
+                    if (snapName != null) ...[
+                      const SizedBox(height: 20),
+                      Html(
+                        data: lang.errorPageUbuntuBug(snapName),
+                        style: {
+                          'body': Style(margin: Margins.zero),
+                          'pre': Style(fontFamily: 'Ubuntu Mono')
+                        },
+                      ),
+                    ]
                   ],
                 ),
               ),

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
@@ -33,7 +33,7 @@
   "accessibilityDesktopZoomLabel": "Desktop zoom",
   "errorPageTitle": "Something went wrong",
   "errorPageUnexpected": "We're sorry, but we're not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.",
-  "errorPageUbuntuBug": "To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug {SNAP}</pre> in a terminal, or from the command console (Alt+F2).",
+  "errorPageUbuntuBug": "To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug {SNAP}</pre> in a terminal, or from the command console (Alt+F2).",
   "@errorPageUbuntuBug": {
     "placeholders": {
       "SNAP": {

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
@@ -33,6 +33,14 @@
   "accessibilityDesktopZoomLabel": "Desktop zoom",
   "errorPageTitle": "Something went wrong",
   "errorPageUnexpected": "We're sorry, but we're not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.",
+  "errorPageUbuntuBug": "To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug {SNAP}</pre> in a terminal, or from the command console (Alt+F2).",
+  "@errorPageUbuntuBug": {
+    "placeholders": {
+      "SNAP": {
+        "type": "String"
+      }
+    }
+  },
   "errorPageShowLog": "Show log",
   "errorPageHideLog": "Hide log",
   "restart": "Restart",

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
@@ -351,6 +351,12 @@ abstract class UbuntuProvisionLocalizations {
   /// **'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.'**
   String get errorPageUnexpected;
 
+  /// No description provided for @errorPageUbuntuBug.
+  ///
+  /// In en, this message translates to:
+  /// **'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug {SNAP}</pre> in a terminal, or from the command console (Alt+F2).'**
+  String errorPageUbuntuBug(String SNAP);
+
   /// No description provided for @errorPageShowLog.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
@@ -354,7 +354,7 @@ abstract class UbuntuProvisionLocalizations {
   /// No description provided for @errorPageUbuntuBug.
   ///
   /// In en, this message translates to:
-  /// **'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug {SNAP}</pre> in a terminal, or from the command console (Alt+F2).'**
+  /// **'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug {SNAP}</pre> in a terminal, or from the command console (Alt+F2).'**
   String errorPageUbuntuBug(String SNAP);
 
   /// No description provided for @errorPageShowLog.

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsAm extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsAm extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsAr extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsAr extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsBe extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Нам вельмі шкада, але мы не ўпэўненыя, якая памылка дакладна адбылася. Вы можаце перазапусціць камп\'ютар і пачаць працэс усталявання яшчэ раз. Вы таксама можаце <a>паведаміць аб праблеме</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Паказаць журнал';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsBe extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsBg extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsBg extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsBn extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsBn extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsBo extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsBo extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsBs extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsBs extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsCa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsCa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsCs extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsCs extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Je nám líto, ale nejsme si jisti, v čem je chyba. Můžete zkusit restartovat počítač a spustit proces instalace znovu. Můžete také <a>problém nahlásit</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Zobrazit záznam';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsCy extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsCy extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsDa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Vi beklager, men vi ved ikke helt, hvad fejlen er. Du kan genstarte computeren og starte installationsproceduren igen. Du kan også <a>indrapportere problemet</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Vis log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsDa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsDe extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Es tut uns leid, aber wir sind uns nicht sicher, was der Fehler ist. Sie können versuchen, Ihren Computer neu zu starten und den Installationsprozess erneut zu beginnen. Sie können auch das <a>Problem melden</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Protokoll anzeigen';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsDe extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsDz extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsDz extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsEl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsEl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsEn extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsEn extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsEo extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsEo extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Bedaŭrinde, ni ne konas la eraron. Vi povas provi restartigi vian komputilon kaj rekomenci la instalon. Vi ankaŭ povas <a>raporti la problemon</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Montri protokolon';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsEs extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsEs extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Lo sentimos, pero no estamos seguros de cuál es el error. Puede intentar reiniciar su computadora y comenzar el proceso de instalación nuevamente. También puede <a>informar del problema</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Mostrar registro';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsEt extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsEt extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsEu extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsEu extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsFa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'متأسفانه مطمئن نیستیم که خطا از کجاست. می‌توانید رایانه‌تان را دوباره راه انداخته و فرایند نصب را آغاز کنید. همچنین می‌توانید <a>مشکل را گزارش کنید</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'نمایش گزارش‌ها';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsFa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsFi extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsFi extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Valitettavasti emme ole varmoja, mikä aiheutti ongelman. Voit käynnistää tietokoneen uudelleen ja käynnistää asennuksen uudelleen. Voit myös <a>ilmoittaa kohtaamastasi ongelmasta</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Näytä loki';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsFr extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Nous sommes désolés, mais nous ne sommes pas sûrs de l\'erreur. Vous pouvez essayer de redémarrer votre ordinateur et recommencer le processus d\'installation. Vous pouvez également <a> signaler le problème</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Afficher le journal';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsFr extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsGa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsGa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsGl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsGl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsGu extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsGu extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsHe extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'אנחנו לא בטוחים מה השגיאה, סליחה. אפשר לנסות להפעיל את המחשב מחדש ולהפעיל את תהליך ההתקנה מחדש. אפשר גם <a>לדווח על התקלה</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'הצגת היומן';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsHe extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsHi extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsHi extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsHr extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsHr extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsHu extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsHu extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsId extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Kami minta maaf, tetapi kami tidak yakin apa kesalahannya. Anda dapat mencoba menjalankan ulang komputer Anda dan memulai proses instalasi lagi. Anda juga dapat <a>melaporkan masalah</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Tampilkan log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsId extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsIs extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsIs extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsIt extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsIt extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsJa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'すみません、なにかエラーが起きました。コンピューターを再起動してもう一度インストールを開始してみてください。この問題の<a>報告</a>もできます。';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'ログを表示';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsJa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsKa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsKa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsKk extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsKk extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsKm extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsKm extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsKn extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsKn extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsKo extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsKo extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsKu extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsKu extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsLo extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsLo extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsLt extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsLt extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsLv extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsLv extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsMk extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsMk extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsMl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsMl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsMr extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsMr extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsMy extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsMy extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsNb extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsNb extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Beklager. Finner ikke ut hva feilen er. Etter en omstart kan du starte installasjonsprosessen igjen. Du kan også <a>rapportere en feil</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Vis logg';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsNe extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsNe extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsNl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsNl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsNn extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsNn extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsOc extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'O planhèm, mas sabèm pas quina error es. Podètz ensajar de reaviar l’ordenador e començar lo processús d’installacion tornamai. Podètz tanben<a>senhalar l’anomalia</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Afichar lo jornal';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsOc extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsPa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsPa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsPl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Przepraszamy, ale nie jesteśmy pewni, na czym polega błąd. Możesz spróbować ponownie uruchomić komputer i jeszcze raz rozpocząć proces instalacji. Możesz także <a>zgłosić problem</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Pokaż dziennik';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsPl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsPt extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsPt extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsRo extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsRo extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsRu extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Сожалеем, но мы не уверены, в чем заключается ошибка. Вы можете попробовать перезагрузить компьютер и начать процесс установки заново. Также Вы можете создать <a>сообщение о проблеме</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Показать журнал';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsRu extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSe extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSe extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSi extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'සටහන් පෙන්වන්න';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSi extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSk extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSk extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Ospravedlňujeme sa, ale nie sme si istí, v čom je chyba. Môžete skúsiť reštartovať počítač a znova spustiť proces inštalácie. Môžete tiež <a>nahlásiť problém</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Zobraziť denník';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSq extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSq extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSr extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSr extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsSv extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsSv extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'Vi är ledsna, men vi är inte säkra på vad felet är. Du kan prova att starta om datorn och starta installationsprocessen igen. Du kan också <a>rapportera problemet</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Visa logg';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsTa extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsTa extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsTe extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsTe extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsTg extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsTg extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsTh extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsTh extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsTl extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsTl extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsTr extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Günlüğü görüntüle';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsTr extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsUg extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsUg extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsUk extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsUk extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsVi extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsVi extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => 'We\'re sorry, but we\'re not sure what the error is. You can try restarting your computer and start the installation process again. You can can also <a>report the issue</a>.';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => 'Show log';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
@@ -66,6 +66,11 @@ class UbuntuProvisionLocalizationsZh extends UbuntuProvisionLocalizations {
   String get errorPageUnexpected => '很抱歉，但我们不确定问题所在。您可以尝试重新启动计算机，并再次启动安装进程。您也可以<a>报告问题</a>。';
 
   @override
+  String errorPageUbuntuBug(String SNAP) {
+    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+  }
+
+  @override
   String get errorPageShowLog => '显示日志';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
@@ -67,7 +67,7 @@ class UbuntuProvisionLocalizationsZh extends UbuntuProvisionLocalizations {
 
   @override
   String errorPageUbuntuBug(String SNAP) {
-    return 'To send an automated bug report including relevant debug information, please run <pre>ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
+    return 'To send an automated bug report including relevant debug information, please run <pre>sudo ubuntu-bug $SNAP</pre> in a terminal, or from the command console (Alt+F2).';
   }
 
   @override


### PR DESCRIPTION
Since automatically running `ubuntu-bug` currently doesn't work due to classic snap confinement issues, @seb128 suggested displaying a corresponding message on the error page instead.

![Screenshot from 2024-07-08 12-05-22](https://github.com/canonical/ubuntu-desktop-provision/assets/113362648/30ad9726-2423-47a2-893d-b29da476a36e)


UDENG-3172