### PR TITLE
docs: adding how to add language packs in autoinstall.yaml

### DIFF
--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -135,8 +135,7 @@ autoinstall:
       curtin in-target --target=/target -- bash -c '
         # Update the package list
         apt-get update
-        # Installing languages not in seed
-        # Note that firefox and thunderbolt are snap packages, so these are not added here
+        # Installing extra languages
         for lang in "fr" "de"; do
              for pkg in $(check-language-support --show-installed -l "$lang"); do
                   # gimp: not installed by default
@@ -237,8 +236,7 @@ autoinstall:
       curtin in-target --target=/target -- bash -c '
         # Update the package list
         apt-get update
-        # Installing languages not in seed
-        # Note that firefox and thunderbolt are snap packages, so these are not added here
+        # Installing extra languages
         for lang in "fr" "de"; do
              for pkg in $(check-language-support --show-installed -l "$lang"); do
                   # gimp: not installed by default

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -119,11 +119,12 @@ touch meta-data
 ```
 #### Adding additional Language packs
 
-The default Ubuntu ISO only has the English language pack seeded. To have additional languages
-available in Gnome Initial Setup, you will need to install additional language packs via the
-`autoinstall.yaml`
+The default Ubuntu ISO seeds multiple languages, but only carries one to the target system. To have
+additional languages available in Gnome Initial Setup, you will need to install additional language
+packs via the `autoinstall.yaml` onto the target system
 
-To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands) in the `autoinstall.yaml:
+To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands)
+in the `autoinstall.yaml:
 
 ```yaml
 #cloud-config
@@ -132,11 +133,16 @@ autoinstall:
   late-commands:
     - |
       curtin in-target --target=/target -- bash -c '
-        # Update package list
+        # Update the package list
         apt-get update
-
-        # Installing languages not in seed
-        # Add language codes of packs you with to install here 
+        # Check if LibreOffice is installed
+        if [ $(apt list --installed libreoffice-core 2>/dev/null | wc -l) -gt 1 ]; then
+          LIBREOFFICE_INSTALLED=true
+        else
+          LIBREOFFICE_INSTALLED=false
+        fi
+        # Note that firefox and thunderbolt are snap packages, so these are not added here
+        # Installing languages not in seed, add desiresd country codes below
         for lang in "fr" "de"; do
             for pkg in $(check-language-support --show-installed -l "$lang"); do
                 # gimp: not installed by default
@@ -145,12 +151,14 @@ autoinstall:
                 if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
                     continue
                 fi
-                apt-get install -y "$pkg"
-            done
-            for pkg in $(check-language-support --show-installed -l "$lang" -p "ibus,gnome-user-docs,gvfs"); do
-                apt-get install -y "$pkg"
-            done
-            for pkg in $(check-language-support --show-installed -l "$lang" -p "libreoffice-common"); do
+                # Skip LibreOffice-related packages if LibreOffice is not installed
+                if [ "$LIBREOFFICE_INSTALLED" = false ] && \
+                   { [ "$pkg" = "hyphen-$lang" ] || \
+                     [ "$pkg" = "libreoffice-help-$lang" ] || \
+                     [ "$pkg" = "libreoffice-l10n-$lang" ] || \
+                     [ "$pkg" = "mythes-$lang" ]; }; then
+                    continue
+                fi
                 apt-get install -y "$pkg"
             done
         done'
@@ -226,11 +234,12 @@ touch meta-data
 
 #### Adding additional Language packs
 
-The default Ubuntu ISO only has the English language pack seeded. To have additional languages
-available in Gnome Initial Setup, you will need to install additional language packs via the
-`autoinstall.yaml`
+The default Ubuntu ISO seeds multiple languages, but only carries one to the target system. To have
+additional languages available in Gnome Initial Setup, you will need to install additional language
+packs via the `autoinstall.yaml` onto the target system
 
