### PR TITLE
snapcraft: Fix *_ORIG variables

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,6 @@ apps:
       APPORT_DATA_DIR: $SNAP/usr/share/apport
       PATH_ORIG: $PATH
       PYTHONPATH_ORIG: $PYTHONPATH
-      LD_LIBRARY_PATH_ORIG: $LD_LIBRARY_PATH
 
   subiquity-loadkeys:
     command: bin/subiquity/bin/subiquity-loadkeys

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,8 @@ apps:
     daemon: simple
     restart-condition: always
     environment:
+      APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
+      APPORT_DATA_DIR: $SNAP/usr/share/apport
       PATH_ORIG: $PATH
       PYTHONPATH_ORIG: $PYTHONPATH
       LD_LIBRARY_PATH_ORIG: $LD_LIBRARY_PATH
@@ -31,6 +33,8 @@ apps:
     command-chain: [bin/launcher]
     desktop: usr/share/applications/ubuntu-desktop-bootstrap.desktop
     environment:
+      APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
+      APPORT_DATA_DIR: $SNAP/usr/share/apport
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri
       GIO_MODULE_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gio/modules

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,8 @@ apps:
     environment:
       APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
       APPORT_DATA_DIR: $SNAP/usr/share/apport
-      PATH_ORIG: $PATH
+      PATH_ORIG: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
+      PYTHON_ORIG: $PYTHON
       PYTHONPATH_ORIG: $PYTHONPATH
 
   subiquity-loadkeys:
@@ -34,7 +35,10 @@ apps:
     environment:
       APPORT_DATA_DIR_ORIG: $APPORT_DATA_DIR
       APPORT_DATA_DIR: $SNAP/usr/share/apport
+      PATH_ORIG: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
+      PYTHON_ORIG: $PYTHON
+      PYTHONPATH_ORIG: $PYTHONPATH
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri
       GIO_MODULE_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gio/modules
       LIVE_RUN: 1


### PR DESCRIPTION
Ensure subiquity-server and ubuntu-desktop-bootstrap apps have PATH_ORIG, PYTHON_ORIG, and PYTHONPATH_ORIG environment variables. Lacking these causes usage of subiquity's system_scripts to fail to find the right python _outside_ of the snap. This is currently causing installs to fail on daily desktop-builds.

Also remove LD_LIBRARY_PATH_ORIG since it's not needed anymore.

The rational for removing LD_LIBRARY_PATH is mostly that we don't need it. However, after injecting a new snap to test these changes I found subiquity struggling to replace LD_LIBRARY_PATH_ORIG because LD_LIBRARY_PATH wasn't set.   LD_LIBRARY_PATH_ORIG is empty, which means the control flow in the environment cleaner function executes [this line](https://github.com/canonical/subiquity/blob/a57ed5a5e3ba1fd2212fae3c2f3e84cc8459a158/subiquitycore/utils.py#L73) which cause a `KeyError` because LD_LIBRARY_PATH is unset (trying to delete a non-existent key). Strangely this error isn't present in an unmodified ISO. This leads me to believe that the way I'm building the snap is slightly different than the launchpad setup. (I can download the snap and inject it without encountering the issue.)  Regardless, we can remove LD_LIBRARY_PATH_ORIG because we're [always going to remove it from the cleaned environment anyways](https://github.com/canonical/subiquity/blob/a57ed5a5e3ba1fd2212fae3c2f3e84cc8459a158/subiquitycore/utils.py#L75).

LP: [#2082851](https://pad.lv/2082851)
