### PR TITLE
fix(24.04): use UTF-8 encoding for password hashing

### DIFF
--- a/packages/ubuntu_bootstrap/lib/services/identity_service.dart
+++ b/packages/ubuntu_bootstrap/lib/services/identity_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:crypt/crypt.dart';
 import 'package:meta/meta.dart';
 import 'package:subiquity_client/subiquity_client.dart';
@@ -5,10 +7,15 @@ import 'package:ubuntu_bootstrap/services/post_install_service.dart';
 import 'package:ubuntu_provision/services.dart';
 
 class SubiquityIdentityService implements IdentityService {
-  const SubiquityIdentityService(this._subiquity, this._postInstall);
+  const SubiquityIdentityService(
+    this._subiquity,
+    this._postInstall, {
+    @visibleForTesting this.testSalt,
+  });
 
   final SubiquityClient _subiquity;
   final PostInstallService _postInstall;
+  final String? testSalt;
 
   /// The auto-login post-install config key for testing purposes.
   @visibleForTesting
@@ -37,7 +44,10 @@ class SubiquityIdentityService implements IdentityService {
       IdentityData(
         realname: identity.realname,
         username: identity.username,
-        cryptedPassword: Crypt.sha512(identity.password).toString(),
+        cryptedPassword: Crypt.sha512(
+          String.fromCharCodes(utf8.encode(identity.password)),
+          salt: testSalt,
+        ).toString(),
         hostname: identity.hostname,
       ),
     );

--- a/packages/ubuntu_bootstrap/test/services/identity_service_test.dart
+++ b/packages/ubuntu_bootstrap/test/services/identity_service_test.dart
@@ -40,13 +40,14 @@ void main() {
   test('set identity', () async {
     final client = MockSubiquityClient();
     final postInstall = MockPostInstallService();
-    final service = SubiquityIdentityService(client, postInstall);
+    final service =
+        SubiquityIdentityService(client, postInstall, testSalt: '12345678');
     await service.setIdentity(
       Identity(
         realname: testIdentity.realname,
         username: testIdentity.username,
         hostname: testIdentity.hostname,
-        password: 'password',
+        password: 'pásswörd',
         autoLogin: true,
       ),
     );
@@ -61,7 +62,8 @@ void main() {
               .having(
                 (i) => i.cryptedPassword,
                 'cryptedPassword',
-                hasLength(greaterThan(8)),
+                // output of: mkpasswd -m sha512crypt pásswörd 12345678
+                '\$6\$12345678\$FQ329IePwMuA9R82gLYtPid4lWfSeq0zCFrg2C8u3J3pv/Js./ZObNOMFT1xLwGV6MnMJGTYAzyFqgDB/zr.d0',
               ),
         ),
       ),


### PR DESCRIPTION
Backport of #835 to `ubuntu/24.04`