### PR TITLE
ci: add write permissions for the snap release job

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -38,6 +38,8 @@ jobs:
 
   release-snaps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: get-snap-branches
     if: ${{ github.event.pull_request.merged && needs.get-snap-branches.outputs.branches != '[]' }}
     strategy:


### PR DESCRIPTION
For pull requests raised from forked repositories, the `GITHUB_TOKEN` only comes with `read` permissions by default. This PR adds `write` permissions for the repository contents, so that the job can create/modify the release branch.