### PR TITLE
feat(reset-tools): Add permission check based on polkit

### DIFF
--- a/ci/snap/reset-tools/snapcraft.yaml
+++ b/ci/snap/reset-tools/snapcraft.yaml
@@ -38,6 +38,7 @@ apps:
       - hardware-observe
       - mount-observe
       - dbus-system-com-canonical-oem-factory-reset-tools-client
+      - polkit
   dbus-daemon:
     command: bin/factory-reset-tools-cli dbus
     daemon: simple
@@ -47,6 +48,7 @@ apps:
       - shutdown
       - hostfs-boot-grub
       - usr-share-desktop-provision-reset-yaml
+      - polkit
 
 parts:
   flutter-git:
@@ -101,18 +103,42 @@ parts:
     plugin: nil
     override-build: |
       set -eux
-      mkdir -p $CRAFT_PART_INSTALL/bin
+      mkdir -p $CRAFT_PART_INSTALL/bin $CRAFT_PART_INSTALL/bin/polkit_agent_helper
       dart pub global activate melos
       dart pub global run melos bootstrap
-      cd packages/factory_reset_tools
+
+      pushd packages/factory_reset_tools
       dart compile exe -o factory-reset-tools-cli lib/dbus/cmdline.dart
       cp factory-reset-tools-cli $CRAFT_PART_INSTALL/bin/
+      popd
+
+      pushd packages/factory_reset_tools/lib/dbus/polkit_agent_helper
+      make helper.so
+      cp helper.so $CRAFT_PART_INSTALL/bin/polkit_agent_helper/
+      popd
     stage-packages:
       - rsync
       - grub2-common
       - uuid-runtime
     build-packages:
       - curl
