### PR TITLE
ci: rename release branch to avoid branch protection issues

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           sign-commits: true
-          branch: ${{ matrix.branch }}-release
+          branch: release/${{ matrix.branch }}
           commit-message: "chore: bump source-commit"
           title: "chore: bump source-commit for ${{ steps.bump-deps.outputs.snap_name }}"
           body: |


### PR DESCRIPTION
This renames the CI automation release branches opened by the bot from e.g. `snap/ubuntu-desktop-bootstrap/main-release` to `release/snap/ubuntu-desktop-bootstrap/main` so that they are no longer affected by the `snap/*` branch protection rules that prevent the bot from updating the release branches.