### PR TITLE
chore: update refs for bootstrap, subiquity and curtin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref 59f70c5d875ea3d2c4dc67bd484361c7dc872445
+    source-commit: &commit-ref 7db1ad18b8328a3322ce87debbb9adf4641984d9
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
@@ -71,7 +71,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 40cae5c60fa9f4c495c7f61cde28862175f93ce2
+    source-commit: 697e83699d493b7491913d822e7f5635d7f10af2
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"


### PR DESCRIPTION
includes subiquity updates from #830 and password encoding fix from #835