### PR TITLE
WIP: build core24 snap

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -17,8 +17,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: snapcore/action-build@v1
-        with:
-          snapcraft-channel: 7.x
         id: snapcraft
       - uses: actions/upload-artifact@v4
         if: github.event_name == 'workflow_dispatch'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref bcd9aa3a6705eddfebd7ce2728363eb7266badc5
+    source-commit: &commit-ref 03e1840c066daa10d6a5c69f022d277c5039ed44
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,10 +8,10 @@ contact: https://bugs.launchpad.net/ubuntu-desktop-provision
 issues: https://bugs.launchpad.net/ubuntu-desktop-provision
 grade: stable
 confinement: classic
-base: core22
-architectures:
-  - build-on: amd64
-  - build-on: arm64
+base: core24
+platforms:
+  amd64:
+  arm64:
 
 apps:
   subiquity-server:
@@ -89,7 +89,7 @@ parts:
       # See https://discuss.python.org/t/18240
       # As a workaround, we use a fake user install to get the package
       # installed in the expected place.
-      PYTHONUSERBASE="$CRAFT_PART_INSTALL" pip3 install --user --no-dependencies .
+      PYTHONUSERBASE="$CRAFT_PART_INSTALL" pip3 install --user --no-dependencies --break-system-packages .
     build-packages:
       - python3-pip
     organize:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,8 +122,8 @@ parts:
       # there doesn't seem to be any real benefit to listing them separately.
       - iso-codes
       - libpython3-stdlib
-      - libpython3.10-minimal
-      - libpython3.10-stdlib
+      - libpython3.12-minimal
+      - libpython3.12-stdlib
       - libsystemd0
       - lsb-release
       - ntfs-3g
@@ -148,7 +148,7 @@ parts:
       - python3-urwid
       - python3-yaml
       - python3-yarl
-      - python3.10-minimal
+      - python3.12-minimal
       - ssh-import-id
       - ubuntu-advantage-tools
     prime:


### PR DESCRIPTION
The snap builds successfully, but when running it on the current plucky ISO the installer UI crashes:

```
$ LD_DEBUG=libs /snap/bin/ubuntu-desktop-bootstrap
...
     10937:    calling init: /snap/ubuntu-desktop-bootstrap/x1/bin/lib/libyaru_window_linux_plugin.so
     10937:    
**
GLib-GObject:ERROR:../../../gobject/gtype.c:2830:g_type_register_static: assertion failed: (static_quark_type_flags)
Bail out! GLib-GObject:ERROR:../../../gobject/gtype.c:2830:g_type_register_static: assertion failed: (static_quark_type_flags)
Aborted (core dumped)
```

There also seems to be a linker issue:

```
$ ldd -r /snap/ubuntu-desktop-bootstrap/current/bin/lib/libyaru_window_linux_plugin.so
    linux-vdso.so.1 (0x0000709920e0c000)
...
undefined symbol: fl_value_get_string    (/snap/ubuntu-desktop-bootstrap/current/bin/lib/libyaru_window_linux_plugin.so)
undefined symbol: fl_value_unref    (/snap/ubuntu-desktop-bootstrap/current/bin/lib/libyaru_window_linux_plugin.so)
undefined symbol: fl_value_new_int    (/snap/ubuntu-desktop-bootstrap/current/bin/lib/libyaru_window_linux_plugin.so)
...
    libflutter_linux_gtk.so => not found
```

Running the UI with `LD_LIBRARY_PATH=/snap/ubuntu-desktop-bootstrap/bin/lib` fixes the linker issue, but not the glib error mentioned above.