### PR TITLE
chore(deps): track subiquity main-core22

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
 	url = https://github.com/canonical/subiquity.git
-	branch = main
+	branch = main-core22


### PR DESCRIPTION
Temporarily track a different branch, to pickup a fix for install- sources but hold off of core24 for the moment.

This branch is not intended to be updated and should only be used until core24 is ready.

If you have core24 support sorted out please reject this PR.