### PR TITLE
ci: subiquity-check check stage-packages

### DIFF
--- a/scripts/subiquity-check.sh
+++ b/scripts/subiquity-check.sh
@@ -20,6 +20,25 @@ done
 if [ "$has_mismatch" = true ]; then
     echo "Commit mismatch detected. Please update the dependency commit hashes in snap/snapcraft.yaml"
     exit 1
-else
-    echo "Dependency check passed."
 fi
+
+BOOTSTRAP_PARTS_OUTPUT="bootstrap_parts.txt"
+SUBIQUITY_PARTS_OUTPUT="subiquity_parts.txt"
+
+yq -r '.parts["subiquitydeps"]["stage-packages"]' snap/snapcraft.yaml > $BOOTSTRAP_PARTS_OUTPUT
+curl -sL https://github.com/canonical/subiquity/raw/$SUBIQUITY_COMMIT/snapcraft.yaml | yq -r '.parts["subiquity"]["stage-packages"]' > $SUBIQUITY_PARTS_OUTPUT
+
+DEP_DIFF=$(diff bootstrap_parts.txt subiquity_parts.txt --unified)
+
+rm $BOOTSTRAP_PARTS_OUTPUT
+rm $SUBIQUITY_PARTS_OUTPUT
+
+if [[ -n "$DEP_DIFF" ]]; then
+    echo "Difference in stage-packages detected:"
+    printf "%s\n\n" "$DEP_DIFF"
+    echo "Please update parts.subiquitydeps.stage-packages in snap/snapcraft.yaml"
+    exit 1
+fi
+
+
+echo "Dependency check passed."


### PR DESCRIPTION
I'd like to propose an additional check to the `subiquity-check` script to check for any stage-packages differences. 
Is this the right branch to open the PR against? Or should it go against `main`?

I skip comparing the WSL specific packages because that's not something subiquity specifies and I'm not sure about the details on why those are under `subiquitydeps` in particular or if those still needs to be there.


