### PR TITLE
chore: update refs for bootstrap, curtin, probert

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref 656bb499a0d6fae676bdacb1e28bd3dc3f9ca7a1
+    source-commit: &commit-ref 0c60c7bcab64481773942d6deac0e50486f58e03
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
@@ -68,7 +68,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 7fbc96a413ed4a85370edbdb4e7bfa456c350346
+    source-commit: 364b719e189708255ff63b95078bc4f6bcf70540
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
@@ -92,7 +92,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/probert.git
     source-type: git
-    source-commit: f34ae3c3f942a9c479fe928911053a302e146251
+    source-commit: 83d25c873a4a7d93c158d76da86cb9c612c29572
     override-build: *pyinstall
     build-packages:
       - build-essential


### PR DESCRIPTION
includes:
- track subiquity's main branch (#811)
- replace mascot on try-or-install-page (#812)