+  
+  polkit-config:
+    plugin: dump
+    source: packages/factory_reset_tools/data/
+    organize:
+      polkit.com-canonical-oem-factory-reset-tools.policy: meta/polkit/
+
+  # copied from fwupd
+  # https://github.com/fwupd/fwupd/blob/main/contrib/snap/snapcraft.yaml
+  pkttyagent:
+    plugin: nil
+    stage-packages:
+      - polkitd
+      - libpolkit-agent-1-0
+    prime:
+      - usr/bin/pkttyagent
+      - usr/lib/*/libpolkit-agent-1.so*
 
 slots:
   dbus-session-com-canonical-oem-factory-reset-tools-service:
@@ -143,3 +169,5 @@ plugs:
     interface: dbus
     bus: system
     name: com.canonical.oem.FactoryResetTools
+  polkit:
+    action-prefix: com.canonical.oem.FactoryResetTools

--- a/packages/factory_reset_tools/data/polkit.com-canonical-oem-factory-reset-tools.policy
+++ b/packages/factory_reset_tools/data/polkit.com-canonical-oem-factory-reset-tools.policy
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig> 
+  <action id="com.canonical.oem.FactoryResetTools.reboot"> 
+    <description>Begin Factory Reset</description>
+    <message>Authentication is required to begin Factory Reset</message>
+    <defaults> 
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/packages/factory_reset_tools/lib/dbus/cmdline.dart
+++ b/packages/factory_reset_tools/lib/dbus/cmdline.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:factory_reset_tools/dbus/dbus_daemon.dart';
 import 'package:factory_reset_tools/dbus/factory_reset.dart';
+import 'package:factory_reset_tools/dbus/polkit_agent.dart';
 import 'package:factory_reset_tools/dbus/reset_media.dart';
 
 /// Command line entrypoint of factory-reset-tools
@@ -89,7 +91,13 @@ class RebootCommand extends Command<void> {
       }
       return;
     }
-    await startCommandViaDbus(ResetOptionType.fromString(argResults.rest[0]));
+    final pkttyagent = PkttyAgent();
+    await pkttyagent.start();
+    try {
+      await startCommandViaDbus(ResetOptionType.fromString(argResults.rest[0]));
+    } finally {
+      pkttyagent.stop();
+    }
     exit(0);
   }
 }

--- a/packages/factory_reset_tools/lib/dbus/dbus_daemon.dart
+++ b/packages/factory_reset_tools/lib/dbus/dbus_daemon.dart
@@ -9,7 +9,45 @@ class FactoryResetToolsObject extends ComCanonicalOemFactoryResetTools {
   }
 
   @override
-  Future<DBusMethodResponse> doReboot(String rebootOption) async {
+  Future<DBusMethodResponse> doReboot(
+    String rebootOption,
+    String? sender,
+  ) async {
+    final dbusClient = DBusClient.system();
+    final proxy = DBusRemoteObject(
+      dbusClient,
+      name: 'org.freedesktop.PolicyKit1',
+      path: DBusObjectPath('/org/freedesktop/PolicyKit1/Authority'),
+    );
+    final authResponse = await proxy.callMethod(
+      'org.freedesktop.PolicyKit1.Authority',
+      'CheckAuthorization',
+      [
+        // IN  Subject                        subject,
+        DBusStruct([
+          const DBusString('system-bus-name'),
+          DBusDict.stringVariant({'name': DBusString(sender ?? '')}),
+        ]),
+        // IN  String                         action_id,
+        const DBusString('com.canonical.oem.FactoryResetTools.reboot'),
+        // IN  Dict<String,String>            details,
+        DBusDict(DBusSignature('s'), DBusSignature('s'), {}),
+        // IN  CheckAuthorizationFlags        flags,
+        const DBusUint32(1),
+        // IN  String                         cancellation_id,
+        const DBusString(''),
+      ],
+      // OUT AuthorizationResult            result
+      replySignature: DBusSignature('(bba{ss})'),
+    );
+
+    final authResult = authResponse.returnValues[0].asStruct();
+    final authorized = authResult[0].asBoolean();
+
+    if (!authorized) {
+      return DBusMethodErrorResponse.authFailed();
+    }
+
     await startCommand(ResetOptionType.fromString(rebootOption));
     return DBusMethodSuccessResponse();
   }

--- a/packages/factory_reset_tools/lib/dbus/dbus_local_object.dart
+++ b/packages/factory_reset_tools/lib/dbus/dbus_local_object.dart
@@ -19,7 +19,10 @@ class ComCanonicalOemFactoryResetTools extends DBusObject {
   }
 
   /// Implementation of com.canonical.oem.FactoryResetTools.Reboot()
-  Future<DBusMethodResponse> doReboot(String rebootOption) async {
+  Future<DBusMethodResponse> doReboot(
+    String rebootOption,
+    String? sender,
+  ) async {
     return DBusMethodErrorResponse.failed(
       'com.canonical.oem.FactoryResetTools.Reboot() not implemented',
     );
@@ -60,7 +63,7 @@ class ComCanonicalOemFactoryResetTools extends DBusObject {
         if (methodCall.signature != DBusSignature('s')) {
           return DBusMethodErrorResponse.invalidArgs();
         }
-        return doReboot(methodCall.values[0].asString());
+        return doReboot(methodCall.values[0].asString(), methodCall.sender);
       } else {
         return DBusMethodErrorResponse.unknownMethod();
       }

--- a/packages/factory_reset_tools/lib/dbus/polkit_agent.dart
+++ b/packages/factory_reset_tools/lib/dbus/polkit_agent.dart
@@ -1,0 +1,68 @@
+import 'dart:ffi';
+import 'dart:io' show Platform, Process, ProcessStartMode, stdin;
+
+import 'package:ffi/ffi.dart';
+import 'package:path/path.dart' as path;
+
+// typedef from glib gerror.h
+final class PipeFds extends Struct {
+  @Int()
+  external int fd0;
+
+  @Int()
+  external int fd1;
+}
+
+typedef PolkitAgentPipe = Int Function(Pointer<PipeFds>);
+typedef PolkitAgentPipeNative = int Function(Pointer<PipeFds>);
+typedef PolkitAgentWait = Void Function(Pointer<PipeFds>);
+typedef PolkitAgentWaitNative = void Function(Pointer<PipeFds>);
+
+class PkttyAgent {
+  factory PkttyAgent() {
+    final exePath = Platform.script.toFilePath();
+    final libraryPath =
+        path.join(path.dirname(exePath), 'polkit_agent_helper', 'helper.so');
+    final dylib = DynamicLibrary.open(libraryPath);
+    final fnPipe = dylib
+        .lookupFunction<PolkitAgentPipe, PolkitAgentPipeNative>('pkagent_pipe');
+    final fnWait = dylib
+        .lookupFunction<PolkitAgentWait, PolkitAgentWaitNative>('pkagent_wait');
+    return PkttyAgent.withFunctions(fnPipe: fnPipe, fnWait: fnWait);
+  }
+
+  PkttyAgent.withFunctions({required this.fnPipe, required this.fnWait});
+
+  PolkitAgentPipeNative fnPipe;
+  PolkitAgentWaitNative fnWait;
+
+  Process? process;
+
+  Future<void> start() async {
+    if (!stdin.hasTerminal) {
+      return;
+    }
+
+    final pipeFds = malloc.allocate<PipeFds>(sizeOf<PipeFds>());
+    try {
+      final result = fnPipe(pipeFds);
+      if (result != 0) {
+        throw 'polkit_agent: unable to create pipefd';
+      }
+
+      process = await Process.start(
+        'pkttyagent',
+        ['--notify-fd', pipeFds.ref.fd1.toString()],
+        mode: ProcessStartMode.inheritStdio,
+      );
+
+      fnWait(pipeFds);
+    } finally {
+      malloc.free(pipeFds);
+    }
+  }
+
+  void stop() {
+    process?.kill();
+  }
+}

--- a/packages/factory_reset_tools/lib/dbus/polkit_agent_helper/Makefile
+++ b/packages/factory_reset_tools/lib/dbus/polkit_agent_helper/Makefile
@@ -1,0 +1,5 @@
+helper.so: helper.c
+	$(CC) helper.c -shared -o helper.so
+
+clean:
+	rm -rf helper.so

--- a/packages/factory_reset_tools/lib/dbus/polkit_agent_helper/helper.c
+++ b/packages/factory_reset_tools/lib/dbus/polkit_agent_helper/helper.c
@@ -1,0 +1,86 @@
+/*
+ * This file modifies from fwupd src/fu-polkit-agent.c to start pkttyagent with
+ * --notify parameter
+ *
+ * Copyright 2011 Lennart Poettering <lennart@poettering.net>
+ * Copyright 2012 Matthias Klumpp <matthias@tenstral.net>
+ * Copyright 2015 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <poll.h>
+#include <unistd.h>
+
+#include <stdio.h>
+
+typedef struct _pipe_fds {
+	int fd0;
+	int fd1;
+} pipe_fds;
+
+static int close_nointr(int fd)
+{
+	/* was assertion: g_return_val_if_fail(fd >= 0, -1); */
+	if (fd < 0) {
+		return -1;
+	}
+
+	for (;;) {
+		int r;
+		r = close(fd);
+		if (r >= 0)
+			return r;
+		if (errno != EINTR)
+			return -errno;
+	}
+}
+
+static void close_nointr_nofail(int fd)
+{
+	int saved_errno = errno;
+	/* cannot fail, and guarantees errno is unchanged */
+	if (close_nointr(fd) != 0) {
+		errno = EBADFD;
+		return;
+	}
+	errno = saved_errno;
+}
+
+static int fd_wait_for_event(int fd, int event, uint64_t t)
+{
+	struct pollfd pollfd = {0};
+	int r;
+
+	pollfd.fd = fd;
+	pollfd.events = event;
+	r = poll(&pollfd, 1, t == (uint64_t)-1 ? -1 : (int)(t / 1000));
+	if (r < 0)
+		return -errno;
+	if (r == 0)
+		return 0;
+
+	return pollfd.revents;
+}
+
+/* dart does not have low level pipe function; use ffi for the task */
+int pkagent_pipe(pipe_fds *fds) {
+	int pipe_fd[2];
+	int ret;
+	ret = pipe(pipe_fd);
+	fds->fd0 = pipe_fd[0];
+	fds->fd1 = pipe_fd[1];
+	return ret;
+}
+
+void pkagent_wait(pipe_fds *fds) {
+	/* close the writing side, because that is the one for the agent */
+	close_nointr_nofail(fds->fd1);
+
+	/* wait until the agent closes the fd */
+	fd_wait_for_event(fds->fd0, POLLHUP, (uint64_t)-1);
+
+	close_nointr_nofail(fds->fd0);
+}

