### PR TITLE
feat: release new version with updated mascot and logo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref 298edf271695df828a169f153143da18712739c3
+    source-commit: &commit-ref 656bb499a0d6fae676bdacb1e28bd3dc3f9ca7a1
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |


### PR DESCRIPTION
Includes the new mascot and logos from #809 as well as the latest subiquity fixes from the `ubuntu/noble` branch (#807) (I'll open a follow-up PR tomorrow to track `ubuntu/main` and pull in the latest subiquity changes here).