### PR TITLE
fix: NetworkPage WiFi bugs

### DIFF
--- a/packages/ubuntu_provision/lib/src/network/network_page.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_page.dart
@@ -41,22 +41,22 @@ class NetworkPage extends ConsumerWidget with ProvisioningPage {
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
         trailing: [
-          WizardButton(
-            label: UbuntuLocalizations.of(context).connectLabel,
-            enabled: !model.isConnecting,
-            visible: model.isEnabled && model.canConnect,
-            onActivated: model.connect,
-          ),
-          NextWizardButton(
-            enabled:
-                model.isEnabled && !model.isConnecting && model.isConnected,
-            visible: !model.isEnabled || !model.canConnect,
-            // suspend network activity when proceeding on the next page
-            onNext: model.cleanup,
-            // resume network activity if/when returning back to this page
-            onReturn: model.init,
-            focusNode: ref.watch(_nextFocusNodeProvider),
-          ),
+          if (model.isEnabled && model.canConnect)
+            WizardButton(
+              label: UbuntuLocalizations.of(context).connectLabel,
+              enabled: !model.isConnecting,
+              onActivated: model.connect,
+            ),
+          if (!model.isEnabled || !model.canConnect)
+            NextWizardButton(
+              enabled:
+                  model.isEnabled && !model.isConnecting && model.isConnected,
+              // suspend network activity when proceeding on the next page
+              onNext: model.cleanup,
+              // resume network activity if/when returning back to this page
+              onReturn: model.init,
+              focusNode: ref.watch(_nextFocusNodeProvider),
+            ),
         ],
       ),
       children: <Widget>[

--- a/packages/ubuntu_provision/lib/src/network/wifi_model.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_model.dart
@@ -142,7 +142,7 @@ class WifiDevice extends NetworkDevice {
   }
 
   NetworkManagerDeviceWireless _wireless;
-  final _accessPoints = <AccessPoint>[];
+  var _accessPoints = <AccessPoint>[];
   final _allAccessPoints = <String, AccessPoint>{};
 
   @override
@@ -218,7 +218,7 @@ class WifiDevice extends NetworkDevice {
   }
 
   void _updateAccessPoints() {
-    _accessPoints.clear();
+    final updatedAps = <AccessPoint>[];
     final previousSelected = _selectedAccessPoint;
     _selectedAccessPoint = null;
     for (final ap in _getAccessPoints()) {
@@ -230,11 +230,12 @@ class WifiDevice extends NetworkDevice {
       } else {
         model._updateAccessPoint(ap);
       }
-      _accessPoints.add(model);
+      updatedAps.add(model);
       if (model == previousSelected) {
         _selectedAccessPoint = model;
       }
     }
+    _accessPoints = updatedAps;
     _selectedAccessPoint ??= activeAccessPoint;
     log.debug(() => 'Update access points: $_accessPoints ($this)');
     notifyListeners();


### PR DESCRIPTION
This fixes two bugs on the network page:
- 'Connect' button gets stuck in loading state (see jira and [lp:2088068](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2088068))
- List of available WiFi networks disappears randomly

See commit messages for more details.

Please double-check that this fixes the 'Connect' button issue by running the installer locally and following those steps (copied from jira):
- advance to the "Connect to the internet" page
- select "Connect to a Wi-Fi network" and select an AP
- click "Connect" in the bottom right
- enter the password and wait for it to connect
- select any other network in the list of APs and see that the "next" button in the bottom right becomes a spinner than never completes

Instead of a spinner, the button should now show 'Connect' again and let you connect to a different network.

UDENG-5269