--- a/packages/factory_reset_tools/pubspec.lock
+++ b/packages/factory_reset_tools/pubspec.lock
@@ -122,13 +122,13 @@ packages:
     source: hosted
     version: "1.3.1"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
-      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   flow_builder:
     dependency: transitive
     description:

--- a/packages/factory_reset_tools/pubspec.yaml
+++ b/packages/factory_reset_tools/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   async: ^2.11.0
   collection: ^1.17.0
   dbus: ^0.7.10
+  ffi: ^2.1.0
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
This feature adds polkit authorization before performing factory reset, both in GUI and in CLI

Need to request for an additional `polkit` autoconnect: https://forum.snapcraft.io/t/factory-reset-tools-polkit-autoconnect-request/41632

While implementing polkit interface for GUI applications seems to be straightforward by adding authorization on the server side, doing it in the CLI client is quite a problem.

First, it is necessary to spawn `pkttyagent` by the user program to show the text prompt, but to wait for the `pkttyagent` to be registered onto `polkitd`, `pkttyagent` uses a `--notify` channel which passes a file descriptor that it should close, which, referring to [fwupd implementation](https://github.com/fwupd/fwupd/blob/main/src/fu-polkit-agent.c), uses a pipe to implement.  However, Dart does not have a low level file/pipe mechanism available, therefore we have to use `dart:ffi` and a C helper to implement such feature.

Second, snapd seems not allow using `pkttyagent` without using `--fallback` to properly show text prompt. The discussion is in Snap Forum: https://forum.snapcraft.io/t/polkit-interface-and-pkttyagent-in-snap/41616

Internal Reference: SOMERVILLE-600