-To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands) in the `autoinstall.yaml:
+To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands)
+in the `autoinstall.yaml:
 
 ```yaml
 #cloud-config
@@ -239,11 +248,16 @@ autoinstall:
   late-commands:
     - |
       curtin in-target --target=/target -- bash -c '
-        # Update package list
+        # Update the package list
         apt-get update
-
-        # Installing languages not in seed
-        # Add language codes of packs you with to install here 
+        # Check if LibreOffice is installed
+        if [ $(apt list --installed libreoffice-core 2>/dev/null | wc -l) -gt 1 ]; then
+          LIBREOFFICE_INSTALLED=true
+        else
+          LIBREOFFICE_INSTALLED=false
+        fi
+        # Note that firefox and thunderbolt are snap packages, so these are not added here
+        # Installing languages not in seed, add desiresd country codes below
         for lang in "fr" "de"; do
             for pkg in $(check-language-support --show-installed -l "$lang"); do
                 # gimp: not installed by default
@@ -252,12 +266,14 @@ autoinstall:
                 if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
                     continue
                 fi
-                apt-get install -y "$pkg"
-            done
-            for pkg in $(check-language-support --show-installed -l "$lang" -p "ibus,gnome-user-docs,gvfs"); do
-                apt-get install -y "$pkg"
-            done
-            for pkg in $(check-language-support --show-installed -l "$lang" -p "libreoffice-common"); do
+                # Skip LibreOffice-related packages if LibreOffice is not installed
+                if [ "$LIBREOFFICE_INSTALLED" = false ] && \
+                   { [ "$pkg" = "hyphen-$lang" ] || \
+                     [ "$pkg" = "libreoffice-help-$lang" ] || \
+                     [ "$pkg" = "libreoffice-l10n-$lang" ] || \
+                     [ "$pkg" = "mythes-$lang" ]; }; then
+                    continue
+                fi
                 apt-get install -y "$pkg"
             done
         done'

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -137,30 +137,32 @@ autoinstall:
         apt-get update
         # Check if LibreOffice is installed
         if [ $(apt list --installed libreoffice-core 2>/dev/null | wc -l) -gt 1 ]; then
-          LIBREOFFICE_INSTALLED=true
+             LIBREOFFICE_INSTALLED=true
         else
-          LIBREOFFICE_INSTALLED=false
+             LIBREOFFICE_INSTALLED=false
         fi
+        # Installing languages not in seed
         # Note that firefox and thunderbolt are snap packages, so these are not added here
-        # Installing languages not in seed, add desiresd country codes below
         for lang in "fr" "de"; do
-            for pkg in $(check-language-support --show-installed -l "$lang"); do
-                # gimp: not installed by default
-                # fcitx5: not used by ubuntu as gnome is in use
-                # mozc-utils-gui: is in universe
-                if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
-                    continue
-                fi
-                # Skip LibreOffice-related packages if LibreOffice is not installed
-                if [ "$LIBREOFFICE_INSTALLED" = false ] && \
-                   { [ "$pkg" = "hyphen-$lang" ] || \
-                     [ "$pkg" = "libreoffice-help-$lang" ] || \
-                     [ "$pkg" = "libreoffice-l10n-$lang" ] || \
-                     [ "$pkg" = "mythes-$lang" ]; }; then
-                    continue
-                fi
-                apt-get install -y "$pkg"
-            done
+             # Pull out which packages are required for LibreOffice.
+             LIBREOFFICE_PACKAGES=$(check-language-support -l "$lang" -p "libreoffice-common" 2>/dev/null)
+             for pkg in $(check-language-support --show-installed -l "$lang"); do
+                  # gimp: not installed by default
+                  # fcitx5: not used by ubuntu as gnome is in use
+                  # mozc-utils-gui: is in universe
+                  if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
+                      continue
+                  fi
+                  # Skip LibreOffice-related packages if LibreOffice is not installed
+                  if [ "$LIBREOFFICE_INSTALLED" = false ]; then
+                      for libre_pkg in $LIBREOFFICE_PACKAGES; do
+                          if [ "$pkg" = "$libre_pkg" ]; then
+                              continue 2
+                          fi
+                      done
+                  fi
+                  apt-get install -y "$pkg"
+             done
         done'
 ```
 #### Serve the cloud-init configuration over HTTP
@@ -252,30 +254,32 @@ autoinstall:
         apt-get update
         # Check if LibreOffice is installed
         if [ $(apt list --installed libreoffice-core 2>/dev/null | wc -l) -gt 1 ]; then
-          LIBREOFFICE_INSTALLED=true
+             LIBREOFFICE_INSTALLED=true
         else
-          LIBREOFFICE_INSTALLED=false
+             LIBREOFFICE_INSTALLED=false
         fi
+        # Installing languages not in seed
         # Note that firefox and thunderbolt are snap packages, so these are not added here
-        # Installing languages not in seed, add desiresd country codes below
         for lang in "fr" "de"; do
