### PR TITLE
docs: Gnome Initial Setup revisions

### DIFF
--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -32,18 +32,20 @@ account is created, allowing user account creation to be passed off to Gnome-Ini
 ## Method 1: Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml
 
 The new [Ubuntu Desktop Bootstrap](https://github.com/canonical/ubuntu-desktop-provision) Flutter installer can be 
-given a `whitelabel.yaml` file to customize its appearance and behavior. One thing you can configure is the `mode` you 
-would like to run the installer in. 
+given a `whitelabel.yaml` file to customize its appearance and behaviour. For example, the installer can be configured
+to run in a specific `mode`.
 
-The `oem` mode skips user creation and time zone setup during installation, leaving them to be handled by Gnome Initial 
-Setup post installation.
+When `oem` mode is active, user creation and time zone setup are skipped during installation, leaving them to be handled by Gnome Initial 
+Setup post-installation.
 
-The following `whitelabel.yaml` placed in `/usr/share/desktop-provision/whitelabel.yaml` on your LiveCD is sufficient 
-to skip user creation during installation, provided you are using the new Ubuntu Desktop Bootstrap installer:
+Enabling `oem` mode only requires the following line to be added to the `whitelabel.yaml`:
 
 ```
 mode: oem
 ```
+
+Placing this `whitelabel.yaml` at `/usr/share/desktop-provision/whitelabel.yaml` on your LiveCD is sufficient 
+to skip user creation during installation, provided you are using the new Ubuntu Desktop Bootstrap installer.
 
 A comprehensive guide to customizing a LiveCD can be found [here](https://help.ubuntu.com/community/LiveCDCustomization).
 
@@ -54,14 +56,16 @@ editing your LiveCD, provided Gnome Initial Setup is already present on your ISO
 
 #### Install ubuntu-desktop-bootstrap
 
-The following command installs the Ubuntu Desktop Bootstrap Flutter installer
+The Ubuntu Desktop Bootstrap Flutter installer first needs to be installed:
+
 ```
 sudo snap install ubuntu-desktop-bootstrap --classic
 ```
 
 #### Write a whitelabel.yaml to set OEM mode
 
-These commands create a `whitelabel.yaml` in the location Ubuntu Desktop Bootstrap will look for them.
+A `whitelabel.yaml` with `oem` mode enabled must then be created in a location Ubuntu Desktop Bootstrap will find it:
+
 ```
 sudo mkdir -p /usr/share/desktop-provision
 
@@ -70,8 +74,9 @@ sudo bash -c 'echo "mode: oem" > /usr/share/desktop-provision/whitelabel.yaml'
 
 #### Launch ubuntu-desktop-bootstrap
 
-Finally, launch the installer. You should be no be prompted for user account creation, which will be handled after the 
-installer finishes
+Finally, the installer can be launched. You should be no be prompted for user account creation, which will be handled after the 
+installer finishes:
+
 ```
 /snap/bin/ubuntu-desktop-bootstrap --try-or-install
 ```

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -21,7 +21,8 @@ that enables user account creation and setup on provisioned systems.
 - [How to provision Ubuntu with Gnome Initial Setup](#how-to-provision-ubuntu-with-gnome-initial-setup)
   - [Method 1: Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml](#method-1-triggering-gnome-initial-setup-via-the-new-flutter-installer-and-a-whitelabelyaml)
   - [Method 2: Triggering Gnome Initial Setup via an autoinstall.yaml](#method-2-triggering-gnome-initial-setup-via-an-autoinstallyaml)
-- [EULA page configuration](#eula-page-configuration)
+  - [EULA Page configuration](#eula-page-configuration)
+  - [EULA Language code format](#eula-language-code-format)
 
 # How-to provision Ubuntu with Gnome Initial Setup
 
@@ -214,11 +215,15 @@ kvm -no-reboot -m 4096 \
 This command boots the system in the VM. You will then be loaded into the Gnome-Initial-Setup session for first time 
 user creation.
 
+## EULA Page configuration
 
-# EULA page configuration
+EULA assets are expected to reside in `/usr/share/desktop-provision/eula/`, with the file name including the language
+code: `EULA_<langcode>.pdf`. If the `<langcode>` is not available, the default file `EULA.pdf` will be used.
+The language code format is the same as that used for slides, for example: `EULA_en_US.pdf`. See the [EULA Language code format
+section](#eula-language-code-format) for further details. If no EULA file is present, the page will be conditionally skipped.
 
-EULA assets are expected to reside in `/usr/share/desktop-provision/eula/` with the file name including the language
-code: EULA_<langcode>.pdf. If the <langcode> is not available, the default file EULA.pdf will be used.
-The language code format is the same as is used for slides, for example: EULA_en_US.pdf, see the [Language code format
-section](#language-code-format) for further details. If no EULA file is present, the page will be conditionally skipped.
+## EULA Language code format
 
+The language code format that is used is the two-letter language code followed by a two-letter country code (see the ISO 639-1 
+and ISO 3166-1 standards). The language code represents the primary language, while the country code specifies the regional 
+or national variant of that language. For example en_US represents American English and pt_BR represents Brazilian Portuguese.

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -83,22 +83,25 @@ Finally, the installer can be launched. You should not be prompted for user acco
 ## Method 2: Triggering Gnome Initial Setup via an autoinstall.yaml
 
 These sections are adapted from the subiquity [documentation](https://canonical-subiquity.readthedocs-hosted.com/en/latest/howto/autoinstall-quickstart.html),
-updated for triggering Gnome Initial Setup with the Ubuntu Desktop ISO
+updated for triggering Gnome Initial Setup with the Ubuntu Desktop ISO.
 
 ### Using an autoinstall provided over the network
 
-#### Getting an ISO
+#### Get an ISO
+
 You can find a desktop ISO to download on the [official Ubuntu website](https://ubuntu.com/download/desktop).
 
 #### Mount the ISO
+
 Once downloaded, you can mount the ISO to make it accessible via from a local directory. Change `<version-number>` in 
-the following command to match the release ISO you downloaded :
+the following command to match the release ISO that you downloaded:
 
 ```
 sudo mount -r ~/Downloads/ubuntu-<version-number>-amd64.iso /mnt
 ```
 
-#### Write your autoinstall configuration
+#### Write an autoinstall configuration
+
 Create your cloud-init configuration, making sure to leave the identity section out so that no user is created during 
 installation:
 
@@ -115,6 +118,8 @@ touch meta-data
 
 #### Serve the cloud-init configuration over HTTP
 
+Change into the directory where the cloud-init configuration was created and start a server:
+
 ```
 cd ~/www
 python3 -m http.server 3003
@@ -123,13 +128,14 @@ python3 -m http.server 3003
 #### Create a target disk
 
 Create the target VM disk for the installation. 25GB is the minimum recommended storage allocation for Ubuntu Desktop:
+
 ```
 truncate -s 25G image.img
 ```
 
 #### Run the installation
 
-Change `<version-number>` in the following command to match the release ISO you downloaded.
+Change `<version-number>` to match the release ISO that you downloaded before running the following command:
 
 ```
 kvm -no-reboot -m 4096 \
@@ -139,26 +145,32 @@ kvm -no-reboot -m 4096 \
     -initrd /mnt/casper/initrd \
     -append 'autoinstall ds=nocloud-net;s=http://_gateway:3003/'
 ```
+
 This command boots the VM, downloads the configuration from the server (prepared in the previous step) and runs the 
-installation. The installer reboots at the end. The `-no-reboot` option to the `kvm` command instructs `kvm` to exit on reboot.
+installation. The installer reboots at the end. The `-no-reboot` flag instructs `kvm` to exit on reboot.
 
 #### Boot the installed system
+
+Run the following command to boot the system in the VM:
 
 ```
 kvm -no-reboot -m 4096 \
     -drive file=image.img,format=raw,cache=none,if=virtio
 ```
-This command boots the system in the VM. You will then be loaded into the Gnome-Initial-Setup session for first time 
+
+You will then be loaded into the Gnome-Initial-Setup session for first time 
 user creation.
 
 ### Using another volume to provide the autoinstall configuration
 
-Use this method to create an installation medium to plug into a computer to have it be installed.
+Use this method to create an installation medium that can be plugged into a computer to trigger installation.
 
 #### Getting an ISO
+
 You can find a desktop ISO to download on the [official Ubuntu website](https://ubuntu.com/download/desktop).
 
-#### Write your autoinstall configuration
+#### Write an autoinstall configuration
+
 Create your cloud-init configuration, making sure to leave the identity section out so that no user is created during 
 installation:
 
@@ -176,11 +188,13 @@ touch meta-data
 #### Create an ISO to use as a cloud-init data source
 
 Install utilities for working with cloud images:
+
 ```
 sudo apt install cloud-image-utils
 ```
 
 Create the ISO image for cloud-init:
+
 ```
 cloud-localds ~/seed.iso user-data meta-data
 ```
@@ -188,13 +202,15 @@ cloud-localds ~/seed.iso user-data meta-data
 #### Create a target disk
 
 Create the target VM disk for the installation:
+
 ```
 truncate -s 25G image.img
 ```
 
 #### Run the installation
 
-Change `<version-number>` in the following command to match the release ISO you downloaded.
+Run the following command to boot the system and run the installation, making sure to 
+change `<version-number>` to match the release ISO that you downloaded:
 
 ```
 kvm -no-reboot -m 4096 \
@@ -203,21 +219,21 @@ kvm -no-reboot -m 4096 \
     -cdrom ~/Downloads/ubuntu-<version-number>-amd64.iso
 ```
 
-This command boots the system and runs the installation. The installer prompts for a confirmation before modifying the
-disk based on the provided `autoinstall`. To skip the need for a confirmation, interrupt the booting process, and add
-the `autoinstall` parameter to the kernel command line.
+The installer prompts for a confirmation before modifying the disk based on the provided `autoinstall`.
+To skip the need for a confirmation you can interrupt the booting process then add the `autoinstall` 
+parameter to the kernel command line.
 
-The installer reboots at the end. The `-no-reboot` option to the `kvm` command instructs `kvm` to exit on reboot.
+The installer reboots at the end. The `-no-reboot` flag instructs `kvm` to exit on reboot.
 
 #### Boot the installed system
+
+This command will boot the system in the VM:
 
 ```
 kvm -no-reboot -m 4096 \
     -drive file=image.img,format=raw,cache=none,if=virtio
 ```
-
-This command boots the system in the VM. You will then be loaded into the Gnome-Initial-Setup session for first time 
-user creation.
+You will then be loaded into the Gnome-Initial-Setup session for first time user creation.
 
 ## EULA Page configuration
 

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -26,8 +26,8 @@ that enables user account creation and setup on provisioned systems.
 
 # How-to provision Ubuntu with Gnome Initial Setup
 
-This guide aims to highlight different ways a system can be provisioned so that Ubuntu is installed but no user 
-account is created, allowing user account creation to be passed off to Gnome-Initial-Setup.
+This guide highlights different methods for provisioning a system so that Ubuntu is installed while no user 
+account is created, thereby allowing user account creation to be passed off to Gnome-Initial-Setup.
 
 ## Method 1: Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml
 
@@ -45,14 +45,14 @@ mode: oem
 ```
 
 Placing this `whitelabel.yaml` at `/usr/share/desktop-provision/whitelabel.yaml` on your LiveCD is sufficient 
-to skip user creation during installation, provided you are using the new Ubuntu Desktop Bootstrap installer.
+to skip user creation during installation, provided that you are using the new Ubuntu Desktop Bootstrap installer.
 
 A comprehensive guide to customizing a LiveCD can be found [here](https://help.ubuntu.com/community/LiveCDCustomization).
 
 ### Using the Flutter installer without modifying the LiveCD
 
 It's possible to test the Gnome Initial Setup user creation flow via the Ubuntu Desktop Bootstrap installer without first 
-editing your LiveCD, provided Gnome Initial Setup is already present on your ISO.
+editing your LiveCD, as long as Gnome Initial Setup is already present on your ISO.
 
 #### Install ubuntu-desktop-bootstrap
 
@@ -82,7 +82,7 @@ Finally, the installer can be launched. You should not be prompted for user acco
 
 ## Method 2: Triggering Gnome Initial Setup via an autoinstall.yaml
 
-These sections are adapted from the subiquity [documentation](https://canonical-subiquity.readthedocs-hosted.com/en/latest/howto/autoinstall-quickstart.html),
+These sections are adapted from the Subiquity [documentation](https://canonical-subiquity.readthedocs-hosted.com/en/latest/howto/autoinstall-quickstart.html),
 updated for triggering Gnome Initial Setup with the Ubuntu Desktop ISO.
 
 ### Using an autoinstall provided over the network
@@ -93,7 +93,7 @@ You can find a desktop ISO to download on the [official Ubuntu website](https://
 
 #### Mount the ISO
 
-Once downloaded, you can mount the ISO to make it accessible via from a local directory. Change `<version-number>` in 
+Once downloaded, you can mount the ISO to make it accessible via a local directory. Change `<version-number>` in 
 the following command to match the release ISO that you downloaded:
 
 ```
@@ -102,7 +102,7 @@ sudo mount -r ~/Downloads/ubuntu-<version-number>-amd64.iso /mnt
 
 #### Write an autoinstall configuration
 
-Create your cloud-init configuration, making sure to leave the identity section out so that no user is created during 
+Create your cloud-init configuration, making sure to omit the identity section so that no user is created during 
 installation:
 
 ```
@@ -171,7 +171,7 @@ You can find a desktop ISO to download on the [official Ubuntu website](https://
 
 #### Write an autoinstall configuration
 
-Create your cloud-init configuration, making sure to leave the identity section out so that no user is created during 
+Create your cloud-init configuration, making sure to omit the identity section so that no user is created during 
 installation:
 
 ```

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -74,8 +74,7 @@ sudo bash -c 'echo "mode: oem" > /usr/share/desktop-provision/whitelabel.yaml'
 
 #### Launch ubuntu-desktop-bootstrap
 
-Finally, the installer can be launched. You should be no be prompted for user account creation, which will be handled after the 
-installer finishes:
+Finally, the installer can be launched. You should not be prompted for user account creation, as this will be handled after the installer finishes.
 
 ```
 /snap/bin/ubuntu-desktop-bootstrap --try-or-install

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -1,40 +1,34 @@
 # 24.04.1 OEM provisioning flow
 
-To help support installation flows where user account setup is a seperate flow from system installation, we have
-included this guide on how to invoke Gnome Initial Setup as part of the installation flow, either via an 
-`autoinstall.yaml` or a `whitelabel.yaml`.
+There are use-cases where it does not make sense for system installation and user creation to happen at the same time.
+These require a workflow that skips the user creation step during installation so that it can be handled later, perhaps by a different user.
+
+Ubuntu accomodates this workflow by shipping with Gnome Initial Setup, a program that can safely handle user account 
+creation and configuration. Gnome Initial Setup is started by default when a system is booted and GNOME Display Manager (GDM) is unable to
+detect any user accounts. Instead of taking you to the login screen, a special Gnome Initial Setup user session is started.
+
+> **NOTE:**
+> This is a special integration built into GDM. If you are using a different
+> display manager, you may need to integrate the [Gnome Initial Setup
+> session](https://salsa.debian.org/gnome-team/gnome-initial-setup/-/blob/ubuntu/latest/data/gnome-initial-setup.session.in?ref_type=heads)
+> being invoked by the display manager yourself.
 
 The version of Gnome Initial Setup in Ubuntu 24.04.1 LTS has been patched to allow for hostnames to be set during
-account creation and EULA pages to render if present on the system. This is in addition to its existing faeture set
-that enables user account creation and setup on provisioned system.
+account creation and EULA pages to render if present on the system. This is in addition to its existing feature set
+that enables user account creation and setup on provisioned systems.
 
 ## Table of contents
-- [Gnome Initial Setup](#gnome-initial-setup)
-  - [Why Gnome Initial Setup](#why-gnome-initial-setup)
-  - [Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml](#triggering-gnome-initial-setup-via-the-new-flutter-installer-and-a-whitelabelyaml)
-  - [Triggering Gnome Initial Setup via an autoinstall.yaml](#triggering-gnome-initial-setup-via-an-autoinstallyaml)
+- [How to provision Ubuntu with Gnome Initial Setup](#how-to-provision-ubuntu-with-gnome-initial-setup)
+  - [Method 1: Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml](#method-1-triggering-gnome-initial-setup-via-the-new-flutter-installer-and-a-whitelabelyaml)
+  - [Method 2: Triggering Gnome Initial Setup via an autoinstall.yaml](#method-2-triggering-gnome-initial-setup-via-an-autoinstallyaml)
 - [EULA page configuration](#eula-page-configuration)
 
-# Gnome Initial Setup
+# How-to provision Ubuntu with Gnome Initial Setup
 
-## Why Gnome Initial Setup
-There are several use cases where it makes sense for system installation and user creation to not happen at the same 
-time. In these instances, it is useful to have a way to skip the user creation step during installation and for it to 
-be handled later, perhaps even by a different user.
-
-To accommodate this workflow Ubuntu ships with Gnome Initial Setup, a program that can safely handle user account 
-creation and configuration. Gnome Initial Setup is started by default when a system is booted and GDM is unable to
-detect any user accounts. Instead of taking you to the login screen, a special Gnome Initial Setup user session is 
-started.
-
-(Note: this is a special integration built into GDM. If you are using a different display manager, you may need to
-integrate the [Gnome Initial Setup session](https://salsa.debian.org/gnome-team/gnome-initial-setup/-/blob/ubuntu/latest/data/gnome-initial-setup.session.in?ref_type=heads)
-being invoked by the display manager yourself.)
-
-This guide aims to highlight some of the ways a system can be provisioned such that Ubuntu is installed, but no user 
+This guide aims to highlight different ways a system can be provisioned so that Ubuntu is installed but no user 
 account is created, allowing user account creation to be passed off to Gnome-Initial-Setup.
 
-## Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml
+## Method 1: Triggering Gnome Initial Setup via the new Flutter installer and a whitelabel.yaml
 
 The new [Ubuntu Desktop Bootstrap](https://github.com/canonical/ubuntu-desktop-provision) Flutter installer can be 
 given a `whitelabel.yaml` file to customize its appearance and behavior. One thing you can configure is the `mode` you 
@@ -52,7 +46,7 @@ mode: oem
 
 A comprehensive guide to customizing a LiveCD can be found [here](https://help.ubuntu.com/community/LiveCDCustomization).
 
-### Triggering Gnome-Initial-Setup without modifying the LiveCD
+### Using the Flutter installer without modifying the LiveCD
 
 It's possible to test the Gnome Initial Setup user creation flow via the Ubuntu Desktop Bootstrap installer without first 
 editing your LiveCD, provided Gnome Initial Setup is already present on your ISO.
@@ -81,7 +75,7 @@ installer finishes
 /snap/bin/ubuntu-desktop-bootstrap --try-or-install
 ```
 
-## Triggering Gnome Initial Setup via an autoinstall.yaml
+## Method 2: Triggering Gnome Initial Setup via an autoinstall.yaml
 
 These sections are adapted from the subiquity [documentation](https://canonical-subiquity.readthedocs-hosted.com/en/latest/howto/autoinstall-quickstart.html),
 updated for triggering Gnome Initial Setup with the Ubuntu Desktop ISO

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -3,7 +3,7 @@
 There are use-cases where it does not make sense for system installation and user creation to happen at the same time.
 These require a workflow that skips the user creation step during installation so that it can be handled later, perhaps by a different user.
 
-Ubuntu accomodates this workflow by shipping with Gnome Initial Setup, a program that can safely handle user account 
+Ubuntu accommodates this workflow by shipping with Gnome Initial Setup, a program that can safely handle user account 
 creation and configuration. Gnome Initial Setup is started by default when a system is booted and GNOME Display Manager (GDM) is unable to
 detect any user accounts. Instead of taking you to the login screen, a special Gnome Initial Setup user session is started.
 


### PR DESCRIPTION
This PR suggests some minor changes to the Gnome Initial Setup documentation to improve structure and readability.

The changes include:

- Combining the Introduction and Why Gnome Initial Setup sections to reduce repetition and improve flow. This also helps keep the focus on the `how-to` aspect of the guide, rather than the `explanatory` material, which should be directed towards providing clear instructions to the user.
- Adds a EULA language code section. This was previously referenced in the doc but the section was not present.
- Numbered the two main methods. This is just to improve how the main information can be parsed in GitHub-rendered markdown.
- Several minor changes to improve consistency and clarity: fixes to ambiguous wording, formatting and spelling.

The general structure of the doc is good. There is some repetition between different methods (e.g., yaml config files) but as these sections are self-contained and complete that makes sense.

Happy to revise the PR as needed ;)

UDENG-3570