### PR TITLE
feat: Inherit Subiquity's ability to configure block probing timeout

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# source the management script
+. "$SNAP"/management-script
+
+
+handle_block_probing_timeout_config()
+{
+    block_probing_timeout="$(block_probing_timeout)"
+
+    case "${block_probing_timeout}" in
+        no | none | null)
+            # Special supported values for no timeout.
+            ;;
+        default)
+            # Special supported values for letting Subiquity decide.
+            ;;
+        "" | *[!0-9]*)
+            # Match everything else that is not an integer.
+            echo "\"${block_probing_timeout}\" is not a valid block probing timeout" >&2
+            return 1
+    esac
+
+    snapctl set block-probing-timeout="${block_probing_timeout}"
+
+    # Restart subiquity-server to apply new config
+    snapctl restart ubuntu-desktop-bootstrap
+}
+
+handle_block_probing_timeout_config

--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# source the management script
+. "$SNAP"/management-script
+
 # store current script directories
 SCRIPT_DIR=`dirname $0`
 
@@ -28,4 +31,17 @@ export SUBIQUITY_ROOT=$SNAP/bin/subiquity
 cd $SCRIPT_DIR/subiquity
 
 args=(--use-os-prober --storage-version=2 --postinst-hooks-dir=$SNAP/etc/subiquity/postinst.d)
+
+block_probing_timeout="$(block_probing_timeout)"
+case "${block_probing_timeout}" in
+    no | none | null)
+        args+=(--no-block-probing-timeout)
+        ;;
+    default)
+        ;;
+    *)
+        args+=(--block-probing-timeout "${block_probing_timeout}")
+        ;;
+esac
+
 $PYTHON -m subiquity.cmd.server "${args[@]}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,9 @@ parts:
       cd packages/ubuntu_bootstrap
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
+    override-prime: |
+      snapcraftctl prime
+      cp $CRAFT_PART_INSTALL/bin/subiquity/scripts/management-script $CRAFT_PRIME/
 
   curtin:
     plugin: nil


### PR DESCRIPTION
Port of https://github.com/canonical/subiquity/pull/2073 to ubuntu-desktop bootstrap.