### PR TITLE
chore(deps): track subiquity main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
 	url = https://github.com/canonical/subiquity.git
-	branch = main-core22
+	branch = main


### PR DESCRIPTION
We have a working core24-based version of the desktop installer in `25.04/edge` now (`0+git.1db71a4e2`, revision 295), so we can go back to tracking subiquity's main branch here.