### PR TITLE
ci: add `pull-requests: write` permission to snap-release job

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     needs: get-snap-branches
     if: ${{ github.event.pull_request.merged && needs.get-snap-branches.outputs.branches != '[]' }}
     strategy:


### PR DESCRIPTION
Apparently #870 wasn't enough to fix the permission issue for the snap release job. I had another look at the [documentation](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#token), which suggests adding `pull-requests: write` as well.