### PR TITLE
chore(deps): track subiquity main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
 	url = https://github.com/canonical/subiquity.git
-	branch = ubuntu/oracular
+	branch = main


### PR DESCRIPTION
LP: #2088978 shows a SerializationError related to parsing of the new install-sources format, which includes information about what kernel to use.

Pick up subiquity main again, which we should do anyway but also because it knows how to work with the new install-sources format.