### PR TITLE
refactor: move tester navigation out of integration tests

### DIFF
--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -43,8 +43,7 @@ Future<void> main() async {
       await tester.runApp(() => runInstallerApp([], theme: currentTheme));
       await tester.pumpAndSettle();
 
-      await tester.testLocalePage(
-          screenshot: '$currentThemeName/locale', tester: tester);
+      await tester.testLocalePage(screenshot: '$currentThemeName/locale');
     },
     variant: themeVariant,
   );

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -13,6 +13,9 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_test/yaru_test.dart';
 
+// TODO: These tests will only pass if run as a group, not individually. This is a known limitation
+// tracked by this issue: https://github.com/canonical/ubuntu-desktop-provision/issues/861
+
 Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   final window = await YaruWindow.ensureInitialized();

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -44,8 +44,7 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testLocalePage(
-        screenshot: '$currentThemeName/locale', tester: tester
-      );
+          screenshot: '$currentThemeName/locale', tester: tester);
     },
     variant: themeVariant,
   );

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -484,6 +484,7 @@ Future<void> main() async {
 
       await tester.testTimezonePage(
         screenshot: '$currentThemeName/timezone',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -277,8 +277,6 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testStoragePage(type: StorageType.manual);
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testManualStoragePage(
         storage: [
@@ -318,8 +316,6 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testStoragePage(type: StorageType.alongside);
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testGuidedResizePage(
         size: 30,
@@ -346,8 +342,6 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testStoragePage(type: StorageType.erase);
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testGuidedReformatPage(
         screenshot: '$currentThemeName/storage-guided-reformat',
@@ -396,8 +390,6 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testStoragePage(type: StorageType.alongside);
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testBitLockerPage(
         screenshot: '$currentThemeName/bitlocker',
@@ -426,8 +418,6 @@ Future<void> main() async {
         type: StorageType.erase,
         guidedCapability: GuidedCapability.LVM_LUKS,
       );
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testPassphrasePage(
         passphrase: 'password',
@@ -519,8 +509,6 @@ Future<void> main() async {
       await tester.testStoragePage(
         type: StorageType.erase,
       );
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testIdentityPage(
         identity: const Identity(
@@ -530,12 +518,8 @@ Future<void> main() async {
         ),
         password: 'password',
       );
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testTimezonePage();
-      await tester.tapNext();
-      await tester.pumpAndSettle();
 
       await tester.testConfirmPage(
         screenshot: '$currentThemeName/confirm',

--- a/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/screenshot_test.dart
@@ -44,7 +44,7 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testLocalePage(
-        screenshot: '$currentThemeName/locale',
+        screenshot: '$currentThemeName/locale', tester: tester
       );
     },
     variant: themeVariant,

--- a/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -43,58 +43,35 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(language: language, tester: tester);
+    await tester.testLocalePage(language: language);
     await expectLocale(locale);
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage(layout: language);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectKeyboard(keyboard);
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(type: StorageType.erase);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testIdentityPage(identity: identity, password: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectIdentity(identity);
 
     await tester.testTimezonePage(timezone: timezone);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectTimezone(timezone);
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -116,46 +93,27 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(type: StorageType.erase);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -174,62 +132,37 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(
       type: StorageType.erase,
       guidedCapability: GuidedCapability.LVM_LUKS,
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testPassphrasePage(passphrase: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testIdentityPage(identity: identity, password: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -251,58 +184,35 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(
       type: StorageType.erase,
       guidedCapability: GuidedCapability.ZFS,
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testIdentityPage(identity: identity, password: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -324,62 +234,37 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(
       type: StorageType.erase,
       guidedCapability: GuidedCapability.ZFS_LUKS_KEYSTORE,
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testPassphrasePage(passphrase: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testIdentityPage(identity: identity, password: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -408,62 +293,39 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(
       type: StorageType.erase,
       guidedCapability: GuidedCapability.CORE_BOOT_ENCRYPTED,
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRecoveryKeyPage();
     await tester.tapNext();
     await tester.pumpAndSettle();
 
     await tester.testIdentityPage(identity: identity, password: 'password');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -489,61 +351,36 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(type: StorageType.manual);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testManualStoragePage(storage: storage);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testIdentityPage(
       identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
       password: 'password',
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -578,61 +415,36 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(type: StorageType.alongside);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testGuidedResizePage(size: 30);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testIdentityPage(
       identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
       password: 'password',
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testTimezonePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pumpAndSettle();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapContinueTesting();
@@ -666,42 +478,25 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testSourceSelectionPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testCodecsAndDriversPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testStoragePage(type: StorageType.alongside);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testBitLockerPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapRestart();
@@ -712,30 +507,19 @@ void main() {
     await tester.runApp(() => app.main(<String>['--welcome']));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(tester: tester);
+    await tester.testLocalePage();
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testRefreshPage();
-    await tester.tapSkip();
-    await tester.pumpAndSettle();
 
     await tester.testTryOrInstallPage(option: TryOrInstallOption.installUbuntu);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testAutoinstallPage();
-    await tester.pumpAndSettle();
   });
 
   testWidgets('semi-automated autoinstall', (tester) async {
@@ -748,15 +532,10 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.testNetworkPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testConfirmPage();
-    await tester.tapConfirm();
-    await tester.pump();
 
     await tester.testInstallPage();
-    await tester.pumpAndSettle();
 
     final windowClosed = YaruTestWindow.waitForClosed();
     await tester.tapRestartNow();

--- a/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/packages/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -43,9 +43,7 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage(language: language);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(language: language, tester: tester);
     await expectLocale(locale);
 
     await tester.testAccessibilityPage();
@@ -118,9 +116,7 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -178,9 +174,7 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -257,9 +251,7 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -332,9 +324,7 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -418,9 +408,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -501,9 +489,7 @@ void main() {
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -592,9 +578,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -682,9 +666,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();
@@ -730,9 +712,7 @@ void main() {
     await tester.runApp(() => app.main(<String>['--welcome']));
     await tester.pumpAndSettle();
 
-    await tester.testLocalePage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -131,15 +131,18 @@ import 'ubuntu_bootstrap_localizations_zh.dart';
 /// be consistent with the languages listed in the UbuntuBootstrapLocalizations.supportedLocales
 /// property.
 abstract class UbuntuBootstrapLocalizations {
-  UbuntuBootstrapLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  UbuntuBootstrapLocalizations(String locale)
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
   static UbuntuBootstrapLocalizations of(BuildContext context) {
-    return Localizations.of<UbuntuBootstrapLocalizations>(context, UbuntuBootstrapLocalizations)!;
+    return Localizations.of<UbuntuBootstrapLocalizations>(
+        context, UbuntuBootstrapLocalizations)!;
   }
 
-  static const LocalizationsDelegate<UbuntuBootstrapLocalizations> delegate = _UbuntuBootstrapLocalizationsDelegate();
+  static const LocalizationsDelegate<UbuntuBootstrapLocalizations> delegate =
+      _UbuntuBootstrapLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -151,7 +154,8 @@ abstract class UbuntuBootstrapLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -1249,7 +1253,8 @@ abstract class UbuntuBootstrapLocalizations {
   ///
   /// In en, this message translates to:
   /// **'partition <b>{sysname}</b> formatted as <b>{format}</b> used for <b>{mount}</b>'**
-  String confirmPartitionFormatMount(String sysname, String format, String mount);
+  String confirmPartitionFormatMount(
+      String sysname, String format, String mount);
 
   /// A formatted partition entry
   ///
@@ -1834,120 +1839,271 @@ abstract class UbuntuBootstrapLocalizations {
   String get validate;
 }
 
-class _UbuntuBootstrapLocalizationsDelegate extends LocalizationsDelegate<UbuntuBootstrapLocalizations> {
+class _UbuntuBootstrapLocalizationsDelegate
+    extends LocalizationsDelegate<UbuntuBootstrapLocalizations> {
   const _UbuntuBootstrapLocalizationsDelegate();
 
   @override
   Future<UbuntuBootstrapLocalizations> load(Locale locale) {
-    return SynchronousFuture<UbuntuBootstrapLocalizations>(lookupUbuntuBootstrapLocalizations(locale));
+    return SynchronousFuture<UbuntuBootstrapLocalizations>(
+        lookupUbuntuBootstrapLocalizations(locale));
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['am', 'ar', 'be', 'bg', 'bn', 'bo', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dz', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'ga', 'gl', 'gu', 'he', 'hi', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'lo', 'lt', 'lv', 'mk', 'ml', 'mr', 'my', 'nb', 'ne', 'nl', 'nn', 'oc', 'pa', 'pl', 'pt', 'ro', 'ru', 'se', 'si', 'sk', 'sl', 'sq', 'sr', 'sv', 'ta', 'te', 'tg', 'th', 'tl', 'tr', 'ug', 'uk', 'vi', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+        'am',
+        'ar',
+        'be',
+        'bg',
+        'bn',
+        'bo',
+        'bs',
+        'ca',
+        'cs',
+        'cy',
+        'da',
+        'de',
+        'dz',
+        'el',
+        'en',
+        'eo',
+        'es',
+        'et',
+        'eu',
+        'fa',
+        'fi',
+        'fr',
+        'ga',
+        'gl',
+        'gu',
+        'he',
+        'hi',
+        'hr',
+        'hu',
+        'id',
+        'is',
+        'it',
+        'ja',
+        'ka',
+        'kk',
+        'km',
+        'kn',
+        'ko',
+        'ku',
+        'lo',
+        'lt',
+        'lv',
+        'mk',
+        'ml',
+        'mr',
+        'my',
+        'nb',
+        'ne',
+        'nl',
+        'nn',
+        'oc',
+        'pa',
+        'pl',
+        'pt',
+        'ro',
+        'ru',
+        'se',
+        'si',
+        'sk',
+        'sl',
+        'sq',
+        'sr',
+        'sv',
+        'ta',
+        'te',
+        'tg',
+        'th',
+        'tl',
+        'tr',
+        'ug',
+        'uk',
+        'vi',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_UbuntuBootstrapLocalizationsDelegate old) => false;
 }
 
 UbuntuBootstrapLocalizations lookupUbuntuBootstrapLocalizations(Locale locale) {
-
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'pt': {
-  switch (locale.countryCode) {
-    case 'BR': return UbuntuBootstrapLocalizationsPtBr();
-   }
-  break;
-   }
-    case 'zh': {
-  switch (locale.countryCode) {
-    case 'TW': return UbuntuBootstrapLocalizationsZhTw();
-   }
-  break;
-   }
+    case 'pt':
+      {
+        switch (locale.countryCode) {
+          case 'BR':
+            return UbuntuBootstrapLocalizationsPtBr();
+        }
+        break;
+      }
+    case 'zh':
+      {
+        switch (locale.countryCode) {
+          case 'TW':
+            return UbuntuBootstrapLocalizationsZhTw();
+        }
+        break;
+      }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'am': return UbuntuBootstrapLocalizationsAm();
-    case 'ar': return UbuntuBootstrapLocalizationsAr();
-    case 'be': return UbuntuBootstrapLocalizationsBe();
-    case 'bg': return UbuntuBootstrapLocalizationsBg();
-    case 'bn': return UbuntuBootstrapLocalizationsBn();
-    case 'bo': return UbuntuBootstrapLocalizationsBo();
-    case 'bs': return UbuntuBootstrapLocalizationsBs();
-    case 'ca': return UbuntuBootstrapLocalizationsCa();
-    case 'cs': return UbuntuBootstrapLocalizationsCs();
-    case 'cy': return UbuntuBootstrapLocalizationsCy();
-    case 'da': return UbuntuBootstrapLocalizationsDa();
-    case 'de': return UbuntuBootstrapLocalizationsDe();
-    case 'dz': return UbuntuBootstrapLocalizationsDz();
-    case 'el': return UbuntuBootstrapLocalizationsEl();
-    case 'en': return UbuntuBootstrapLocalizationsEn();
-    case 'eo': return UbuntuBootstrapLocalizationsEo();
-    case 'es': return UbuntuBootstrapLocalizationsEs();
-    case 'et': return UbuntuBootstrapLocalizationsEt();
-    case 'eu': return UbuntuBootstrapLocalizationsEu();
-    case 'fa': return UbuntuBootstrapLocalizationsFa();
-    case 'fi': return UbuntuBootstrapLocalizationsFi();
-    case 'fr': return UbuntuBootstrapLocalizationsFr();
-    case 'ga': return UbuntuBootstrapLocalizationsGa();
-    case 'gl': return UbuntuBootstrapLocalizationsGl();
-    case 'gu': return UbuntuBootstrapLocalizationsGu();
-    case 'he': return UbuntuBootstrapLocalizationsHe();
-    case 'hi': return UbuntuBootstrapLocalizationsHi();
-    case 'hr': return UbuntuBootstrapLocalizationsHr();
-    case 'hu': return UbuntuBootstrapLocalizationsHu();
-    case 'id': return UbuntuBootstrapLocalizationsId();
-    case 'is': return UbuntuBootstrapLocalizationsIs();
-    case 'it': return UbuntuBootstrapLocalizationsIt();
-    case 'ja': return UbuntuBootstrapLocalizationsJa();
-    case 'ka': return UbuntuBootstrapLocalizationsKa();
-    case 'kk': return UbuntuBootstrapLocalizationsKk();
-    case 'km': return UbuntuBootstrapLocalizationsKm();
-    case 'kn': return UbuntuBootstrapLocalizationsKn();
-    case 'ko': return UbuntuBootstrapLocalizationsKo();
-    case 'ku': return UbuntuBootstrapLocalizationsKu();
-    case 'lo': return UbuntuBootstrapLocalizationsLo();
-    case 'lt': return UbuntuBootstrapLocalizationsLt();
-    case 'lv': return UbuntuBootstrapLocalizationsLv();
-    case 'mk': return UbuntuBootstrapLocalizationsMk();
-    case 'ml': return UbuntuBootstrapLocalizationsMl();
-    case 'mr': return UbuntuBootstrapLocalizationsMr();
-    case 'my': return UbuntuBootstrapLocalizationsMy();
-    case 'nb': return UbuntuBootstrapLocalizationsNb();
-    case 'ne': return UbuntuBootstrapLocalizationsNe();
-    case 'nl': return UbuntuBootstrapLocalizationsNl();
-    case 'nn': return UbuntuBootstrapLocalizationsNn();
-    case 'oc': return UbuntuBootstrapLocalizationsOc();
-    case 'pa': return UbuntuBootstrapLocalizationsPa();
-    case 'pl': return UbuntuBootstrapLocalizationsPl();
-    case 'pt': return UbuntuBootstrapLocalizationsPt();
-    case 'ro': return UbuntuBootstrapLocalizationsRo();
-    case 'ru': return UbuntuBootstrapLocalizationsRu();
-    case 'se': return UbuntuBootstrapLocalizationsSe();
-    case 'si': return UbuntuBootstrapLocalizationsSi();
-    case 'sk': return UbuntuBootstrapLocalizationsSk();
-    case 'sl': return UbuntuBootstrapLocalizationsSl();
-    case 'sq': return UbuntuBootstrapLocalizationsSq();
-    case 'sr': return UbuntuBootstrapLocalizationsSr();
-    case 'sv': return UbuntuBootstrapLocalizationsSv();
-    case 'ta': return UbuntuBootstrapLocalizationsTa();
-    case 'te': return UbuntuBootstrapLocalizationsTe();
-    case 'tg': return UbuntuBootstrapLocalizationsTg();
-    case 'th': return UbuntuBootstrapLocalizationsTh();
-    case 'tl': return UbuntuBootstrapLocalizationsTl();
-    case 'tr': return UbuntuBootstrapLocalizationsTr();
-    case 'ug': return UbuntuBootstrapLocalizationsUg();
-    case 'uk': return UbuntuBootstrapLocalizationsUk();
-    case 'vi': return UbuntuBootstrapLocalizationsVi();
-    case 'zh': return UbuntuBootstrapLocalizationsZh();
+    case 'am':
+      return UbuntuBootstrapLocalizationsAm();
+    case 'ar':
+      return UbuntuBootstrapLocalizationsAr();
+    case 'be':
+      return UbuntuBootstrapLocalizationsBe();
+    case 'bg':
+      return UbuntuBootstrapLocalizationsBg();
+    case 'bn':
+      return UbuntuBootstrapLocalizationsBn();
+    case 'bo':
+      return UbuntuBootstrapLocalizationsBo();
+    case 'bs':
+      return UbuntuBootstrapLocalizationsBs();
+    case 'ca':
+      return UbuntuBootstrapLocalizationsCa();
+    case 'cs':
+      return UbuntuBootstrapLocalizationsCs();
+    case 'cy':
+      return UbuntuBootstrapLocalizationsCy();
+    case 'da':
+      return UbuntuBootstrapLocalizationsDa();
+    case 'de':
+      return UbuntuBootstrapLocalizationsDe();
+    case 'dz':
+      return UbuntuBootstrapLocalizationsDz();
+    case 'el':
+      return UbuntuBootstrapLocalizationsEl();
+    case 'en':
+      return UbuntuBootstrapLocalizationsEn();
+    case 'eo':
+      return UbuntuBootstrapLocalizationsEo();
+    case 'es':
+      return UbuntuBootstrapLocalizationsEs();
+    case 'et':
+      return UbuntuBootstrapLocalizationsEt();
+    case 'eu':
+      return UbuntuBootstrapLocalizationsEu();
+    case 'fa':
+      return UbuntuBootstrapLocalizationsFa();
+    case 'fi':
+      return UbuntuBootstrapLocalizationsFi();
+    case 'fr':
+      return UbuntuBootstrapLocalizationsFr();
+    case 'ga':
+      return UbuntuBootstrapLocalizationsGa();
+    case 'gl':
+      return UbuntuBootstrapLocalizationsGl();
+    case 'gu':
+      return UbuntuBootstrapLocalizationsGu();
+    case 'he':
+      return UbuntuBootstrapLocalizationsHe();
+    case 'hi':
+      return UbuntuBootstrapLocalizationsHi();
+    case 'hr':
+      return UbuntuBootstrapLocalizationsHr();
+    case 'hu':
+      return UbuntuBootstrapLocalizationsHu();
+    case 'id':
+      return UbuntuBootstrapLocalizationsId();
+    case 'is':
+      return UbuntuBootstrapLocalizationsIs();
+    case 'it':
+      return UbuntuBootstrapLocalizationsIt();
+    case 'ja':
+      return UbuntuBootstrapLocalizationsJa();
+    case 'ka':
+      return UbuntuBootstrapLocalizationsKa();
+    case 'kk':
+      return UbuntuBootstrapLocalizationsKk();
+    case 'km':
+      return UbuntuBootstrapLocalizationsKm();
+    case 'kn':
+      return UbuntuBootstrapLocalizationsKn();
+    case 'ko':
+      return UbuntuBootstrapLocalizationsKo();
+    case 'ku':
+      return UbuntuBootstrapLocalizationsKu();
+    case 'lo':
+      return UbuntuBootstrapLocalizationsLo();
+    case 'lt':
+      return UbuntuBootstrapLocalizationsLt();
+    case 'lv':
+      return UbuntuBootstrapLocalizationsLv();
+    case 'mk':
+      return UbuntuBootstrapLocalizationsMk();
+    case 'ml':
+      return UbuntuBootstrapLocalizationsMl();
+    case 'mr':
+      return UbuntuBootstrapLocalizationsMr();
+    case 'my':
+      return UbuntuBootstrapLocalizationsMy();
+    case 'nb':
+      return UbuntuBootstrapLocalizationsNb();
+    case 'ne':
+      return UbuntuBootstrapLocalizationsNe();
+    case 'nl':
+      return UbuntuBootstrapLocalizationsNl();
+    case 'nn':
+      return UbuntuBootstrapLocalizationsNn();
+    case 'oc':
+      return UbuntuBootstrapLocalizationsOc();
+    case 'pa':
+      return UbuntuBootstrapLocalizationsPa();
+    case 'pl':
+      return UbuntuBootstrapLocalizationsPl();
+    case 'pt':
+      return UbuntuBootstrapLocalizationsPt();
+    case 'ro':
+      return UbuntuBootstrapLocalizationsRo();
+    case 'ru':
+      return UbuntuBootstrapLocalizationsRu();
+    case 'se':
+      return UbuntuBootstrapLocalizationsSe();
+    case 'si':
+      return UbuntuBootstrapLocalizationsSi();
+    case 'sk':
+      return UbuntuBootstrapLocalizationsSk();
+    case 'sl':
+      return UbuntuBootstrapLocalizationsSl();
+    case 'sq':
+      return UbuntuBootstrapLocalizationsSq();
+    case 'sr':
+      return UbuntuBootstrapLocalizationsSr();
+    case 'sv':
+      return UbuntuBootstrapLocalizationsSv();
+    case 'ta':
+      return UbuntuBootstrapLocalizationsTa();
+    case 'te':
+      return UbuntuBootstrapLocalizationsTe();
+    case 'tg':
+      return UbuntuBootstrapLocalizationsTg();
+    case 'th':
+      return UbuntuBootstrapLocalizationsTh();
+    case 'tl':
+      return UbuntuBootstrapLocalizationsTl();
+    case 'tr':
+      return UbuntuBootstrapLocalizationsTr();
+    case 'ug':
+      return UbuntuBootstrapLocalizationsUg();
+    case 'uk':
+      return UbuntuBootstrapLocalizationsUk();
+    case 'vi':
+      return UbuntuBootstrapLocalizationsVi();
+    case 'zh':
+      return UbuntuBootstrapLocalizationsZh();
   }
 
   throw FlutterError(
-    'UbuntuBootstrapLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
-  );
+      'UbuntuBootstrapLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/packages/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -131,18 +131,15 @@ import 'ubuntu_bootstrap_localizations_zh.dart';
 /// be consistent with the languages listed in the UbuntuBootstrapLocalizations.supportedLocales
 /// property.
 abstract class UbuntuBootstrapLocalizations {
-  UbuntuBootstrapLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  UbuntuBootstrapLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
   static UbuntuBootstrapLocalizations of(BuildContext context) {
-    return Localizations.of<UbuntuBootstrapLocalizations>(
-        context, UbuntuBootstrapLocalizations)!;
+    return Localizations.of<UbuntuBootstrapLocalizations>(context, UbuntuBootstrapLocalizations)!;
   }
 
-  static const LocalizationsDelegate<UbuntuBootstrapLocalizations> delegate =
-      _UbuntuBootstrapLocalizationsDelegate();
+  static const LocalizationsDelegate<UbuntuBootstrapLocalizations> delegate = _UbuntuBootstrapLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -154,8 +151,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -1253,8 +1249,7 @@ abstract class UbuntuBootstrapLocalizations {
   ///
   /// In en, this message translates to:
   /// **'partition <b>{sysname}</b> formatted as <b>{format}</b> used for <b>{mount}</b>'**
-  String confirmPartitionFormatMount(
-      String sysname, String format, String mount);
+  String confirmPartitionFormatMount(String sysname, String format, String mount);
 
   /// A formatted partition entry
   ///
@@ -1839,271 +1834,120 @@ abstract class UbuntuBootstrapLocalizations {
   String get validate;
 }
 
-class _UbuntuBootstrapLocalizationsDelegate
-    extends LocalizationsDelegate<UbuntuBootstrapLocalizations> {
+class _UbuntuBootstrapLocalizationsDelegate extends LocalizationsDelegate<UbuntuBootstrapLocalizations> {
   const _UbuntuBootstrapLocalizationsDelegate();
 
   @override
   Future<UbuntuBootstrapLocalizations> load(Locale locale) {
-    return SynchronousFuture<UbuntuBootstrapLocalizations>(
-        lookupUbuntuBootstrapLocalizations(locale));
+    return SynchronousFuture<UbuntuBootstrapLocalizations>(lookupUbuntuBootstrapLocalizations(locale));
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-        'am',
-        'ar',
-        'be',
-        'bg',
-        'bn',
-        'bo',
-        'bs',
-        'ca',
-        'cs',
-        'cy',
-        'da',
-        'de',
-        'dz',
-        'el',
-        'en',
-        'eo',
-        'es',
-        'et',
-        'eu',
-        'fa',
-        'fi',
-        'fr',
-        'ga',
-        'gl',
-        'gu',
-        'he',
-        'hi',
-        'hr',
-        'hu',
-        'id',
-        'is',
-        'it',
-        'ja',
-        'ka',
-        'kk',
-        'km',
-        'kn',
-        'ko',
-        'ku',
-        'lo',
-        'lt',
-        'lv',
-        'mk',
-        'ml',
-        'mr',
-        'my',
-        'nb',
-        'ne',
-        'nl',
-        'nn',
-        'oc',
-        'pa',
-        'pl',
-        'pt',
-        'ro',
-        'ru',
-        'se',
-        'si',
-        'sk',
-        'sl',
-        'sq',
-        'sr',
-        'sv',
-        'ta',
-        'te',
-        'tg',
-        'th',
-        'tl',
-        'tr',
-        'ug',
-        'uk',
-        'vi',
-        'zh'
-      ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['am', 'ar', 'be', 'bg', 'bn', 'bo', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'dz', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'ga', 'gl', 'gu', 'he', 'hi', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'lo', 'lt', 'lv', 'mk', 'ml', 'mr', 'my', 'nb', 'ne', 'nl', 'nn', 'oc', 'pa', 'pl', 'pt', 'ro', 'ru', 'se', 'si', 'sk', 'sl', 'sq', 'sr', 'sv', 'ta', 'te', 'tg', 'th', 'tl', 'tr', 'ug', 'uk', 'vi', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_UbuntuBootstrapLocalizationsDelegate old) => false;
 }
 
 UbuntuBootstrapLocalizations lookupUbuntuBootstrapLocalizations(Locale locale) {
+
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'pt':
-      {
-        switch (locale.countryCode) {
-          case 'BR':
-            return UbuntuBootstrapLocalizationsPtBr();
-        }
-        break;
-      }
-    case 'zh':
-      {
-        switch (locale.countryCode) {
-          case 'TW':
-            return UbuntuBootstrapLocalizationsZhTw();
-        }
-        break;
-      }
+    case 'pt': {
+  switch (locale.countryCode) {
+    case 'BR': return UbuntuBootstrapLocalizationsPtBr();
+   }
+  break;
+   }
+    case 'zh': {
+  switch (locale.countryCode) {
+    case 'TW': return UbuntuBootstrapLocalizationsZhTw();
+   }
+  break;
+   }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'am':
-      return UbuntuBootstrapLocalizationsAm();
-    case 'ar':
-      return UbuntuBootstrapLocalizationsAr();
-    case 'be':
-      return UbuntuBootstrapLocalizationsBe();
-    case 'bg':
-      return UbuntuBootstrapLocalizationsBg();
-    case 'bn':
-      return UbuntuBootstrapLocalizationsBn();
-    case 'bo':
-      return UbuntuBootstrapLocalizationsBo();
-    case 'bs':
-      return UbuntuBootstrapLocalizationsBs();
-    case 'ca':
-      return UbuntuBootstrapLocalizationsCa();
-    case 'cs':
-      return UbuntuBootstrapLocalizationsCs();
-    case 'cy':
-      return UbuntuBootstrapLocalizationsCy();
-    case 'da':
-      return UbuntuBootstrapLocalizationsDa();
-    case 'de':
-      return UbuntuBootstrapLocalizationsDe();
-    case 'dz':
-      return UbuntuBootstrapLocalizationsDz();
-    case 'el':
-      return UbuntuBootstrapLocalizationsEl();
-    case 'en':
-      return UbuntuBootstrapLocalizationsEn();
-    case 'eo':
-      return UbuntuBootstrapLocalizationsEo();
-    case 'es':
-      return UbuntuBootstrapLocalizationsEs();
-    case 'et':
-      return UbuntuBootstrapLocalizationsEt();
-    case 'eu':
-      return UbuntuBootstrapLocalizationsEu();
-    case 'fa':
-      return UbuntuBootstrapLocalizationsFa();
-    case 'fi':
-      return UbuntuBootstrapLocalizationsFi();
-    case 'fr':
-      return UbuntuBootstrapLocalizationsFr();
-    case 'ga':
-      return UbuntuBootstrapLocalizationsGa();
-    case 'gl':
-      return UbuntuBootstrapLocalizationsGl();
-    case 'gu':
-      return UbuntuBootstrapLocalizationsGu();
-    case 'he':
-      return UbuntuBootstrapLocalizationsHe();
-    case 'hi':
-      return UbuntuBootstrapLocalizationsHi();
-    case 'hr':
-      return UbuntuBootstrapLocalizationsHr();
-    case 'hu':
-      return UbuntuBootstrapLocalizationsHu();
-    case 'id':
-      return UbuntuBootstrapLocalizationsId();
-    case 'is':
-      return UbuntuBootstrapLocalizationsIs();
-    case 'it':
-      return UbuntuBootstrapLocalizationsIt();
-    case 'ja':
-      return UbuntuBootstrapLocalizationsJa();
-    case 'ka':
-      return UbuntuBootstrapLocalizationsKa();
-    case 'kk':
-      return UbuntuBootstrapLocalizationsKk();
-    case 'km':
-      return UbuntuBootstrapLocalizationsKm();
-    case 'kn':
-      return UbuntuBootstrapLocalizationsKn();
-    case 'ko':
-      return UbuntuBootstrapLocalizationsKo();
-    case 'ku':
-      return UbuntuBootstrapLocalizationsKu();
-    case 'lo':
-      return UbuntuBootstrapLocalizationsLo();
-    case 'lt':
-      return UbuntuBootstrapLocalizationsLt();
-    case 'lv':
-      return UbuntuBootstrapLocalizationsLv();
-    case 'mk':
-      return UbuntuBootstrapLocalizationsMk();
-    case 'ml':
-      return UbuntuBootstrapLocalizationsMl();
-    case 'mr':
-      return UbuntuBootstrapLocalizationsMr();
-    case 'my':
-      return UbuntuBootstrapLocalizationsMy();
-    case 'nb':
-      return UbuntuBootstrapLocalizationsNb();
-    case 'ne':
-      return UbuntuBootstrapLocalizationsNe();
-    case 'nl':
-      return UbuntuBootstrapLocalizationsNl();
-    case 'nn':
-      return UbuntuBootstrapLocalizationsNn();
-    case 'oc':
-      return UbuntuBootstrapLocalizationsOc();
-    case 'pa':
-      return UbuntuBootstrapLocalizationsPa();
-    case 'pl':
-      return UbuntuBootstrapLocalizationsPl();
-    case 'pt':
-      return UbuntuBootstrapLocalizationsPt();
-    case 'ro':
-      return UbuntuBootstrapLocalizationsRo();
-    case 'ru':
-      return UbuntuBootstrapLocalizationsRu();
-    case 'se':
-      return UbuntuBootstrapLocalizationsSe();
-    case 'si':
-      return UbuntuBootstrapLocalizationsSi();
-    case 'sk':
-      return UbuntuBootstrapLocalizationsSk();
-    case 'sl':
-      return UbuntuBootstrapLocalizationsSl();
-    case 'sq':
-      return UbuntuBootstrapLocalizationsSq();
-    case 'sr':
-      return UbuntuBootstrapLocalizationsSr();
-    case 'sv':
-      return UbuntuBootstrapLocalizationsSv();
-    case 'ta':
-      return UbuntuBootstrapLocalizationsTa();
-    case 'te':
-      return UbuntuBootstrapLocalizationsTe();
-    case 'tg':
-      return UbuntuBootstrapLocalizationsTg();
-    case 'th':
-      return UbuntuBootstrapLocalizationsTh();
-    case 'tl':
-      return UbuntuBootstrapLocalizationsTl();
-    case 'tr':
-      return UbuntuBootstrapLocalizationsTr();
-    case 'ug':
-      return UbuntuBootstrapLocalizationsUg();
-    case 'uk':
-      return UbuntuBootstrapLocalizationsUk();
-    case 'vi':
-      return UbuntuBootstrapLocalizationsVi();
-    case 'zh':
-      return UbuntuBootstrapLocalizationsZh();
+    case 'am': return UbuntuBootstrapLocalizationsAm();
+    case 'ar': return UbuntuBootstrapLocalizationsAr();
+    case 'be': return UbuntuBootstrapLocalizationsBe();
+    case 'bg': return UbuntuBootstrapLocalizationsBg();
+    case 'bn': return UbuntuBootstrapLocalizationsBn();
+    case 'bo': return UbuntuBootstrapLocalizationsBo();
+    case 'bs': return UbuntuBootstrapLocalizationsBs();
+    case 'ca': return UbuntuBootstrapLocalizationsCa();
+    case 'cs': return UbuntuBootstrapLocalizationsCs();
+    case 'cy': return UbuntuBootstrapLocalizationsCy();
+    case 'da': return UbuntuBootstrapLocalizationsDa();
+    case 'de': return UbuntuBootstrapLocalizationsDe();
+    case 'dz': return UbuntuBootstrapLocalizationsDz();
+    case 'el': return UbuntuBootstrapLocalizationsEl();
+    case 'en': return UbuntuBootstrapLocalizationsEn();
+    case 'eo': return UbuntuBootstrapLocalizationsEo();
+    case 'es': return UbuntuBootstrapLocalizationsEs();
+    case 'et': return UbuntuBootstrapLocalizationsEt();
+    case 'eu': return UbuntuBootstrapLocalizationsEu();
+    case 'fa': return UbuntuBootstrapLocalizationsFa();
+    case 'fi': return UbuntuBootstrapLocalizationsFi();
+    case 'fr': return UbuntuBootstrapLocalizationsFr();
+    case 'ga': return UbuntuBootstrapLocalizationsGa();
+    case 'gl': return UbuntuBootstrapLocalizationsGl();
+    case 'gu': return UbuntuBootstrapLocalizationsGu();
+    case 'he': return UbuntuBootstrapLocalizationsHe();
+    case 'hi': return UbuntuBootstrapLocalizationsHi();
+    case 'hr': return UbuntuBootstrapLocalizationsHr();
+    case 'hu': return UbuntuBootstrapLocalizationsHu();
+    case 'id': return UbuntuBootstrapLocalizationsId();
+    case 'is': return UbuntuBootstrapLocalizationsIs();
+    case 'it': return UbuntuBootstrapLocalizationsIt();
+    case 'ja': return UbuntuBootstrapLocalizationsJa();
+    case 'ka': return UbuntuBootstrapLocalizationsKa();
+    case 'kk': return UbuntuBootstrapLocalizationsKk();
+    case 'km': return UbuntuBootstrapLocalizationsKm();
+    case 'kn': return UbuntuBootstrapLocalizationsKn();
+    case 'ko': return UbuntuBootstrapLocalizationsKo();
+    case 'ku': return UbuntuBootstrapLocalizationsKu();
+    case 'lo': return UbuntuBootstrapLocalizationsLo();
+    case 'lt': return UbuntuBootstrapLocalizationsLt();
+    case 'lv': return UbuntuBootstrapLocalizationsLv();
+    case 'mk': return UbuntuBootstrapLocalizationsMk();
+    case 'ml': return UbuntuBootstrapLocalizationsMl();
+    case 'mr': return UbuntuBootstrapLocalizationsMr();
+    case 'my': return UbuntuBootstrapLocalizationsMy();
+    case 'nb': return UbuntuBootstrapLocalizationsNb();
+    case 'ne': return UbuntuBootstrapLocalizationsNe();
+    case 'nl': return UbuntuBootstrapLocalizationsNl();
+    case 'nn': return UbuntuBootstrapLocalizationsNn();
+    case 'oc': return UbuntuBootstrapLocalizationsOc();
+    case 'pa': return UbuntuBootstrapLocalizationsPa();
+    case 'pl': return UbuntuBootstrapLocalizationsPl();
+    case 'pt': return UbuntuBootstrapLocalizationsPt();
+    case 'ro': return UbuntuBootstrapLocalizationsRo();
+    case 'ru': return UbuntuBootstrapLocalizationsRu();
+    case 'se': return UbuntuBootstrapLocalizationsSe();
+    case 'si': return UbuntuBootstrapLocalizationsSi();
+    case 'sk': return UbuntuBootstrapLocalizationsSk();
+    case 'sl': return UbuntuBootstrapLocalizationsSl();
+    case 'sq': return UbuntuBootstrapLocalizationsSq();
+    case 'sr': return UbuntuBootstrapLocalizationsSr();
+    case 'sv': return UbuntuBootstrapLocalizationsSv();
+    case 'ta': return UbuntuBootstrapLocalizationsTa();
+    case 'te': return UbuntuBootstrapLocalizationsTe();
+    case 'tg': return UbuntuBootstrapLocalizationsTg();
+    case 'th': return UbuntuBootstrapLocalizationsTh();
+    case 'tl': return UbuntuBootstrapLocalizationsTl();
+    case 'tr': return UbuntuBootstrapLocalizationsTr();
+    case 'ug': return UbuntuBootstrapLocalizationsUg();
+    case 'uk': return UbuntuBootstrapLocalizationsUk();
+    case 'vi': return UbuntuBootstrapLocalizationsVi();
+    case 'zh': return UbuntuBootstrapLocalizationsZh();
   }
 
   throw FlutterError(
-      'UbuntuBootstrapLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'UbuntuBootstrapLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
 }

--- a/packages/ubuntu_init/integration_test/e2e_test.dart
+++ b/packages/ubuntu_init/integration_test/e2e_test.dart
@@ -35,11 +35,9 @@ void main() {
       ),
     );
 
-    await tester.testLocalePage(language: 'Deutsch', tester: tester);
+    await tester.testLocalePage(language: 'Deutsch');
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     // TODO: Test accessibility settings
 
     await tester.testKeyboardPage(layout: 'Englisch (Britisch)');
@@ -54,8 +52,6 @@ void main() {
     // TODO: Test gsettings input-sources
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testEulaPage();
     await tester.tapNext();

--- a/packages/ubuntu_init/integration_test/e2e_test.dart
+++ b/packages/ubuntu_init/integration_test/e2e_test.dart
@@ -35,9 +35,7 @@ void main() {
       ),
     );
 
-    await tester.testLocalePage(language: 'Deutsch');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(language: 'Deutsch', tester: tester);
 
     await tester.testAccessibilityPage();
     await tester.tapNext();

--- a/packages/ubuntu_init/integration_test/e2e_test.dart
+++ b/packages/ubuntu_init/integration_test/e2e_test.dart
@@ -41,8 +41,6 @@ void main() {
     // TODO: Test accessibility settings
 
     await tester.testKeyboardPage(layout: 'Englisch (Britisch)');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await expectCommand('localectl', [], [
       contains('LANG=de_DE.UTF-8'),
@@ -54,8 +52,6 @@ void main() {
     await tester.testNetworkPage(mode: ConnectMode.none);
 
     await tester.testEulaPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     const identity = Identity(
       realname: 'Test User',
@@ -66,8 +62,6 @@ void main() {
       identity: identity,
       password: 'password',
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await expectCommand('getent', [
       'passwd',
@@ -82,19 +76,13 @@ void main() {
     await expectUser(identity, 'password');
 
     await tester.testUbunutuProOnboardingPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testTimezonePage(timezone: 'Europe/Berlin');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectCommand('timedatectl', [], [
       contains('Time zone: Europe/Berlin'),
     ]);
 
     await tester.testTelemetryPage(enabled: false);
-    await tester.tapDone();
-    await tester.pumpAndSettle();
     await expectLater(windowClosed, completes);
   });
 }

--- a/packages/ubuntu_init/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_init/integration_test/screenshot_test.dart
@@ -25,6 +25,7 @@ Future<void> main() async {
 
       await tester.testWelcomeInitPage(
         screenshot: '$currentThemeName/welcome',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -36,7 +37,8 @@ Future<void> main() async {
       await tester.runApp(() => runInitApp([], theme: currentTheme));
       await tester.pumpAndSettle();
 
-      await tester.testLocalePage(screenshot: '$currentThemeName/locale');
+      await tester.testLocalePage(
+          screenshot: '$currentThemeName/locale', shouldNavigate: false);
     },
     variant: themeVariant,
   );
@@ -50,6 +52,7 @@ Future<void> main() async {
 
     await tester.testAccessibilityPage(
       screenshot: '$currentThemeName/accessibility',
+      shouldNavigate: false,
     );
   });
 
@@ -64,6 +67,7 @@ Future<void> main() async {
 
       await tester.testKeyboardPage(
         screenshot: '$currentThemeName/keyboard',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -81,6 +85,7 @@ Future<void> main() async {
       await tester.testNetworkPage(
         mode: ConnectMode.none,
         screenshot: '$currentThemeName/network',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -97,6 +102,7 @@ Future<void> main() async {
 
       await tester.testEulaPage(
         screenshot: '$currentThemeName/eula',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -119,6 +125,7 @@ Future<void> main() async {
         ),
         password: 'password',
         screenshot: '$currentThemeName/identity',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -135,6 +142,7 @@ Future<void> main() async {
 
       await tester.testUbunutuProOnboardingPage(
         screenshot: '$currentThemeName/ubuntu-pro-onboarding',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -203,6 +211,7 @@ Future<void> main() async {
 
       await tester.testTimezonePage(
         screenshot: '$currentThemeName/timezone',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,
@@ -219,6 +228,7 @@ Future<void> main() async {
 
       await tester.testTelemetryPage(
         screenshot: '$currentThemeName/telemetry',
+        shouldNavigate: false,
       );
     },
     variant: themeVariant,

--- a/packages/ubuntu_init/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_init/integration_test/screenshot_test.dart
@@ -8,6 +8,9 @@ import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_provision_test/ubuntu_provision_test.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
 
+// TODO: These tests will only pass if run as a group, not individually. This is a known limitation
+// tracked by this issue: https://github.com/canonical/ubuntu-desktop-provision/issues/861
+
 Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/ubuntu_init/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_init/integration_test/screenshot_test.dart
@@ -37,8 +37,7 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testLocalePage(
-        screenshot: '$currentThemeName/locale', tester: tester
-      );
+          screenshot: '$currentThemeName/locale', tester: tester);
     },
     variant: themeVariant,
   );

--- a/packages/ubuntu_init/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_init/integration_test/screenshot_test.dart
@@ -36,8 +36,7 @@ Future<void> main() async {
       await tester.runApp(() => runInitApp([], theme: currentTheme));
       await tester.pumpAndSettle();
 
-      await tester.testLocalePage(
-          screenshot: '$currentThemeName/locale', tester: tester);
+      await tester.testLocalePage(screenshot: '$currentThemeName/locale');
     },
     variant: themeVariant,
   );

--- a/packages/ubuntu_init/integration_test/screenshot_test.dart
+++ b/packages/ubuntu_init/integration_test/screenshot_test.dart
@@ -37,7 +37,7 @@ Future<void> main() async {
       await tester.pumpAndSettle();
 
       await tester.testLocalePage(
-        screenshot: '$currentThemeName/locale',
+        screenshot: '$currentThemeName/locale', tester: tester
       );
     },
     variant: themeVariant,

--- a/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
+++ b/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
@@ -24,25 +24,17 @@ void main() {
 
     await tester.runApp(() => runInitApp([]));
 
-    await tester.testLocalePage(language: 'Deutsch', tester: tester);
+    await tester.testLocalePage(language: 'Deutsch');
     await expectLocale('de_DE.UTF-8');
 
     await tester.testAccessibilityPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testKeyboardPage(layout: 'Englisch (Britisch)');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectKeyboard(const KeyboardSetting(layout: 'gb'));
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testEulaPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     const identity = Identity(
       realname: 'User',
@@ -53,22 +45,14 @@ void main() {
       identity: identity,
       password: 'password',
     );
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectIdentity(identity);
 
     await tester.testUbunutuProOnboardingPage();
-    await tester.tapNext();
-    await tester.pumpAndSettle();
 
     await tester.testTimezonePage(timezone: 'Europe/Berlin');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
     await expectTimezone('Europe/Berlin');
 
     await tester.testTelemetryPage(enabled: false);
-    await tester.tapDone();
-    await tester.pumpAndSettle();
     await expectLater(windowClosed, completes);
   });
 
@@ -78,8 +62,6 @@ void main() {
     await tester.runApp(() => runInitApp(['--welcome']));
 
     await tester.testWelcomeInitPage();
-    await tester.tapDone();
-    await tester.pumpAndSettle();
     await expectLater(windowClosed, completes);
   });
 }

--- a/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
+++ b/packages/ubuntu_init/integration_test/ubuntu_init_test.dart
@@ -24,9 +24,7 @@ void main() {
 
     await tester.runApp(() => runInitApp([]));
 
-    await tester.testLocalePage(language: 'Deutsch');
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tester.testLocalePage(language: 'Deutsch', tester: tester);
     await expectLocale('de_DE.UTF-8');
 
     await tester.testAccessibilityPage();

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -343,7 +343,6 @@ extension UbuntuBootstrapPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-
     await tapNext();
     await pumpAndSettle();
   }

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -30,6 +30,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testAutoinstallPage({
@@ -47,6 +50,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testRstPage({
@@ -85,6 +91,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapSkip();
+    await pumpAndSettle();
   }
 
   Future<void> testSourceSelectionPage({
@@ -106,6 +115,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testCodecsAndDriversPage({
@@ -124,6 +136,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testNotEnoughDiskSpacePage({
@@ -195,6 +210,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (guidedCapability == null && screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testBitLockerPage({
@@ -218,6 +236,8 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot('$screenshot-confirm');
     }
+
+    await pumpAndSettle();
   }
 
   Future<void> testGuidedReformatPage({
@@ -264,6 +284,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testManualStoragePage({
@@ -319,6 +342,10 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testPassphrasePage({
@@ -346,6 +373,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testRecoveryKeyPage({
@@ -376,6 +406,9 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapConfirm();
+    await pumpAndSettle();
   }
 
   Future<void> testInstallPage({
@@ -391,5 +424,6 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     }
 
     await pumpUntil(find.button(l10n.continueTesting));
+    await pumpAndSettle();
   }
 }

--- a/packages/ubuntu_provision_test/lib/src/init_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/init_tester.dart
@@ -7,6 +7,7 @@ import 'package:yaru_test/yaru_test.dart';
 extension UbuntuInitPageTester on WidgetTester {
   Future<void> testWelcomeInitPage({
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(WelcomePage);
 
@@ -19,13 +20,16 @@ extension UbuntuInitPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapDone();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapDone();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testTelemetryPage({
     bool? enabled,
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(TelemetryPage);
 
@@ -43,8 +47,10 @@ extension UbuntuInitPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapDone();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testUbuntuProPage({
@@ -64,6 +70,7 @@ extension UbuntuInitPageTester on WidgetTester {
 
   Future<void> testUbunutuProOnboardingPage({
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(UbuntuProOnboardingPage);
 
@@ -83,8 +90,10 @@ extension UbuntuInitPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testUbuntuProSuccessAttachProPage({

--- a/packages/ubuntu_provision_test/lib/src/init_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/init_tester.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_init/ubuntu_init.dart';
 import 'package:ubuntu_provision_test/src/wizard_tester.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru_test/yaru_test.dart';
 
 extension UbuntuInitPageTester on WidgetTester {

--- a/packages/ubuntu_provision_test/lib/src/init_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/init_tester.dart
@@ -17,6 +17,9 @@ extension UbuntuInitPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapDone();
+    await pumpAndSettle();
   }
 
   Future<void> testTelemetryPage({
@@ -38,6 +41,9 @@ extension UbuntuInitPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapDone();
+    await pumpAndSettle();
   }
 
   Future<void> testUbuntuProPage({
@@ -75,6 +81,9 @@ extension UbuntuInitPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testUbuntuProSuccessAttachProPage({

--- a/packages/ubuntu_provision_test/lib/src/init_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/init_tester.dart
@@ -48,7 +48,7 @@ extension UbuntuInitPageTester on WidgetTester {
     }
 
     if (shouldNavigate) {
-      await tapNext();
+      await tapDone();
       await pumpAndSettle();
     }
   }

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -215,11 +215,11 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-      if (shouldNavigate) {
+    if (shouldNavigate) {
       await tapNext();
       await pumpAndSettle();
     }
-}
+  }
 
   Future<void> testIdentityPage({
     Identity? identity,

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_flavor/ubuntu_flavor.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_provision_test/src/wizard_tester.dart';
+import 'package:ubuntu_test/ubuntu_test.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_test/yaru_test.dart';
 
@@ -10,6 +11,7 @@ extension UbuntuProvisionPageTester on WidgetTester {
   Future<void> testLocalePage({
     String? language,
     String? screenshot,
+    required WidgetTester tester,
   }) async {
     await pumpUntilPage(LocalePage);
 
@@ -33,6 +35,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tester.tapNext();
+    await tester.pumpAndSettle();
   }
 
   Future<void> testAccessibilityPage({

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -11,7 +11,6 @@ extension UbuntuProvisionPageTester on WidgetTester {
   Future<void> testLocalePage({
     String? language,
     String? screenshot,
-    required WidgetTester tester,
   }) async {
     await pumpUntilPage(LocalePage);
 
@@ -36,8 +35,8 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tester.tapNext();
-    await tester.pumpAndSettle();
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testAccessibilityPage({
@@ -58,6 +57,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testKeyboardPage({
@@ -106,6 +108,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
         await pumpAndSettle();
       }
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testNetworkPage({
@@ -127,6 +132,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testEulaPage({
@@ -149,6 +157,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testTimezonePage({
@@ -188,6 +199,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testIdentityPage({
@@ -243,6 +257,9 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testActiveDirectoryPage({

--- a/packages/ubuntu_provision_test/lib/src/provision_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/provision_tester.dart
@@ -11,6 +11,7 @@ extension UbuntuProvisionPageTester on WidgetTester {
   Future<void> testLocalePage({
     String? language,
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(LocalePage);
 
@@ -34,13 +35,15 @@ extension UbuntuProvisionPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
-
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testAccessibilityPage({
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(AccessibilityPage);
 
@@ -58,14 +61,17 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testKeyboardPage({
     String? layout,
     String? variant,
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(KeyboardPage);
 
@@ -109,13 +115,16 @@ extension UbuntuProvisionPageTester on WidgetTester {
       }
     }
 
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testNetworkPage({
     ConnectMode? mode,
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(NetworkPage);
 
@@ -133,12 +142,15 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testEulaPage({
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(EulaPage);
 
@@ -158,14 +170,17 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testTimezonePage({
     String? location,
     String? timezone,
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(TimezonePage);
 
@@ -200,14 +215,17 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapNext();
-    await pumpAndSettle();
-  }
+      if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
+}
 
   Future<void> testIdentityPage({
     Identity? identity,
     String? password,
     String? screenshot,
+    bool shouldNavigate = true,
   }) async {
     await pumpUntilPage(IdentityPage);
 
@@ -258,8 +276,10 @@ extension UbuntuProvisionPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapNext();
-    await pumpAndSettle();
+    if (shouldNavigate) {
+      await tapNext();
+      await pumpAndSettle();
+    }
   }
 
   Future<void> testActiveDirectoryPage({


### PR DESCRIPTION
A small refactor to move repeated navigation functions into their test functions for better test readability to help me get more comfortable with navigating the installer project :slightly_smiling_face: 