### PR TITLE
ci: release automation

### DIFF
--- a/.github/workflows/check-snap-label.yaml
+++ b/.github/workflows/check-snap-label.yaml
@@ -1,0 +1,30 @@
+name: Check snap label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check-snap-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the PR is tagged with a snap/* label
+        if: >
+          !contains(github.event.pull_request.labels.*.name, 'snap/ubuntu-desktop-bootstrap') &&
+          !contains(github.event.pull_request.labels.*.name, 'snap/ubuntu-desktop-init') &&
+          !contains(github.event.pull_request.labels.*.name, 'snap/factory-reset-tools') &&
+          !contains(github.event.pull_request.labels.*.name, 'snap/none')
+        run: |
+          echo '::error::No valid snap label found!'
+          echo 'Please tag your PR with one of the following labels:' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '- `snap/ubuntu-desktop-bootstrap`' >> $GITHUB_STEP_SUMMARY
+          echo '- `snap/ubuntu-desktop-init`' >> $GITHUB_STEP_SUMMARY
+          echo '- `snap/factory-reset-tools`' >> $GITHUB_STEP_SUMMARY
+          echo '- `snap/none`' >> $GITHUB_STEP_SUMMARY
+          exit 1

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,0 +1,93 @@
+name: Release Snaps
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  get-snap-branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.parse-labels.outputs.branches }}
+
+    steps:
+      - name: Parse labels
+        id: parse-labels
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          case $BASE_REF in
+            main)
+              BASE=main
+              ;;
+            ubuntu/*)
+              BASE=$(echo $BASE_REF | cut -d'/' -f2)
+              ;;
+            *)
+              echo "::error::Unknown base '$BASE_REF'"
+              exit 1
+          esac
+
+          # Appends '/$BASE' to the PR labels that start with 'snap/' and filters out everything else, including 'snap/none'
+          # Example: ['mylabel', 'snap/none', 'snap/ubuntu-desktop-bootstrap'] -> ['snap/ubuntu-desktop-bootstrap/main']
+          BRANCHES=$(echo $LABELS | jq -c "[.[]|select(.!=\"snap/none\")|select(startswith(\"snap/\"))|.+\"/$BASE\"]")
+          echo "Found branches: $BRANCHES" >> $GITHUB_STEP_SUMMARY
+          echo "branches=$BRANCHES" >> $GITHUB_OUTPUT
+
+  release-snaps:
+    runs-on: ubuntu-latest
+    needs: get-snap-branches
+    if: ${{ github.event.pull_request.merged && needs.get-snap-branches.outputs.branches != '[]' }}
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.get-snap-branches.outputs.branches) }}
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+
+      - name: Bump source-commit in snapcraft.yaml
+        id: bump-deps
+        env:
+          BRANCH: ${{ matrix.branch }}
+          NEW_HASH: ${{ github.sha }}
+        run: |
+          case $BRANCH in
+            snap/ubuntu-desktop-bootstrap/*)
+              PART_NAME='ubuntu-bootstrap'
+              ;;
+            snap/ubuntu-desktop-init/*)
+              PART_NAME='ubuntu-desktop-init'
+              ;;
+            snap/factory-reset-tools/*)
+              PART_NAME='factory-reset-tools'
+              ;;
+            *)
+              echo "::error::Unknown branch '$BRANCH'"
+              exit 1
+          esac
+          echo "part_name=$PART_NAME" >> $GITHUB_OUTPUT
+
+          SNAP_NAME=$(echo $BRANCH | cut -d '/' -f2)
+          echo "snap_name=$SNAP_NAME" >> $GITHUB_OUTPUT
+
+          OLD_HASH=$(yq ".parts[\"$PART_NAME\"][\"source-commit\"]" snap/snapcraft.yaml)
+          echo "old_hash=$OLD_HASH" >> $GITHUB_OUTPUT
+          sed -i "s/$OLD_HASH/$NEW_HASH/" snap/snapcraft.yaml
+          echo "Updating source-commit for part '$PART_NAME' from '$OLD_HASH' to '$NEW_HASH'" >> $GITHUB_STEP_SUMMARY
+          git diff
+
+      - name: Open or update PR on release branch
+        uses: peter-evans/create-pull-request@v7
+        with:
+          sign-commits: true
+          branch: ${{ matrix.branch }}-release
+          commit-message: "chore: bump source-commit"
+          title: "chore: bump source-commit for ${{ steps.bump-deps.outputs.snap_name }}"
+          body: |
+            Updates the `source-commit` for `${{ steps.bump-deps.outputs.part_name }}` in the snapcraft.yaml from ${{ steps.bump-deps.outputs.old_hash }} to ${{ github.sha }} ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ steps.bump-deps.outputs.old_hash }}...${{ github.sha }}))

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -91,3 +91,4 @@ jobs:
           title: "chore: bump source-commit for ${{ steps.bump-deps.outputs.snap_name }}"
           body: |
             Updates the `source-commit` for `${{ steps.bump-deps.outputs.part_name }}` in the snapcraft.yaml from ${{ steps.bump-deps.outputs.old_hash }} to ${{ github.sha }} ([diff](${{ github.event.pull_request.base.repo.html_url }}/compare/${{ steps.bump-deps.outputs.old_hash }}...${{ github.sha }}))
+          reviewers: ${{ github.event.sender.login }}


### PR DESCRIPTION
This PR adds two github workflows that allow us to automatically raise snap build PRs (`snap/*` branches) driven by labels on mainline PRs.

- `check-snap-label.yaml`
Checks if mainline PRs are labeled with at least one of:
  - `snap/ubuntu-desktop-bootstrap`
  - `snap/ubuntu-desktop-init`
  - `snap/factory-reset-tools`
  - `snap/none` (used for PRs that shouldn't trigger any snap release PRs, e.g. documentation changes, ..)
- `snap-release.yaml`
  - Runs when a PR is merged into a mainline branch
  - Parses the labels from the merged PR and translates them into the names of the release branches, e.g. `snap/ubuntu-desktop-bootstrap` -> `snap/ubuntu-desktop-bootstrap/main` for a PR targeting `main`, or `snap/ubuntu-desktop-bootstrap` -> `snap/ubuntu-desktop-init/24.04` for a PR targeting `ubuntu/24.04` (will need backporting to `ubuntu/24.04`)
  - Replaces the `commit-ref` for the corresponding `part` in the snapcraft.yaml with the commit hash of the PR's merge commit
  - Pushes the changes to a dedicated release branch (e.g. `snap/ubuntu-desktop-bootstrap/main-release`) or updates the branch if it already exists
  - Opens a PR from that branch to the corresponding snap branch (e.g. `snap/ubuntu-desktop-bootstrap/main`) or updates it.

UDENG-5076