-            for pkg in $(check-language-support --show-installed -l "$lang"); do
-                # gimp: not installed by default
-                # fcitx5: not used by ubuntu as gnome is in use
-                # mozc-utils-gui: is in universe
-                if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
-                    continue
-                fi
-                # Skip LibreOffice-related packages if LibreOffice is not installed
-                if [ "$LIBREOFFICE_INSTALLED" = false ] && \
-                   { [ "$pkg" = "hyphen-$lang" ] || \
-                     [ "$pkg" = "libreoffice-help-$lang" ] || \
-                     [ "$pkg" = "libreoffice-l10n-$lang" ] || \
-                     [ "$pkg" = "mythes-$lang" ]; }; then
-                    continue
-                fi
-                apt-get install -y "$pkg"
-            done
+             # Pull out which packages are required for LibreOffice.
+             LIBREOFFICE_PACKAGES=$(check-language-support -l "$lang" -p "libreoffice-common" 2>/dev/null)
+             for pkg in $(check-language-support --show-installed -l "$lang"); do
+                  # gimp: not installed by default
+                  # fcitx5: not used by ubuntu as gnome is in use
+                  # mozc-utils-gui: is in universe
+                  if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
+                      continue
+                  fi
+                  # Skip LibreOffice-related packages if LibreOffice is not installed
+                  if [ "$LIBREOFFICE_INSTALLED" = false ]; then
+                      for libre_pkg in $LIBREOFFICE_PACKAGES; do
+                          if [ "$pkg" = "$libre_pkg" ]; then
+                              continue 2
+                          fi
+                      done
+                  fi
+                  apt-get install -y "$pkg"
+             done
         done'
 ```
 

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -117,7 +117,42 @@ autoinstall:
 EOF
 touch meta-data
 ```
+#### Adding additional Language packs
 
+The default Ubuntu ISO only has the English language pack seeded. To have additional languages available in Gnome Initial Setup, you will need to install additional language packs via the `autoinstall.yaml`
+
+To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands) in the `autoinstall.yaml:
+
+```yaml
+#cloud-config
+autoinstall:
+  version: 1
+  late-commands:
+    - |
+      curtin in-target --target=/target -- bash -c '
+        # Update package list
+        apt-get update
+
+        # Installing languages not in seed
+        # Add language codes of packs you with to install here 
+        for lang in "fr" "de"; do
+            for pkg in $(check-language-support --show-installed -l "$lang"); do
+                # gimp: not installed by default
+                # fcitx5: not used by ubuntu as gnome is in use
+                # mozc-utils-gui: is in universe
+                if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
+                    continue
+                fi
+                apt-get install -y "$pkg"
+            done
+            for pkg in $(check-language-support --show-installed -l "$lang" -p "ibus,gnome-user-docs,gvfs"); do
+                apt-get install -y "$pkg"
+            done
+            for pkg in $(check-language-support --show-installed -l "$lang" -p "libreoffice-common"); do
+                apt-get install -y "$pkg"
+            done
+        done'
+```
 #### Serve the cloud-init configuration over HTTP
 
 Change into the directory where the cloud-init configuration was created and start a server:
@@ -185,6 +220,43 @@ autoinstall:
   version: 1
 EOF
 touch meta-data
+```
+
+#### Adding additional Language packs
+
+The default Ubuntu ISO only has the English language pack seeded. To have additional languages available in Gnome Initial Setup, you will need to install additional language packs via the `autoinstall.yaml`
+
+To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands) in the `autoinstall.yaml:
+
+```yaml
+#cloud-config
+autoinstall:
+  version: 1
+  late-commands:
+    - |
+      curtin in-target --target=/target -- bash -c '
+        # Update package list
+        apt-get update
+
+        # Installing languages not in seed
+        # Add language codes of packs you with to install here 
+        for lang in "fr" "de"; do
+            for pkg in $(check-language-support --show-installed -l "$lang"); do
+                # gimp: not installed by default
+                # fcitx5: not used by ubuntu as gnome is in use
+                # mozc-utils-gui: is in universe
+                if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
+                    continue
+                fi
+                apt-get install -y "$pkg"
+            done
+            for pkg in $(check-language-support --show-installed -l "$lang" -p "ibus,gnome-user-docs,gvfs"); do
+                apt-get install -y "$pkg"
+            done
+            for pkg in $(check-language-support --show-installed -l "$lang" -p "libreoffice-common"); do
+                apt-get install -y "$pkg"
+            done
+        done'
 ```
 
 #### Create an ISO to use as a cloud-init data source

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -135,17 +135,9 @@ autoinstall:
       curtin in-target --target=/target -- bash -c '
         # Update the package list
         apt-get update
-        # Check if LibreOffice is installed
-        if [ $(apt list --installed libreoffice-core 2>/dev/null | wc -l) -gt 1 ]; then
-             LIBREOFFICE_INSTALLED=true
-        else
-             LIBREOFFICE_INSTALLED=false
-        fi
         # Installing languages not in seed
         # Note that firefox and thunderbolt are snap packages, so these are not added here
         for lang in "fr" "de"; do
-             # Pull out which packages are required for LibreOffice.
-             LIBREOFFICE_PACKAGES=$(check-language-support -l "$lang" -p "libreoffice-common" 2>/dev/null)
              for pkg in $(check-language-support --show-installed -l "$lang"); do
                   # gimp: not installed by default
                   # fcitx5: not used by ubuntu as gnome is in use
@@ -153,18 +145,11 @@ autoinstall:
                   if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
                       continue
                   fi
-                  # Skip LibreOffice-related packages if LibreOffice is not installed
-                  if [ "$LIBREOFFICE_INSTALLED" = false ]; then
-                      for libre_pkg in $LIBREOFFICE_PACKAGES; do
-                          if [ "$pkg" = "$libre_pkg" ]; then
-                              continue 2
-                          fi
-                      done
-                  fi
                   apt-get install -y "$pkg"
              done
         done'
 ```
