### PR TITLE
chore: remove unused stage-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,7 +116,6 @@ parts:
     stage-packages:
       # This list includes the dependencies for curtin and probert as well,
       # there doesn't seem to be any real benefit to listing them separately.
-      - dctrl-tools
       - iso-codes
       - libpython3-stdlib
       - libpython3.10-minimal
@@ -146,9 +145,6 @@ parts:
       - python3.10-minimal
       - ssh-import-id
       - ubuntu-advantage-tools
-      # WSL specifics:
-      - language-selector-common
-      - locales
     prime:
       - -lib/systemd/system/*
 


### PR DESCRIPTION
Cleans up the `stage-packages` in the snapcraft.yaml to match subiquity's list. See #827.