### PR TITLE
ci: move ubuntu-desktop-bootstrap to new branch setup

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -2,7 +2,9 @@ name: Main Documentation Checks
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - ubuntu/**
   pull_request:
   # Manual trigger
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - ubuntu/**
 
   pull_request:
     branches:
       - main
+      - ubuntu/**
 
   workflow_dispatch:
 

--- a/.github/workflows/rebase-for-snap-cicd.yaml
+++ b/.github/workflows/rebase-for-snap-cicd.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        input: ["init", "bootstrap", "reset-tools"]
+        input: ["init", "reset-tools"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We've now setup the following snap branches for ubuntu-desktop-bootstrap (arrows point to the snap channels to which the builds are uploaded):

`snap/ubuntu-desktop-bootstrap/24.04` -> `24.04/edge`, `latest/candidate` ("legacy", we need to continue maintaining the `latest` since the subiquity version shipped on the 24.04.x ISOs uses that track for the refresh mechanism)
`snap/ubuntu-desktop-bootstrap/main` -> `24.10/edge` (once we start working on features for 25.04, we'll add a `snap/ubuntu-desktop-bootstrap/24.10` branch)

This PR removes 'bootstrap' from the 'rebase' workflow that creates the ephemeral `ci/bootstrap` branch, which is now no longer used. We'll migrate ubuntu-init and the reset-tools separately.
We'll also need to introduce development branches for released versions of the installer that aren't supposed to receive any features from new releases (but might still need to get some bug fixes). Those will be called `ubuntu/24.04`, etc. The CI should run when opening a PR or pushing to those branches as well.