+
 #### Serve the cloud-init configuration over HTTP
 
 Change into the directory where the cloud-init configuration was created and start a server:
@@ -252,31 +237,15 @@ autoinstall:
       curtin in-target --target=/target -- bash -c '
         # Update the package list
         apt-get update
-        # Check if LibreOffice is installed
-        if [ $(apt list --installed libreoffice-core 2>/dev/null | wc -l) -gt 1 ]; then
-             LIBREOFFICE_INSTALLED=true
-        else
-             LIBREOFFICE_INSTALLED=false
-        fi
         # Installing languages not in seed
         # Note that firefox and thunderbolt are snap packages, so these are not added here
         for lang in "fr" "de"; do
-             # Pull out which packages are required for LibreOffice.
-             LIBREOFFICE_PACKAGES=$(check-language-support -l "$lang" -p "libreoffice-common" 2>/dev/null)
              for pkg in $(check-language-support --show-installed -l "$lang"); do
                   # gimp: not installed by default
                   # fcitx5: not used by ubuntu as gnome is in use
                   # mozc-utils-gui: is in universe
                   if [ "${pkg%%-*}" = gimp ] || [ "${pkg%%-*}" = fcitx5 ] || [ "$pkg" = "mozc-utils-gui" ]; then
                       continue
-                  fi
-                  # Skip LibreOffice-related packages if LibreOffice is not installed
-                  if [ "$LIBREOFFICE_INSTALLED" = false ]; then
-                      for libre_pkg in $LIBREOFFICE_PACKAGES; do
-                          if [ "$pkg" = "$libre_pkg" ]; then
-                              continue 2
-                          fi
-                      done
                   fi
                   apt-get install -y "$pkg"
              done

--- a/docs/oem-provisioning-24_04_1.md
+++ b/docs/oem-provisioning-24_04_1.md
@@ -119,7 +119,9 @@ touch meta-data
 ```
 #### Adding additional Language packs
 
-The default Ubuntu ISO only has the English language pack seeded. To have additional languages available in Gnome Initial Setup, you will need to install additional language packs via the `autoinstall.yaml`
+The default Ubuntu ISO only has the English language pack seeded. To have additional languages
+available in Gnome Initial Setup, you will need to install additional language packs via the
+`autoinstall.yaml`
 
 To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands) in the `autoinstall.yaml:
 
@@ -224,7 +226,9 @@ touch meta-data
 
 #### Adding additional Language packs
 
-The default Ubuntu ISO only has the English language pack seeded. To have additional languages available in Gnome Initial Setup, you will need to install additional language packs via the `autoinstall.yaml`
+The default Ubuntu ISO only has the English language pack seeded. To have additional languages
+available in Gnome Initial Setup, you will need to install additional language packs via the
+`autoinstall.yaml`
 
 To install additional language packs, you can make use of [late commands](https://canonical-subiquity.readthedocs-hosted.com/en/latest/reference/autoinstall-reference.html#late-commands) in the `autoinstall.yaml:
 


### PR DESCRIPTION
Adding a section on how to install additional language packs to appear in GIS via running late-commands in the `autoinstall.yaml`

This is doubled up as its applicable to two flow's