### PR TITLE
unstage cloud-init from the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,7 +116,6 @@ parts:
     stage-packages:
       # This list includes the dependencies for curtin and probert as well,
       # there doesn't seem to be any real benefit to listing them separately.
-      - cloud-init
       - dctrl-tools
       - iso-codes
       - libpython3-stdlib


### PR DESCRIPTION
We removed cloud-init from the Subiquity snap in commit [0]. This can now be removed from the udb snap too.


[0] afcd2b364a33dcd5bacecee4a7e0f285b87ae2b2