### PR TITLE
feat: Erase and install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,6 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
-	url = https://github.com/canonical/subiquity.git
-	branch = main
+	; url = https://github.com/canonical/subiquity.git
+	; branch = main
+	url = https://github.com/ogayot/subiquity.git
+	branch = erase-and-install

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
-	; url = https://github.com/canonical/subiquity.git
-	; branch = main
-	url = https://github.com/ogayot/subiquity.git
-	branch = erase-and-install
+	url = https://github.com/canonical/subiquity.git
+	branch = main

--- a/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -52,15 +52,10 @@ void main() {
     await expectKeyboard(keyboard);
 
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
-
     await tester.testStoragePage(type: StorageType.erase);
 
     await tester.testIdentityPage(identity: identity, password: 'password');
@@ -70,7 +65,6 @@ void main() {
     await expectTimezone(timezone);
 
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -92,27 +86,16 @@ void main() {
 
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
-
     await tester.testStoragePage(type: StorageType.erase);
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -131,21 +114,13 @@ void main() {
 
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
 
     await tester.testStoragePage(
@@ -159,9 +134,7 @@ void main() {
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -183,21 +156,13 @@ void main() {
 
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
 
     await tester.testStoragePage(
@@ -209,9 +174,7 @@ void main() {
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -233,21 +196,13 @@ void main() {
 
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
 
     await tester.testStoragePage(
@@ -261,9 +216,7 @@ void main() {
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -291,22 +244,15 @@ void main() {
         '--bootloader=uefi',
       ]),
     );
+
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
 
     await tester.testStoragePage(
@@ -322,9 +268,7 @@ void main() {
     await expectIdentity(identity);
 
     await tester.testTimezonePage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -350,25 +294,15 @@ void main() {
 
     await tester.runApp(() => app.main(<String>[]));
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
-
     await tester.testStoragePage(type: StorageType.manual);
-
     await tester.testManualStoragePage(storage: storage);
 
     await tester.testIdentityPage(
@@ -377,9 +311,7 @@ void main() {
     );
 
     await tester.testTimezonePage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -413,26 +345,17 @@ void main() {
         '--bootloader=uefi',
       ]),
     );
+
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
-
     await tester.testStoragePage(type: StorageType.alongside);
-
     await tester.testGuidedResizePage(size: 30);
 
     await tester.testIdentityPage(
@@ -441,9 +364,7 @@ void main() {
     );
 
     await tester.testTimezonePage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -476,26 +397,17 @@ void main() {
         '--machine-config=examples/machines/win10.json',
       ]),
     );
+
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testAutoinstallPage();
-
     await tester.testSourceSelectionPage();
-
     await tester.testCodecsAndDriversPage();
-
     await tester.testStoragePage(type: StorageType.alongside);
-
     await tester.testBitLockerPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();
@@ -506,19 +418,12 @@ void main() {
   testWidgets('welcome', (tester) async {
     await tester.runApp(() => app.main(<String>['--welcome']));
     await tester.pumpAndSettle();
-
     await tester.testLocalePage();
-
     await tester.testAccessibilityPage();
-
     await tester.testKeyboardPage();
-
     await tester.testNetworkPage(mode: ConnectMode.none);
-
     await tester.testRefreshPage();
-
     await tester.testTryOrInstallPage(option: TryOrInstallOption.installUbuntu);
-
     await tester.testAutoinstallPage();
   });
 
@@ -529,12 +434,10 @@ void main() {
         '--autoinstall=examples/autoinstall/interactive.yaml',
       ]),
     );
+
     await tester.pumpAndSettle();
-
     await tester.testNetworkPage();
-
     await tester.testConfirmPage();
-
     await tester.testInstallPage();
 
     final windowClosed = YaruTestWindow.waitForClosed();

--- a/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -365,8 +365,8 @@ void main() {
 
   // FIXME: this currently fails due to a known Subiquity bug with partition relabelling
   testWidgets(
-    skip: true,
     'erase and install first logical partition',
+    skip: true,
     (tester) => eraseInstallTest(
       tester: tester,
       machineConfig: 'examples/machines/threebuntu-on-msdos.json',

--- a/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -338,11 +338,12 @@ void main() {
   });
 
   // threebuntu-on-msdos has three existing ubuntu partitions:
-  //   - 20.04.4 on sda1
-  //   - 21.10 on sda5
-  //   - 22.04 on sda6
-  testWidgets('erase and install primary partition', (tester) async {
-    await eraseInstallTest(
+  //   - 20.04.4 on sda1 (primary)
+  //   - 21.10   on sda5 (logical)
+  //   - 22.04   on sda6 (logical)
+  testWidgets(
+    'erase and install primary partition',
+    (tester) => eraseInstallTest(
       tester: tester,
       machineConfig: 'examples/machines/threebuntu-on-msdos.json',
       target: GuidedStorageTargetEraseInstall(
@@ -359,13 +360,14 @@ void main() {
           ],
         ),
       ],
-    );
-  });
+    ),
+  );
 
   // FIXME: this currently fails due to a known Subiquity bug with partition relabelling
-  testWidgets(skip: true, 'erase and install first logical partition',
-      (tester) async {
-    await eraseInstallTest(
+  testWidgets(
+    skip: true,
+    'erase and install first logical partition',
+    (tester) => eraseInstallTest(
       tester: tester,
       machineConfig: 'examples/machines/threebuntu-on-msdos.json',
       target: GuidedStorageTargetEraseInstall(
@@ -382,11 +384,12 @@ void main() {
           ],
         ),
       ],
-    );
-  });
+    ),
+  );
 
-  testWidgets('erase and install last logical partition', (tester) async {
-    await eraseInstallTest(
+  testWidgets(
+    'erase and install last logical partition',
+    (tester) => eraseInstallTest(
       tester: tester,
       machineConfig: 'examples/machines/threebuntu-on-msdos.json',
       target: GuidedStorageTargetEraseInstall(
@@ -403,8 +406,8 @@ void main() {
           ],
         ),
       ],
-    );
-  });
+    ),
+  );
 
   testWidgets('alongside windows', (tester) async {
     await tester.runApp(
@@ -539,12 +542,10 @@ Future<void> eraseInstallTest({
   await tester.testSourceSelectionPage();
   await tester.testCodecsAndDriversPage();
   await tester.testStoragePage(type: StorageTypeEraseInstall(target));
-
   await tester.testIdentityPage(
     identity: const Identity(realname: 'a', hostname: 'b', username: 'c'),
     password: 'password',
   );
-
   await tester.testTimezonePage();
   await tester.testConfirmPage();
   await tester.testInstallPage();

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -205,7 +205,7 @@
       }
     }
   },
-  "installationTypeEraseInfo": "Warning: All data and partitions on the disk will be erased, including operating systems.",
+  "installationTypeEraseInfo": "All data and partitions on the disk will be erased, including operating systems.",
   "installationTypeAdvancedLabel": "Advanced features...",
   "installationTypeAdvancedTitle": "Advanced features",
   "installationTypeExperimental": "Experimental",
@@ -277,7 +277,7 @@
       }
     }
   },
-  "installationTypeAlongsideMulti": "Install {product} alongside them",
+  "installationTypeAlongsideMulti": "Install {product} alongside existing operating systems",
   "@installationTypeAlongsideMulti": {
     "placeholders": {
       "product": {
@@ -312,7 +312,7 @@
       }
     }
   },
-  "installationTypeEraseAndInstallInfo": "Warning: All files and data from the existing {os} installation will be permenantly deleted.",
+  "installationTypeEraseAndInstallInfo": "All files and data from the existing {os} installation will be permanently deleted.",
   "@installationTypeEraseAndInstallInfo": {
     "placeholders": {
       "os": {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -294,6 +294,18 @@
     }
   },
   "installationTypeAlongsideInfo": "You can choose your operating system during boot.",
+  "installationTypeEraseAndInstall": "Erase {os} and install {product}",
+  "@installationTypeEraseAndInstall": {
+    "placeholders": {
+      "os": {
+        "type": "String"
+      },
+      "product": {
+        "type": "String"
+      }
+    }
+  },
+  "installationTypeEraseAndInstallInfo": "Replace your currently installed OS.",
   "installationTypeManual": "Manual installation",
   "installationTypeManualInfo": "For advanced users seeking customized disk setups.",
   "@installationTypeManualInfo": {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -205,7 +205,7 @@
       }
     }
   },
-  "installationTypeEraseInfo": "Start from scratch on your selected disk.",
+  "installationTypeEraseInfo": "Warning: All data and partitions on the disk will be erased, including operating systems.",
   "installationTypeAdvancedLabel": "Advanced features...",
   "installationTypeAdvancedTitle": "Advanced features",
   "installationTypeExperimental": "Experimental",
@@ -293,7 +293,14 @@
       }
     }
   },
-  "installationTypeAlongsideInfo": "You can choose your operating system during boot.",
+  "installationTypeAlongsideInfo": "Select a partition to resize and create space for {product}. You can choose your operating system during boot.",
+  "@installationTypeAlongsideInfo": {
+    "placeholders": {
+      "product": {
+        "type": "String"
+      }
+    }
+  },
   "installationTypeEraseAndInstall": "Erase {os} and install {product}",
   "@installationTypeEraseAndInstall": {
     "placeholders": {
@@ -305,7 +312,14 @@
       }
     }
   },
-  "installationTypeEraseAndInstallInfo": "Replace your currently installed OS.",
+  "installationTypeEraseAndInstallInfo": "Warning: All files and data from the existing {os} installation will be permenantly deleted.",
+  "@installationTypeEraseAndInstallInfo": {
+    "placeholders": {
+      "os": {
+        "type": "String"
+      }
+    }
+  },
   "installationTypeManual": "Manual installation",
   "installationTypeManualInfo": "For advanced users seeking customized disk setups.",
   "@installationTypeManualInfo": {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -698,7 +698,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @installationTypeEraseInfo.
   ///
   /// In en, this message translates to:
-  /// **'Warning: All data and partitions on the disk will be erased, including operating systems.'**
+  /// **'All data and partitions on the disk will be erased, including operating systems.'**
   String get installationTypeEraseInfo;
 
   /// No description provided for @installationTypeAdvancedLabel.
@@ -830,7 +830,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @installationTypeAlongsideMulti.
   ///
   /// In en, this message translates to:
-  /// **'Install {product} alongside them'**
+  /// **'Install {product} alongside existing operating systems'**
   String installationTypeAlongsideMulti(String product);
 
   /// No description provided for @installationTypeAlongsideUnknown.
@@ -854,7 +854,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @installationTypeEraseAndInstallInfo.
   ///
   /// In en, this message translates to:
-  /// **'Warning: All files and data from the existing {os} installation will be permenantly deleted.'**
+  /// **'All files and data from the existing {os} installation will be permanently deleted.'**
   String installationTypeEraseAndInstallInfo(String os);
 
   /// No description provided for @installationTypeManual.

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -845,6 +845,18 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'You can choose your operating system during boot.'**
   String get installationTypeAlongsideInfo;
 
+  /// No description provided for @installationTypeEraseAndInstall.
+  ///
+  /// In en, this message translates to:
+  /// **'Erase {os} and install {product}'**
+  String installationTypeEraseAndInstall(String os, String product);
+
+  /// No description provided for @installationTypeEraseAndInstallInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Replace your currently installed OS.'**
+  String get installationTypeEraseAndInstallInfo;
+
   /// No description provided for @installationTypeManual.
   ///
   /// In en, this message translates to:

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -698,7 +698,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @installationTypeEraseInfo.
   ///
   /// In en, this message translates to:
-  /// **'Start from scratch on your selected disk.'**
+  /// **'Warning: All data and partitions on the disk will be erased, including operating systems.'**
   String get installationTypeEraseInfo;
 
   /// No description provided for @installationTypeAdvancedLabel.
@@ -842,8 +842,8 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @installationTypeAlongsideInfo.
   ///
   /// In en, this message translates to:
-  /// **'You can choose your operating system during boot.'**
-  String get installationTypeAlongsideInfo;
+  /// **'Select a partition to resize and create space for {product}. You can choose your operating system during boot.'**
+  String installationTypeAlongsideInfo(String product);
 
   /// No description provided for @installationTypeEraseAndInstall.
   ///
@@ -854,8 +854,8 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @installationTypeEraseAndInstallInfo.
   ///
   /// In en, this message translates to:
-  /// **'Replace your currently installed OS.'**
-  String get installationTypeEraseAndInstallInfo;
+  /// **'Warning: All files and data from the existing {os} installation will be permenantly deleted.'**
+  String installationTypeEraseAndInstallInfo(String os);
 
   /// No description provided for @installationTypeManual.
   ///

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'الميزات المتقدمة...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'التقسيم اليدوي';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'الميزات المتقدمة...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'التقسيم اليدوي';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Вы можаце выбіраць аперацыйную сістэму падчас загрузкі.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Усталяванне ўручную';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Вы можаце выбіраць аперацыйную сістэму падчас загрузкі.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Вы можаце выбіраць аперацыйную сістэму падчас загрузкі.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Усталяванне ўручную';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Característiques avançades…';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Els documents, la música i la resta de fitxers personals es conservaran. Podreu triar quin sistema operatiu voleu utilitzar cada cop que engegueu l\'ordinador.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Alguna altra cosa';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Característiques avançades…';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Els documents, la música i la resta de fitxers personals es conservaran. Podreu triar quin sistema operatiu voleu utilitzar cada cop que engegueu l\'ordinador.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Els documents, la música i la resta de fitxers personals es conservaran. Podreu triar quin sistema operatiu voleu utilitzar cada cop que engegueu l\'ordinador.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Alguna altra cosa';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumenty, hudba a ostatní osobní soubory zůstanou zachovány. Pokaždé, když počítač spustíte z vypnutého stavu (tedy nikoli uspání), budete si moci zvolit který operační systém spustit.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Ruční rozdělení na oddíly';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumenty, hudba a ostatní osobní soubory zůstanou zachovány. Pokaždé, když počítač spustíte z vypnutého stavu (tedy nikoli uspání), budete si moci zvolit který operační systém spustit.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumenty, hudba a ostatní osobní soubory zůstanou zachovány. Pokaždé, když počítač spustíte z vypnutého stavu (tedy nikoli uspání), budete si moci zvolit který operační systém spustit.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Ruční rozdělení na oddíly';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Caiff dogfennau, cerddoriaeth, a ffeiliau personol eriall eu cadw. Gallwch ddewis pa system weithredu i\'w defnyddio bob tro mae\'r cyfrifiadur yn cychwyn.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Rhywbeth arall';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Nodweddion Uwch...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Nodweddion Uwch...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Caiff dogfennau, cerddoriaeth, a ffeiliau personol eriall eu cadw. Gallwch ddewis pa system weithredu i\'w defnyddio bob tro mae\'r cyfrifiadur yn cychwyn.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Caiff dogfennau, cerddoriaeth, a ffeiliau personol eriall eu cadw. Gallwch ddewis pa system weithredu i\'w defnyddio bob tro mae\'r cyfrifiadur yn cychwyn.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Rhywbeth arall';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Du kan vælge dit operativsystem under systemopstart.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manuel installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Du kan vælge dit operativsystem under systemopstart.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Du kan vælge dit operativsystem under systemopstart.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manuel installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumente, Musik und andere persönliche Dateien bleiben erhalten. Sie können bei jedem Start des Computers auswählen, welches Betriebssystem Sie verwenden möchten.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manuelle Installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumente, Musik und andere persönliche Dateien bleiben erhalten. Sie können bei jedem Start des Computers auswählen, welches Betriebssystem Sie verwenden möchten.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumente, Musik und andere persönliche Dateien bleiben erhalten. Sie können bei jedem Start des Computers auswählen, welches Betriebssystem Sie verwenden möchten.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manuelle Installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumentoj, muziko kaj aliaj personaj dosieroj estas konservotaj. Vi povos elekti tiun mastruman sistemon, kiun vi volas, kiam la komputilo startas.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumentoj, muziko kaj aliaj personaj dosieroj estas konservotaj. Vi povos elekti tiun mastruman sistemon, kiun vi volas, kiam la komputilo startas.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Neaŭtomata instalado';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumentoj, muziko kaj aliaj personaj dosieroj estas konservotaj. Vi povos elekti tiun mastruman sistemon, kiun vi volas, kiam la komputilo startas.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Neaŭtomata instalado';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Podrá elegir qué sistema operativo quiere iniciar en cada arranque.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Instalación manual';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Podrá elegir qué sistema operativo quiere iniciar en cada arranque.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Podrá elegir qué sistema operativo quiere iniciar en cada arranque.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Instalación manual';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'ویژگی‌های پیش‌رفته…';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'سندها، آهنگ‌ها و دیگرپرونده‌های شخصی حفظ خواهند شد. هر بار که رایانه روشن می‌شود می‌توانید بگزینید که کدام سیستم‌عامل را می‌خواهید.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'سندها، آهنگ‌ها و دیگرپرونده‌های شخصی حفظ خواهند شد. هر بار که رایانه روشن می‌شود می‌توانید بگزینید که کدام سیستم‌عامل را می‌خواهید.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'افرازش دستی';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'سندها، آهنگ‌ها و دیگرپرونده‌های شخصی حفظ خواهند شد. هر بار که رایانه روشن می‌شود می‌توانید بگزینید که کدام سیستم‌عامل را می‌خواهید.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'افرازش دستی';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'ویژگی‌های پیش‌رفته…';
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Voit valita käyttöjärjestelmän käynnistettäessä.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Voit valita käyttöjärjestelmän käynnistettäessä.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manuaalinen asennus';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Voit valita käyttöjärjestelmän käynnistettäessä.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manuaalinen asennus';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Vous pouvez choisir votre système d\'exploitation pendant le démarrage.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Vous pouvez choisir votre système d\'exploitation pendant le démarrage.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Partitionnement manuel';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Vous pouvez choisir votre système d\'exploitation pendant le démarrage.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Partitionnement manuel';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Is féidir leat a roghnú do chóras oibriúcháin le linn tosaithe.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Is féidir leat a roghnú do chóras oibriúcháin le linn tosaithe.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Suiteáil láimhe';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Is féidir leat a roghnú do chóras oibriúcháin le linn tosaithe.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Suiteáil láimhe';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'המסמכים, המוזיקה וקבצים אישיים נוספים יישמרו. אפשר לבחור איזו מערכת הפעלה תיטען עם כל הפעלה של המחשב.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'חלוקה ידנית למחיצות';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'המסמכים, המוזיקה וקבצים אישיים נוספים יישמרו. אפשר לבחור איזו מערכת הפעלה תיטען עם כל הפעלה של המחשב.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'המסמכים, המוזיקה וקבצים אישיים נוספים יישמרו. אפשר לבחור איזו מערכת הפעלה תיטען עם כל הפעלה של המחשב.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'חלוקה ידנית למחיצות';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Kiválaszthatja az operációs rendszert a rendszerindítás során.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Kiválaszthatja az operációs rendszert a rendszerindítás során.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Kézi telepítés';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Kiválaszthatja az operációs rendszert a rendszerindítás során.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Kézi telepítés';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumen, musik, dan berkas-berkas pribadi lain akan disimpan. Anda dapat memilih sistem operasi yang Anda inginkan setiap kali komputer dinyalakan.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumen, musik, dan berkas-berkas pribadi lain akan disimpan. Anda dapat memilih sistem operasi yang Anda inginkan setiap kali komputer dinyalakan.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Sesuatu yang lain';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumen, musik, dan berkas-berkas pribadi lain akan disimpan. Anda dapat memilih sistem operasi yang Anda inginkan setiap kali komputer dinyalakan.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Sesuatu yang lain';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Caratteristiche avanzate…';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Altro';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Altro';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Caratteristiche avanzate…';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'ファイルは削除されません。コンピュータを起動する際に、どのOSで起動するか選択できます。';
+  String installationTypeAlongsideInfo(String product) {
+    return 'ファイルは削除されません。コンピュータを起動する際に、どのOSで起動するか選択できます。';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => '手動パーティショニング';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'ファイルは削除されません。コンピュータを起動する際に、どのOSで起動するか選択できます。';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => '手動パーティショニング';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -357,7 +357,19 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => '컴퓨터를 시작할 때 원하는 운영체제를 선택하실 수 있습니다.';
+  String installationTypeAlongsideInfo(String product) {
+    return '컴퓨터를 시작할 때 원하는 운영체제를 선택하실 수 있습니다.';
+  }
+
+  @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'All files and data from the existing $os installation will be permanently deleted.';
+  }
 
   @override
   String get installationTypeManual => '수동 설치';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Išplėstinės ypatybės...';
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Išplėstinės ypatybės...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumentai, muzika ir kiti asmeniniai failai bus išsaugoti. Kas kartą įjungę kompiuterį, galėsite pasirinkti, kurią operacinę sistemą paleisti.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumentai, muzika ir kiti asmeniniai failai bus išsaugoti. Kas kartą įjungę kompiuterį, galėsite pasirinkti, kurią operacinę sistemą paleisti.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Rankinis skaidymas';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumentai, muzika ir kiti asmeniniai failai bus išsaugoti. Kas kartą įjungę kompiuterį, galėsite pasirinkti, kurią operacinę sistemą paleisti.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Rankinis skaidymas';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'പ്രമാണങ്ങളും സംഗീതവും മറ്റ് സ്വകാര്യ ഫയലുകളും സൂക്ഷിക്കും. ഓരോ തവണ കമ്പ്യൂട്ടർ ഓണാകുമ്പോഴും ഏത് ഓപ്പറേറ്റിംഗ് സിസ്റ്റം വേണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'വേറെ എന്തെങ്കിലും';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'വിപുലമായ സവിശേഷതകൾ…';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'വിപുലമായ സവിശേഷതകൾ…';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'പ്രമാണങ്ങളും സംഗീതവും മറ്റ് സ്വകാര്യ ഫയലുകളും സൂക്ഷിക്കും. ഓരോ തവണ കമ്പ്യൂട്ടർ ഓണാകുമ്പോഴും ഏത് ഓപ്പറേറ്റിംഗ് സിസ്റ്റം വേണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'പ്രമാണങ്ങളും സംഗീതവും മറ്റ് സ്വകാര്യ ഫയലുകളും സൂക്ഷിക്കും. ഓരോ തവണ കമ്പ്യൂട്ടർ ഓണാകുമ്പോഴും ഏത് ഓപ്പറേറ്റിംഗ് സിസ്റ്റം വേണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'വേറെ എന്തെങ്കിലും';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumenter, musikk og andre personlige filer vil bli oppbevart. Du kan velge hvilket operativsystem du vil ha hver gang datamaskinen starter opp.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumenter, musikk og andre personlige filer vil bli oppbevart. Du kan velge hvilket operativsystem du vil ha hver gang datamaskinen starter opp.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Noe annet';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumenter, musikk og andre personlige filer vil bli oppbevart. Du kan velge hvilket operativsystem du vil ha hver gang datamaskinen starter opp.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Noe annet';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Los documents, la musica e los autres fichièrs personals seràn gardats. Podètz causir quin sistèma operatiu volètz cada que l’ordenador s’aluca.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Los documents, la musica e los autres fichièrs personals seràn gardats. Podètz causir quin sistèma operatiu volètz cada que l’ordenador s’aluca.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Particionament manual';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Los documents, la musica e los autres fichièrs personals seràn gardats. Podètz causir quin sistèma operatiu volètz cada que l’ordenador s’aluca.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Particionament manual';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokumenty, muzyka i inne pliki osobiste zostaną zachowane. Przy każdym uruchomieniu komputera można wybrać system operacyjny, który ma być używany.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Ręczne partycjonowanie';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokumenty, muzyka i inne pliki osobiste zostaną zachowane. Przy każdym uruchomieniu komputera można wybrać system operacyjny, który ma być używany.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokumenty, muzyka i inne pliki osobiste zostaną zachowane. Przy każdym uruchomieniu komputera można wybrać system operacyjny, który ma być używany.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Ręczne partycjonowanie';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Documentos, músicas e outros ficheiros pessoais serão mantidos. Poderá selecionar qual o sistema operativo a usar cada vez que o computador iniciar.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Documentos, músicas e outros ficheiros pessoais serão mantidos. Poderá selecionar qual o sistema operativo a usar cada vez que o computador iniciar.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Particionamento manual';
@@ -1335,7 +1339,9 @@ class UbuntuBootstrapLocalizationsPtBr extends UbuntuBootstrapLocalizationsPt {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Documentos, músicas, e outros arquivos pessoais serão mantidos. Você poderá selecionar qual sistema operacional usar cada vez que o computador iniciar.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Documentos, músicas, e outros arquivos pessoais serão mantidos. Você poderá selecionar qual sistema operacional usar cada vez que o computador iniciar.';
+  }
 
   @override
   String get installationTypeManual => 'Particionamento manual';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Documentos, músicas e outros ficheiros pessoais serão mantidos. Poderá selecionar qual o sistema operativo a usar cada vez que o computador iniciar.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Particionamento manual';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Вы сможете выбирать операционную систему во время загрузки.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Вы сможете выбирать операционную систему во время загрузки.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Ручная установка';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Вы сможете выбирать операционную систему во время загрузки.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Ручная установка';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -357,7 +357,19 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'ලේඛන, ගීත සහ අනෙකුත් පෞද්. ගොනු රඳවා ගැනෙයි. පරිගණකය ආරම්භ වන සැමවිට අවශ්‍ය මෙහෙයුම් පද්ධතිය තේරීමට හැකිය.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'ලේඛන, ගීත සහ අනෙකුත් පෞද්. ගොනු රඳවා ගැනෙයි. පරිගණකය ආරම්භ වන සැමවිට අවශ්‍ය මෙහෙයුම් පද්ධතිය තේරීමට හැකිය.';
+  }
+
+  @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'All files and data from the existing $os installation will be permanently deleted.';
+  }
 
   @override
   String get installationTypeManual => 'අතින් ස්ථාපනය';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Počas zavádzania si môžete vybrať operačný systém.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manuálna inštalácia';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Počas zavádzania si môžete vybrať operačný systém.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Počas zavádzania si môžete vybrať operačný systém.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manuálna inštalácia';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Diçka tjetër';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Opsionet e perpapruara...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Opsionet e perpapruara...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Diçka tjetër';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Можете изабрати свој оперативни систем током покретања.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Ручна инсталација';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Можете изабрати свој оперативни систем током покретања.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Можете изабрати свој оперативни систем током покретања.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Ручна инсталација';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Dokument, musik och andra personliga filer kommer att sparas. Du kan välja vilket operativsystem du vill ha varje gång datorn startar.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manuell partitionering';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Dokument, musik och andra personliga filer kommer att sparas. Du kan välja vilket operativsystem du vill ha varje gång datorn startar.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Dokument, musik och andra personliga filer kommer att sparas. Du kan välja vilket operativsystem du vill ha varje gång datorn startar.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manuell partitionering';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'மேம்பட்ட அம்சங்கள்...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'மேம்பட்ட அம்சங்கள்...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Belgeler, müzik ve diğer kişisel dosyalar korunacak. Bilgisayar her başlatıldığında hangi işletim sistemini istediğinizi seçebilirsiniz.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Elle bölümlendirme';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Gelişmiş özellikler...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Belgeler, müzik ve diğer kişisel dosyalar korunacak. Bilgisayar her başlatıldığında hangi işletim sistemini istediğinizi seçebilirsiniz.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Belgeler, müzik ve diğer kişisel dosyalar korunacak. Bilgisayar her başlatıldığında hangi işletim sistemini istediğinizi seçebilirsiniz.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Elle bölümlendirme';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Gelişmiş özellikler...';
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'Документи, музика та інші особисті файли будуть збережені. Ви можете вибрати, яку операційну систему ви бажаєте використовувати при кожному запуску комп\'ютера.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Щось інше';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'Документи, музика та інші особисті файли будуть збережені. Ви можете вибрати, яку операційну систему ви бажаєте використовувати при кожному запуску комп\'ютера.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Документи, музика та інші особисті файли будуть збережені. Ви можете вибрати, яку операційну систему ви бажаєте використовувати при кожному запуску комп\'ютера.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Щось інше';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Start from scratch on your selected disk.';
+  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
+  String installationTypeAlongsideInfo(String product) {
+    return 'Select a partition to resize and create space for $product. You can choose your operating system during boot.';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => 'Manual installation';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -271,7 +271,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseInfo => 'Warning: All data and partitions on the disk will be erased, including operating systems.';
+  String get installationTypeEraseInfo => 'All data and partitions on the disk will be erased, including operating systems.';
 
   @override
   String get installationTypeAdvancedLabel => 'Advanced features...';
@@ -348,7 +348,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeAlongsideMulti(String product) {
-    return 'Install $product alongside them';
+    return 'Install $product alongside existing operating systems';
   }
 
   @override
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => 'You can choose your operating system during boot.';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => 'Manual installation';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -360,6 +360,14 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get installationTypeAlongsideInfo => '将保存文件、音乐和其他个人文件。每次启动时，您可以选择所需的操作系统。';
 
   @override
+  String installationTypeEraseAndInstall(String os, String product) {
+    return 'Erase $os and install $product';
+  }
+
+  @override
+  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+
+  @override
   String get installationTypeManual => '手动分区';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -357,7 +357,9 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeAlongsideInfo => '将保存文件、音乐和其他个人文件。每次启动时，您可以选择所需的操作系统。';
+  String installationTypeAlongsideInfo(String product) {
+    return '将保存文件、音乐和其他个人文件。每次启动时，您可以选择所需的操作系统。';
+  }
 
   @override
   String installationTypeEraseAndInstall(String os, String product) {
@@ -365,7 +367,9 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get installationTypeEraseAndInstallInfo => 'Replace your currently installed OS.';
+  String installationTypeEraseAndInstallInfo(String os) {
+    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+  }
 
   @override
   String get installationTypeManual => '手动分区';
@@ -1335,7 +1339,9 @@ class UbuntuBootstrapLocalizationsZhTw extends UbuntuBootstrapLocalizationsZh {
   }
 
   @override
-  String get installationTypeAlongsideInfo => '應用程式、音樂等個人檔案將會被保留，您可以在每次電腦啟動時選擇其中一個作業系統。';
+  String installationTypeAlongsideInfo(String product) {
+    return '應用程式、音樂等個人檔案將會被保留，您可以在每次電腦啟動時選擇其中一個作業系統。';
+  }
 
   @override
   String get installationTypeManual => '手動硬碟分割';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -368,7 +368,7 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
 
   @override
   String installationTypeEraseAndInstallInfo(String os) {
-    return 'Warning: All files and data from the existing $os installation will be permenantly deleted.';
+    return 'All files and data from the existing $os installation will be permanently deleted.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_model.dart
@@ -57,6 +57,16 @@ class ConfirmModel extends SafeChangeNotifier {
   /// A list of existing OS installations or null if not detected.
   List<OsProber>? get existingOS => _storage.existingOS;
 
+  String? getEraseInstallOsName(GuidedStorageTargetEraseInstall target) {
+    return disks
+        .firstWhere((d) => d.id == target.diskId)
+        .partitions
+        .whereType<Partition>()
+        .firstWhere((p) => p.number == target.partitionNumber)
+        .os
+        ?.long;
+  }
+
   /// Initializes the model.
   Future<void> init() async {
     if (_storage.guidedTarget != null) {

--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -204,16 +204,22 @@ class _DiskSetup extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = UbuntuBootstrapLocalizations.of(context);
     final confirmModel = ref.watch(confirmModelProvider);
+    final flavor = ref.watch(flavorProvider);
+
     return Text(
       switch (ref.watch(storageModelProvider.select((s) => s.type))) {
         StorageType.alongside => StoragePage.formatAlongside(
             lang,
-            ref.watch(flavorProvider).displayName,
+            flavor.displayName,
             confirmModel.existingOS ?? [],
           ),
-        StorageType.erase =>
-          lang.installationTypeErase(ref.watch(flavorProvider).displayName),
+        StorageType.erase => lang.installationTypeErase(flavor.displayName),
         StorageType.manual => lang.installationTypeManual,
+        StorageTypeEraseInstall(target: final target) =>
+          lang.installationTypeEraseAndInstall(
+            confirmModel.getEraseInstallOsName(target) ?? 'unknown',
+            flavor.displayName,
+          ),
         _ => '',
       },
       textAlign: TextAlign.end,

--- a/apps/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/bitlocker/bitlocker_model.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_bootstrap/widgets.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
@@ -14,6 +15,10 @@ class BitLockerPage extends ConsumerWidget with ProvisioningPage {
 
   @override
   Future<bool> load(BuildContext context, WidgetRef ref) {
+    if (ref.read(storageModelProvider).type == StorageType.manual) {
+      return Future.value(false);
+    }
+
     return ref.read(bitLockerModelProvider.notifier).init();
   }
 

--- a/apps/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/guided_reformat/guided_reformat_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/guided_reformat/guided_reformat_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/guided_resize/storage_icon.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_bootstrap/services.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
@@ -14,6 +15,10 @@ class GuidedReformatPage extends ConsumerWidget {
   const GuidedReformatPage({super.key});
 
   static Future<bool> load(WidgetRef ref) {
+    if (ref.read(storageModelProvider).type != StorageType.erase) {
+      return Future.value(false);
+    }
+
     return ref.read(guidedReformatModelProvider.notifier).init();
   }
 

--- a/apps/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/guided_resize/guided_resize_page.dart
@@ -4,6 +4,7 @@ import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/guided_resize/guided_resize_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/guided_resize/guided_resize_widgets.dart';
 import 'package:ubuntu_bootstrap/pages/storage/guided_resize/storage_slider_view.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 
@@ -12,6 +13,10 @@ class GuidedResizePage extends ConsumerWidget {
   const GuidedResizePage({super.key});
 
   static Future<bool> load(WidgetRef ref) {
+    if (ref.read(storageModelProvider).type != StorageType.alongside) {
+      return Future.value(false);
+    }
+
     return ref.read(guidedResizeModelProvider).init();
   }
 

--- a/apps/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_page.dart
@@ -7,6 +7,7 @@ import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/manual/manual_storage_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/manual/manual_storage_widgets.dart';
 import 'package:ubuntu_bootstrap/pages/storage/manual/storage_selector.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
@@ -14,6 +15,10 @@ class ManualStoragePage extends ConsumerStatefulWidget {
   const ManualStoragePage({super.key});
 
   static Future<bool> load(WidgetRef ref) {
+    if (ref.read(storageModelProvider).type != StorageType.manual) {
+      return Future.value(false);
+    }
+
     return ref
         .read(manualStorageModelProvider.notifier)
         .init()

--- a/apps/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/recovery_key/recovery_key_model.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
@@ -10,6 +11,10 @@ class RecoveryKeyPage extends StatelessWidget {
   const RecoveryKeyPage({super.key});
 
   static Future<bool> load(WidgetRef ref) {
+    if (ref.read(storageModelProvider).type == StorageType.manual) {
+      return Future.value(false);
+    }
+
     return ref.read(recoveryKeyModelProvider).init();
   }
 

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -245,8 +245,12 @@ class StorageModel extends SafeChangeNotifier {
     } else if (type == StorageType.manual) {
       return 'manual';
     } else if (type case StorageTypeEraseInstall()) {
-      return 'reuse_partition';
+      return 'replace_partition';
     }
+    // TODO: map upgrading the current Ubuntu installation without
+    // wiping the user's home directory (not implemented yet)
+    // to the 'reuse_partition' method.
+
     return null;
   }
 

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -40,7 +40,8 @@ class StorageTypeEraseInstall extends StorageType {
     return identical(this, other) ||
         (other is StorageTypeEraseInstall &&
             other.runtimeType == runtimeType &&
-            other.target == target);
+            other.target.diskId == target.diskId &&
+            other.target.partitionNumber == target.partitionNumber);
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -9,7 +9,13 @@ import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
-export 'storage_model.dart' show StorageType;
+export 'storage_model.dart'
+    show
+        StorageType,
+        StorageTypeAlongside,
+        StorageTypeErase,
+        StorageTypeEraseInstall,
+        StorageTypeManual;
 
 /// Select between guided and manual partitioning.
 class StoragePage extends ConsumerWidget with ProvisioningPage {
@@ -81,13 +87,12 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
             subtitle: Text(lang.installationTypeAlongsideInfo),
           ),
         if (model.canEraseAndInstall)
-          ...model.getEraseInstallOsNames().indexed.map(
-                (elem) => _InstallationTypeTile(
-                  storageType: StorageType.eraseAndInstall,
-                  eraseInstallIndex: elem.$1,
+          ...model.getEraseInstallTargets().map(
+                (target) => _InstallationTypeTile(
+                  storageType: StorageTypeEraseInstall(target),
                   title: Text(
                     lang.installationTypeEraseAndInstall(
-                      elem.$2,
+                      model.getEraseInstallOsName(target) ?? 'unknown',
                       flavor.displayName,
                     ),
                   ),
@@ -166,11 +171,9 @@ class _InstallationTypeTile extends ConsumerWidget {
     required this.title,
     this.subtitle,
     this.trailing,
-    this.eraseInstallIndex,
   });
 
   final StorageType storageType;
-  final int? eraseInstallIndex;
   final Widget title;
   final Widget? subtitle;
   final Widget? trailing;
@@ -189,12 +192,9 @@ class _InstallationTypeTile extends ConsumerWidget {
         ),
         contentPadding: kWizardTilePadding,
         isThreeLine: true,
-        value: (storageType, eraseInstallIndex),
-        groupValue: (model.type, model.eraseInstallIndex),
-        onChanged: (value) {
-          model.type = value?.$1;
-          model.eraseInstallIndex = value?.$2;
-        },
+        value: storageType,
+        groupValue: model.type,
+        onChanged: (value) => model.type = value,
       ),
     );
   }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -51,7 +51,6 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // final model = ref.watch(storageModelProvider);
     final lang = UbuntuBootstrapLocalizations.of(context);
     final flavor = ref.watch(flavorProvider);
     final theme = Theme.of(context);

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -100,11 +100,10 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
                       flavor.displayName,
                     ),
                   ),
-                  subtitle: Text(
-                    lang.installationTypeEraseAndInstallInfo(
+                  subtitle: _WarningSubtitle(
+                    text: lang.installationTypeEraseAndInstallInfo(
                       model.getEraseInstallOsName(target) ?? 'unknown',
                     ),
-                    style: theme.textTheme.bodySmall,
                   ),
                 ),
               ),
@@ -112,10 +111,7 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
           _InstallationTypeTile(
             storageType: StorageType.erase,
             title: Text(lang.installationTypeErase(flavor.displayName)),
-            subtitle: Text(
-              lang.installationTypeEraseInfo,
-              style: theme.textTheme.bodySmall,
-            ),
+            subtitle: _WarningSubtitle(text: lang.installationTypeEraseInfo),
             trailing: model.hasAdvancedFeatures
                 ? Padding(
                     padding: const EdgeInsets.only(top: kWizardSpacing),
@@ -210,6 +206,31 @@ class _InstallationTypeTile extends ConsumerWidget {
         value: storageType,
         groupValue: model.type,
         onChanged: (value) => model.type = value,
+      ),
+    );
+  }
+}
+
+class _WarningSubtitle extends ConsumerWidget {
+  const _WarningSubtitle({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
+    return RichText(
+      text: TextSpan(
+        text: UbuntuLocalizations.of(context).warningLabel,
+        style: theme.textTheme.bodySmall!.copyWith(
+          color: theme.colorScheme.warning,
+          fontWeight: FontWeight.bold,
+        ),
+        children: <TextSpan>[
+          TextSpan(text: ': ', style: theme.textTheme.bodySmall),
+          TextSpan(text: text, style: theme.textTheme.bodySmall),
+        ],
       ),
     );
   }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -237,17 +237,19 @@ class _InstallationTypeTile extends ConsumerWidget {
 
     return Align(
       alignment: AlignmentDirectional.centerStart,
-      child: YaruRadioListTile(
-        title: title,
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [subtitle, trailing].whereNotNull().toList(),
+      child: Material(
+        child: YaruRadioListTile(
+          title: title,
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [subtitle, trailing].whereNotNull().toList(),
+          ),
+          contentPadding: kWizardTilePadding,
+          isThreeLine: true,
+          value: storageType,
+          groupValue: model.type,
+          onChanged: (value) => model.type = value,
         ),
-        contentPadding: kWizardTilePadding,
-        isThreeLine: true,
-        value: storageType,
-        groupValue: model.type,
-        onChanged: (value) => model.type = value,
       ),
     );
   }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -54,6 +54,7 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
     final model = ref.watch(storageModelProvider);
     final lang = UbuntuBootstrapLocalizations.of(context);
     final flavor = ref.watch(flavorProvider);
+    final theme = Theme.of(context);
 
     return HorizontalPage(
       windowTitle: lang.installationTypeTitle,
@@ -84,7 +85,10 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
                 model.existingOS ?? [],
               ),
             ),
-            subtitle: Text(lang.installationTypeAlongsideInfo),
+            subtitle: Text(
+              lang.installationTypeAlongsideInfo(flavor.displayName),
+              style: theme.textTheme.bodySmall,
+            ),
           ),
         if (model.canEraseAndInstall)
           ...model.getEraseInstallTargets().map(
@@ -96,14 +100,22 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
                       flavor.displayName,
                     ),
                   ),
-                  subtitle: Text(lang.installationTypeAlongsideInfo),
+                  subtitle: Text(
+                    lang.installationTypeEraseAndInstallInfo(
+                      model.getEraseInstallOsName(target) ?? 'unknown',
+                    ),
+                    style: theme.textTheme.bodySmall,
+                  ),
                 ),
               ),
         if (model.canEraseDisk) ...[
           _InstallationTypeTile(
             storageType: StorageType.erase,
             title: Text(lang.installationTypeErase(flavor.displayName)),
-            subtitle: Text(lang.installationTypeEraseInfo),
+            subtitle: Text(
+              lang.installationTypeEraseInfo,
+              style: theme.textTheme.bodySmall,
+            ),
             trailing: model.hasAdvancedFeatures
                 ? Padding(
                     padding: const EdgeInsets.only(top: kWizardSpacing),
@@ -132,7 +144,10 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
           _InstallationTypeTile(
             storageType: StorageType.manual,
             title: Text(lang.installationTypeManual),
-            subtitle: Text(lang.installationTypeManualInfo(flavor.displayName)),
+            subtitle: Text(
+              lang.installationTypeManualInfo(flavor.displayName),
+              style: theme.textTheme.bodySmall,
+            ),
           ),
       ],
     );

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -74,12 +74,26 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
             title: Text(
               formatAlongside(
                 lang,
-                ref.watch(flavorProvider).displayName,
+                flavor.displayName,
                 model.existingOS ?? [],
               ),
             ),
             subtitle: Text(lang.installationTypeAlongsideInfo),
           ),
+        if (model.canEraseAndInstall)
+          ...model.getEraseInstallOsNames().indexed.map(
+                (elem) => _InstallationTypeTile(
+                  storageType: StorageType.eraseAndInstall,
+                  eraseInstallIndex: elem.$1,
+                  title: Text(
+                    lang.installationTypeEraseAndInstall(
+                      elem.$2,
+                      flavor.displayName,
+                    ),
+                  ),
+                  subtitle: Text(lang.installationTypeAlongsideInfo),
+                ),
+              ),
         if (model.canEraseDisk) ...[
           _InstallationTypeTile(
             storageType: StorageType.erase,
@@ -152,9 +166,11 @@ class _InstallationTypeTile extends ConsumerWidget {
     required this.title,
     this.subtitle,
     this.trailing,
+    this.eraseInstallIndex,
   });
 
   final StorageType storageType;
+  final int? eraseInstallIndex;
   final Widget title;
   final Widget? subtitle;
   final Widget? trailing;
@@ -173,9 +189,12 @@ class _InstallationTypeTile extends ConsumerWidget {
         ),
         contentPadding: kWizardTilePadding,
         isThreeLine: true,
-        value: storageType,
-        groupValue: model.type,
-        onChanged: (value) => model.type = value,
+        value: (storageType, eraseInstallIndex),
+        groupValue: (model.type, model.eraseInstallIndex),
+        onChanged: (value) {
+          model.type = value?.$1;
+          model.eraseInstallIndex = value?.$2;
+        },
       ),
     );
   }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
@@ -7,7 +7,6 @@ import 'package:ubuntu_bootstrap/pages/storage/guided_resize/guided_resize_page.
 import 'package:ubuntu_bootstrap/pages/storage/manual/manual_storage_page.dart';
 import 'package:ubuntu_bootstrap/pages/storage/passphrase/passphrase_page.dart';
 import 'package:ubuntu_bootstrap/pages/storage/recovery_key/recovery_key_page.dart';
-import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_page.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_routes.dart';
 import 'package:ubuntu_provision/interfaces.dart';

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
@@ -34,6 +34,7 @@ class StorageWizard extends ConsumerWidget with ProvisioningPage {
   Widget build(BuildContext context, WidgetRef ref) {
     final type = ref.watch(storageModelProvider.select((m) => m.type));
 
+    // TODO: is there another page we need to add in here for erase&install?
     final routes = {
       InstallationStep.storage.route: WizardRoute(
         builder: (_) => StoragePage(),

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
@@ -34,7 +34,6 @@ class StorageWizard extends ConsumerWidget with ProvisioningPage {
   Widget build(BuildContext context, WidgetRef ref) {
     final type = ref.watch(storageModelProvider.select((m) => m.type));
 
-    // TODO: is there another page we need to add in here for erase&install?
     final routes = {
       InstallationStep.storage.route: WizardRoute(
         builder: (_) => StoragePage(),

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
@@ -32,54 +32,45 @@ class StorageWizard extends ConsumerWidget with ProvisioningPage {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final type = ref.watch(storageModelProvider.select((m) => m.type));
-
     final routes = {
       InstallationStep.storage.route: WizardRoute(
         builder: (_) => StoragePage(),
         userData: WizardRouteData(step: InstallationStep.secureBoot.pageIndex),
       ),
-      if (type != StorageType.manual)
-        StorageSteps.bitlocker.route: WizardRoute(
-          builder: (_) => const BitLockerPage(),
-          onLoad: (_) => const BitLockerPage().load(context, ref),
-        ),
-      if (type == StorageType.erase)
-        StorageSteps.guidedReformat.route: WizardRoute(
-          builder: (_) => const GuidedReformatPage(),
-          userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
-          onLoad: (_) => GuidedReformatPage.load(ref),
-          onReplace: (_) => StorageSteps.manual.route,
-        ),
-      if (type == StorageType.alongside)
-        StorageSteps.guidedResize.route: WizardRoute(
-          builder: (_) => const GuidedResizePage(),
-          userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
-          onLoad: (_) => GuidedResizePage.load(ref),
-          onReplace: (_) => StorageSteps.manual.route,
-        ),
-      if (type == StorageType.manual)
-        StorageSteps.manual.route: WizardRoute(
-          builder: (_) => const ManualStoragePage(),
-          userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
-          onLoad: (_) => ManualStoragePage.load(ref),
-        ),
-      if (type != StorageType.manual)
-        StorageSteps.passphrase.route: WizardRoute(
-          builder: (_) => const PassphrasePage(),
-          userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
-          onLoad: (_) => PassphrasePage.load(ref),
-        ),
-      if (type != StorageType.manual)
-        StorageSteps.recoveryKey.route: WizardRoute(
-          builder: (_) => const RecoveryKeyPage(),
-          userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
-          onLoad: (_) => RecoveryKeyPage.load(ref),
-        ),
+      StorageSteps.bitlocker.route: WizardRoute(
+        builder: (_) => const BitLockerPage(),
+        onLoad: (_) => const BitLockerPage().load(context, ref),
+      ),
+      StorageSteps.guidedReformat.route: WizardRoute(
+        builder: (_) => const GuidedReformatPage(),
+        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
+        onLoad: (_) => GuidedReformatPage.load(ref),
+        onReplace: (_) => StorageSteps.manual.route,
+      ),
+      StorageSteps.guidedResize.route: WizardRoute(
+        builder: (_) => const GuidedResizePage(),
+        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
+        onLoad: (_) => GuidedResizePage.load(ref),
+        onReplace: (_) => StorageSteps.manual.route,
+      ),
+      StorageSteps.manual.route: WizardRoute(
+        builder: (_) => const ManualStoragePage(),
+        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
+        onLoad: (_) => ManualStoragePage.load(ref),
+      ),
+      StorageSteps.passphrase.route: WizardRoute(
+        builder: (_) => const PassphrasePage(),
+        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
+        onLoad: (_) => PassphrasePage.load(ref),
+      ),
+      StorageSteps.recoveryKey.route: WizardRoute(
+        builder: (_) => const RecoveryKeyPage(),
+        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
+        onLoad: (_) => RecoveryKeyPage.load(ref),
+      ),
     };
 
     return Wizard(
-      key: ValueKey(type),
       userData: WizardData(
         totalSteps:
             InstallationStep.values.where((value) => value.discreteStep).length,

--- a/apps/ubuntu_bootstrap/test/confirm/test_confirm.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/confirm/test_confirm.mocks.dart
@@ -89,6 +89,13 @@ class MockConfirmModel extends _i1.Mock implements _i3.ConfirmModel {
       )) as _i4.Partition?);
 
   @override
+  String? getEraseInstallOsName(_i4.GuidedStorageTargetEraseInstall? target) =>
+      (super.noSuchMethod(Invocation.method(
+        #getEraseInstallOsName,
+        [target],
+      )) as String?);
+
+  @override
   _i5.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,

--- a/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -128,7 +128,8 @@ void main() {
       ),
     );
     await model.save();
-    verify(telemetry.addMetric('PartitionMethod', 'reuse_partition')).called(1);
+    verify(telemetry.addMetric('PartitionMethod', 'replace_partition'))
+        .called(1);
     reset(telemetry);
 
     when(storage.guidedCapability).thenReturn(GuidedCapability.LVM);

--- a/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -293,7 +293,7 @@ void main() {
           path: '',
           bootDevice: false,
           canBeBootDevice: true,
-        )
+        ),
       ],
     );
 

--- a/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -14,6 +14,7 @@ void main() {
     when(service.hasBitLocker()).thenAnswer((_) async => true);
     when(service.getGuidedStorage())
         .thenAnswer((_) async => fakeGuidedStorageResponse());
+    when(service.getStorage()).thenAnswer((_) async => []);
 
     final model = StorageModel(
       service,
@@ -66,7 +67,7 @@ void main() {
 
     wasNotified = false;
     expect(model.type, isNull);
-    model.type = StorageType.manual;
+    model.type = StorageTypeManual();
     expect(wasNotified, isTrue);
 
     wasNotified = false;
@@ -120,6 +121,16 @@ void main() {
     verify(telemetry.addMetric('PartitionMethod', 'manual')).called(1);
     reset(telemetry);
 
+    model.type = StorageTypeEraseInstall(
+      GuidedStorageTargetEraseInstall(
+        diskId: 'foo',
+        partitionNumber: 1,
+      ),
+    );
+    await model.save();
+    verify(telemetry.addMetric('PartitionMethod', 'reuse_partition')).called(1);
+    reset(telemetry);
+
     when(storage.guidedCapability).thenReturn(GuidedCapability.LVM);
     await model.save();
     verify(telemetry.addMetric('PartitionMethod', 'use_lvm')).called(1);
@@ -158,6 +169,7 @@ void main() {
     final service = MockStorageService();
     when(service.guidedCapability).thenReturn(null);
     when(service.hasBitLocker()).thenAnswer((_) async => false);
+    when(service.getStorage()).thenAnswer((_) async => []);
 
     final model = StorageModel(
       service,
@@ -189,10 +201,12 @@ void main() {
     expect(model.hasAdvancedFeatures, isFalse);
   });
 
-  test('can install alongside, erase disk, manual partition', () async {
+  test('can install alongside, erase disk, erase install, manual partition',
+      () async {
     final service = MockStorageService();
     when(service.guidedCapability).thenReturn(null);
     when(service.hasBitLocker()).thenAnswer((_) async => false);
+    when(service.getStorage()).thenAnswer((_) async => []);
 
     final model = StorageModel(
       service,
@@ -206,6 +220,7 @@ void main() {
     await model.init();
     expect(model.canInstallAlongside, isFalse);
     expect(model.canEraseDisk, isFalse);
+    expect(model.canEraseAndInstall, isFalse);
     expect(model.canManualPartition, isFalse);
 
     // reformat
@@ -219,6 +234,7 @@ void main() {
     await model.init();
     expect(model.canInstallAlongside, isFalse);
     expect(model.canEraseDisk, isTrue);
+    expect(model.canEraseAndInstall, isFalse);
     expect(model.canManualPartition, isFalse);
 
     // resize
@@ -236,6 +252,7 @@ void main() {
     await model.init();
     expect(model.canInstallAlongside, isTrue);
     expect(model.canEraseDisk, isFalse);
+    expect(model.canEraseAndInstall, isFalse);
     expect(model.canManualPartition, isFalse);
 
     // gap
@@ -249,6 +266,41 @@ void main() {
     await model.init();
     expect(model.canInstallAlongside, isTrue);
     expect(model.canEraseDisk, isFalse);
+    expect(model.canEraseAndInstall, isFalse);
+    expect(model.canManualPartition, isFalse);
+
+    // erase and install
+    const eraseInstall = GuidedStorageTargetEraseInstall(
+      diskId: 'sda',
+      partitionNumber: 1,
+      allowed: [GuidedCapability.LVM],
+    );
+    when(service.getGuidedStorage()).thenAnswer(
+      (_) async => fakeGuidedStorageResponse(targets: [eraseInstall]),
+    );
+    when(service.getStorage()).thenAnswer(
+      (_) async => [
+        Disk(
+          id: 'sda',
+          label: '',
+          type: '',
+          size: 0,
+          usageLabels: [],
+          partitions: [Partition(number: 1)],
+          okForGuided: true,
+          ptable: '',
+          preserve: true,
+          path: '',
+          bootDevice: false,
+          canBeBootDevice: true,
+        )
+      ],
+    );
+
+    await model.init();
+    expect(model.canInstallAlongside, isFalse);
+    expect(model.canEraseDisk, isFalse);
+    expect(model.canEraseAndInstall, isTrue);
     expect(model.canManualPartition, isFalse);
 
     // manual
@@ -260,6 +312,7 @@ void main() {
     await model.init();
     expect(model.canInstallAlongside, isFalse);
     expect(model.canEraseDisk, isFalse);
+    expect(model.canEraseAndInstall, isFalse);
     expect(model.canManualPartition, isTrue);
 
     // all
@@ -270,6 +323,7 @@ void main() {
     await model.init();
     expect(model.canInstallAlongside, isTrue);
     expect(model.canEraseDisk, isTrue);
+    expect(model.canEraseAndInstall, isFalse);
     expect(model.canManualPartition, isTrue);
   });
 
@@ -295,6 +349,7 @@ void main() {
       capability = i.positionalArguments.single as GuidedCapability?;
     });
     when(storage.hasBitLocker()).thenAnswer((_) async => false);
+    when(storage.getStorage()).thenAnswer((_) async => []);
 
     final model = StorageModel(
       storage,

--- a/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -67,7 +67,7 @@ void main() {
 
     wasNotified = false;
     expect(model.type, isNull);
-    model.type = StorageTypeManual();
+    model.type = StorageType.manual;
     expect(wasNotified, isTrue);
 
     wasNotified = false;

--- a/apps/ubuntu_bootstrap/test/storage/storage_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/storage_page_test.dart
@@ -156,7 +156,7 @@ void main() {
     );
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('alongside bitlocker', (tester) async {
@@ -182,7 +182,7 @@ void main() {
     expect(radio, findsOneWidget);
 
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('alongside ubuntu', (tester) async {
@@ -206,7 +206,7 @@ void main() {
     );
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('alongside unknown', (tester) async {
@@ -223,7 +223,7 @@ void main() {
     );
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('alongside dual os', (tester) async {
@@ -258,7 +258,7 @@ void main() {
     );
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('alongside duplicate os', (tester) async {
@@ -289,7 +289,7 @@ void main() {
     );
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('alongside multi os', (tester) async {
@@ -326,7 +326,7 @@ void main() {
     );
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.alongside).called(1);
+    verify(model.type = argThat(isA<StorageTypeAlongside>())).called(1);
   });
 
   testWidgets('can erase disk', (tester) async {
@@ -339,7 +339,7 @@ void main() {
     final radio = find.radioListTile(l10n.installationTypeErase('Ubuntu'));
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.erase).called(1);
+    verify(model.type = argThat(isA<StorageTypeErase>())).called(1);
   });
 
   testWidgets('cannot erase disk', (tester) async {
@@ -354,7 +354,7 @@ void main() {
   });
 
   testWidgets('can manual partition', (tester) async {
-    final model = buildStorageModel(type: StorageType.manual);
+    final model = buildStorageModel(type: StorageTypeManual());
     await tester.pumpApp((_) => buildPage(model));
 
     final context = tester.element(find.byType(StoragePage));
@@ -364,7 +364,7 @@ void main() {
     await tester.ensureVisible(radio);
     expect(radio, findsOneWidget);
     await tester.tap(radio);
-    verify(model.type = StorageType.manual).called(1);
+    verify(model.type = argThat(isA<StorageTypeManual>())).called(1);
 
     expect(find.button(l10n.installationTypeAdvancedLabel), isDisabled);
   });

--- a/apps/ubuntu_bootstrap/test/storage/test_storage.dart
+++ b/apps/ubuntu_bootstrap/test/storage/test_storage.dart
@@ -24,6 +24,7 @@ StorageModel buildStorageModel({
   List<OsProber>? existingOS,
   SecureBootScenarios? scenario,
   bool canInstallAlongside = true,
+  bool canEraseAndInstall = false, // need to add getEraseInstallTargets
   bool canEraseDisk = true,
   bool canManualPartition = true,
   bool hasAdvancedFeatures = true,
@@ -41,6 +42,7 @@ StorageModel buildStorageModel({
   when(model.tpmInfoUrl).thenReturn(tpmInfoUrl);
   when(model.existingOS).thenReturn(existingOS);
   when(model.canInstallAlongside).thenReturn(canInstallAlongside);
+  when(model.canEraseAndInstall).thenReturn(canEraseAndInstall);
   when(model.canEraseDisk).thenReturn(canEraseDisk);
   when(model.canManualPartition).thenReturn(canManualPartition);
   when(model.hasAdvancedFeatures).thenReturn(hasAdvancedFeatures);

--- a/apps/ubuntu_bootstrap/test/storage/test_storage.dart
+++ b/apps/ubuntu_bootstrap/test/storage/test_storage.dart
@@ -24,7 +24,7 @@ StorageModel buildStorageModel({
   List<OsProber>? existingOS,
   SecureBootScenarios? scenario,
   bool canInstallAlongside = true,
-  bool canEraseAndInstall = false, // need to add getEraseInstallTargets
+  bool canEraseAndInstall = false,
   bool canEraseDisk = true,
   bool canManualPartition = true,
   bool hasAdvancedFeatures = true,

--- a/apps/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
@@ -168,6 +168,23 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
       ) as List<_i6.GuidedStorageTarget>);
 
   @override
+  Iterable<_i6.GuidedStorageTargetEraseInstall> getEraseInstallTargets() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getEraseInstallTargets,
+          [],
+        ),
+        returnValue: <_i6.GuidedStorageTargetEraseInstall>[],
+      ) as Iterable<_i6.GuidedStorageTargetEraseInstall>);
+
+  @override
+  String? getEraseInstallOsName(_i6.GuidedStorageTargetEraseInstall? target) =>
+      (super.noSuchMethod(Invocation.method(
+        #getEraseInstallOsName,
+        [target],
+      )) as String?);
+
+  @override
   String getReleaseNotesURL(_i7.Locale? locale) => (super.noSuchMethod(
         Invocation.method(
           #getReleaseNotesURL,

--- a/apps/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
@@ -123,6 +123,12 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
       ) as bool);
 
   @override
+  bool get canEraseAndInstall => (super.noSuchMethod(
+        Invocation.getter(#canEraseAndInstall),
+        returnValue: false,
+      ) as bool);
+
+  @override
   bool get canEraseDisk => (super.noSuchMethod(
         Invocation.getter(#canEraseDisk),
         returnValue: false,

--- a/apps/ubuntu_init/test/init_model_test.mocks.dart
+++ b/apps/ubuntu_init/test/init_model_test.mocks.dart
@@ -191,13 +191,15 @@ class MockIdentityService extends _i1.Mock implements _i2.IdentityService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<dynamic> validateUsername(String? username) => (super.noSuchMethod(
+  _i4.Future<_i2.UsernameValidation> validateUsername(String? username) =>
+      (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
-        returnValue: _i4.Future<dynamic>.value(),
-      ) as _i4.Future<dynamic>);
+        returnValue:
+            _i4.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
+      ) as _i4.Future<_i2.UsernameValidation>);
 }
 
 /// A class which mocks [GdmService].

--- a/apps/ubuntu_init/test/init_model_test.mocks.dart
+++ b/apps/ubuntu_init/test/init_model_test.mocks.dart
@@ -191,15 +191,13 @@ class MockIdentityService extends _i1.Mock implements _i2.IdentityService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<_i2.UsernameValidation> validateUsername(String? username) =>
-      (super.noSuchMethod(
+  _i4.Future<dynamic> validateUsername(String? username) => (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
-        returnValue:
-            _i4.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
-      ) as _i4.Future<_i2.UsernameValidation>);
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
 }
 
 /// A class which mocks [GdmService].

--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -965,6 +965,14 @@ class GuidedStorageTarget with _$GuidedStorageTarget {
     @Default([]) List<GuidedDisallowedCapability> disallowed,
   }) = GuidedStorageTargetResize;
 
+  @FreezedUnionValue('GuidedStorageTargetEraseInstall')
+  const factory GuidedStorageTarget.eraseInstall({
+    required String diskId,
+    required int partitionNumber,
+    @Default([]) List<GuidedCapability> allowed,
+    @Default([]) List<GuidedDisallowedCapability> disallowed,
+  }) = GuidedStorageTargetEraseInstall;
+
   @FreezedUnionValue('GuidedStorageTargetUseGap')
   const factory GuidedStorageTarget.useGap({
     required String diskId,

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -26,12 +26,8 @@ mixin _$ErrorReportRef {
   bool get seen => throw _privateConstructorUsedError;
   String? get oopsId => throw _privateConstructorUsedError;
 
-  /// Serializes this ErrorReportRef to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ErrorReportRefCopyWith<ErrorReportRef> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -60,8 +56,6 @@ class _$ErrorReportRefCopyWithImpl<$Res, $Val extends ErrorReportRef>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -120,8 +114,6 @@ class __$$ErrorReportRefImplCopyWithImpl<$Res>
       _$ErrorReportRefImpl _value, $Res Function(_$ErrorReportRefImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -197,13 +189,11 @@ class _$ErrorReportRefImpl implements _ErrorReportRef {
             (identical(other.oopsId, oopsId) || other.oopsId == oopsId));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, state, base, kind, seen, oopsId);
 
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
@@ -239,11 +229,8 @@ abstract class _ErrorReportRef implements ErrorReportRef {
   bool get seen;
   @override
   String? get oopsId;
-
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -258,12 +245,8 @@ mixin _$NonReportableError {
   String get message => throw _privateConstructorUsedError;
   String? get details => throw _privateConstructorUsedError;
 
-  /// Serializes this NonReportableError to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $NonReportableErrorCopyWith<NonReportableError> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -287,8 +270,6 @@ class _$NonReportableErrorCopyWithImpl<$Res, $Val extends NonReportableError>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -332,8 +313,6 @@ class __$$NonReportableErrorImplCopyWithImpl<$Res>
       $Res Function(_$NonReportableErrorImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -389,13 +368,11 @@ class _$NonReportableErrorImpl implements _NonReportableError {
             (identical(other.details, details) || other.details == details));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, cause, message, details);
 
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
@@ -425,11 +402,8 @@ abstract class _NonReportableError implements NonReportableError {
   String get message;
   @override
   String? get details;
-
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -451,12 +425,8 @@ mixin _$ApplicationStatus {
   String get logSyslogId => throw _privateConstructorUsedError;
   String get eventSyslogId => throw _privateConstructorUsedError;
 
-  /// Serializes this ApplicationStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ApplicationStatusCopyWith<ApplicationStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -492,8 +462,6 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -547,8 +515,6 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     ) as $Val);
   }
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get error {
@@ -561,8 +527,6 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     });
   }
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $NonReportableErrorCopyWith<$Res>? get nonreportableError {
@@ -610,8 +574,6 @@ class __$$ApplicationStatusImplCopyWithImpl<$Res>
       $Res Function(_$ApplicationStatusImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -730,7 +692,7 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
                 other.eventSyslogId == eventSyslogId));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -744,9 +706,7 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
       logSyslogId,
       eventSyslogId);
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
@@ -794,11 +754,8 @@ abstract class _ApplicationStatus implements ApplicationStatus {
   String get logSyslogId;
   @override
   String get eventSyslogId;
-
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -812,12 +769,8 @@ mixin _$KeyFingerprint {
   String get keytype => throw _privateConstructorUsedError;
   String get fingerprint => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyFingerprint to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyFingerprintCopyWith<KeyFingerprint> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -841,8 +794,6 @@ class _$KeyFingerprintCopyWithImpl<$Res, $Val extends KeyFingerprint>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -881,8 +832,6 @@ class __$$KeyFingerprintImplCopyWithImpl<$Res>
       _$KeyFingerprintImpl _value, $Res Function(_$KeyFingerprintImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -931,13 +880,11 @@ class _$KeyFingerprintImpl implements _KeyFingerprint {
                 other.fingerprint == fingerprint));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, keytype, fingerprint);
 
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
@@ -964,11 +911,8 @@ abstract class _KeyFingerprint implements KeyFingerprint {
   String get keytype;
   @override
   String get fingerprint;
-
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -988,12 +932,8 @@ mixin _$LiveSessionSSHInfo {
   List<KeyFingerprint> get hostKeyFingerprints =>
       throw _privateConstructorUsedError;
 
-  /// Serializes this LiveSessionSSHInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $LiveSessionSSHInfoCopyWith<LiveSessionSSHInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1023,8 +963,6 @@ class _$LiveSessionSSHInfoCopyWithImpl<$Res, $Val extends LiveSessionSSHInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1089,8 +1027,6 @@ class __$$LiveSessionSSHInfoImplCopyWithImpl<$Res>
       $Res Function(_$LiveSessionSSHInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1202,7 +1138,7 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
                 .equals(other._hostKeyFingerprints, _hostKeyFingerprints));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1213,9 +1149,7 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
       const DeepCollectionEquality().hash(_ips),
       const DeepCollectionEquality().hash(_hostKeyFingerprints));
 
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
@@ -1255,11 +1189,8 @@ abstract class _LiveSessionSSHInfo implements LiveSessionSSHInfo {
   List<String> get ips;
   @override
   List<KeyFingerprint> get hostKeyFingerprints;
-
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1274,12 +1205,8 @@ mixin _$RefreshStatus {
   String get currentSnapVersion => throw _privateConstructorUsedError;
   String get newSnapVersion => throw _privateConstructorUsedError;
 
-  /// Serializes this RefreshStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $RefreshStatusCopyWith<RefreshStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1306,8 +1233,6 @@ class _$RefreshStatusCopyWithImpl<$Res, $Val extends RefreshStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1354,8 +1279,6 @@ class __$$RefreshStatusImplCopyWithImpl<$Res>
       _$RefreshStatusImpl _value, $Res Function(_$RefreshStatusImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1418,14 +1341,12 @@ class _$RefreshStatusImpl implements _RefreshStatus {
                 other.newSnapVersion == newSnapVersion));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, availability, currentSnapVersion, newSnapVersion);
 
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
@@ -1454,11 +1375,8 @@ abstract class _RefreshStatus implements RefreshStatus {
   String get currentSnapVersion;
   @override
   String get newSnapVersion;
-
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1528,8 +1446,6 @@ mixin _$AnyStep {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
-
-  /// Serializes this AnyStep to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -1548,9 +1464,6 @@ class _$AnyStepCopyWithImpl<$Res, $Val extends AnyStep>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1570,8 +1483,6 @@ class __$$StepPressKeyImplCopyWithImpl<$Res>
       _$StepPressKeyImpl _value, $Res Function(_$StepPressKeyImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1639,16 +1550,14 @@ class _$StepPressKeyImpl implements StepPressKey {
             const DeepCollectionEquality().equals(other._keycodes, _keycodes));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_symbols),
       const DeepCollectionEquality().hash(_keycodes));
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
@@ -1744,10 +1653,7 @@ abstract class StepPressKey implements AnyStep {
 
   List<String> get symbols;
   Map<int, String> get keycodes;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1769,8 +1675,6 @@ class __$$StepKeyPresentImplCopyWithImpl<$Res>
       _$StepKeyPresentImpl _value, $Res Function(_$StepKeyPresentImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1833,13 +1737,11 @@ class _$StepKeyPresentImpl implements StepKeyPresent {
             (identical(other.no, no) || other.no == no));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, symbol, yes, no);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
@@ -1938,10 +1840,7 @@ abstract class StepKeyPresent implements AnyStep {
   String get symbol;
   String get yes;
   String get no;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1963,8 +1862,6 @@ class __$$StepResultImplCopyWithImpl<$Res>
       _$StepResultImpl _value, $Res Function(_$StepResultImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2016,13 +1913,11 @@ class _$StepResultImpl implements StepResult {
             (identical(other.variant, variant) || other.variant == variant));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
@@ -2118,10 +2013,7 @@ abstract class StepResult implements AnyStep {
 
   String get layout;
   String get variant;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2136,12 +2028,8 @@ mixin _$KeyboardSetting {
   String get variant => throw _privateConstructorUsedError;
   String? get toggle => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardSettingCopyWith<KeyboardSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2165,8 +2053,6 @@ class _$KeyboardSettingCopyWithImpl<$Res, $Val extends KeyboardSetting>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2210,8 +2096,6 @@ class __$$KeyboardSettingImplCopyWithImpl<$Res>
       _$KeyboardSettingImpl _value, $Res Function(_$KeyboardSettingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2268,13 +2152,11 @@ class _$KeyboardSettingImpl implements _KeyboardSetting {
             (identical(other.toggle, toggle) || other.toggle == toggle));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant, toggle);
 
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
@@ -2304,11 +2186,8 @@ abstract class _KeyboardSetting implements KeyboardSetting {
   String get variant;
   @override
   String? get toggle;
-
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2322,12 +2201,8 @@ mixin _$KeyboardVariant {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardVariant to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardVariantCopyWith<KeyboardVariant> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2351,8 +2226,6 @@ class _$KeyboardVariantCopyWithImpl<$Res, $Val extends KeyboardVariant>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2391,8 +2264,6 @@ class __$$KeyboardVariantImplCopyWithImpl<$Res>
       _$KeyboardVariantImpl _value, $Res Function(_$KeyboardVariantImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2439,13 +2310,11 @@ class _$KeyboardVariantImpl implements _KeyboardVariant {
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
@@ -2472,11 +2341,8 @@ abstract class _KeyboardVariant implements KeyboardVariant {
   String get code;
   @override
   String get name;
-
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2491,12 +2357,8 @@ mixin _$KeyboardLayout {
   String get name => throw _privateConstructorUsedError;
   List<KeyboardVariant> get variants => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardLayout to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardLayoutCopyWith<KeyboardLayout> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2520,8 +2382,6 @@ class _$KeyboardLayoutCopyWithImpl<$Res, $Val extends KeyboardLayout>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2565,8 +2425,6 @@ class __$$KeyboardLayoutImplCopyWithImpl<$Res>
       _$KeyboardLayoutImpl _value, $Res Function(_$KeyboardLayoutImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2630,14 +2488,12 @@ class _$KeyboardLayoutImpl implements _KeyboardLayout {
             const DeepCollectionEquality().equals(other._variants, _variants));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, const DeepCollectionEquality().hash(_variants));
 
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
@@ -2667,11 +2523,8 @@ abstract class _KeyboardLayout implements KeyboardLayout {
   String get name;
   @override
   List<KeyboardVariant> get variants;
-
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2685,12 +2538,8 @@ mixin _$KeyboardSetup {
   KeyboardSetting get setting => throw _privateConstructorUsedError;
   List<KeyboardLayout> get layouts => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardSetup to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardSetupCopyWith<KeyboardSetup> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2716,8 +2565,6 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2736,8 +2583,6 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
     ) as $Val);
   }
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $KeyboardSettingCopyWith<$Res> get setting {
@@ -2769,8 +2614,6 @@ class __$$KeyboardSetupImplCopyWithImpl<$Res>
       _$KeyboardSetupImpl _value, $Res Function(_$KeyboardSetupImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2824,14 +2667,12 @@ class _$KeyboardSetupImpl implements _KeyboardSetup {
             const DeepCollectionEquality().equals(other._layouts, _layouts));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, setting, const DeepCollectionEquality().hash(_layouts));
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
@@ -2857,11 +2698,8 @@ abstract class _KeyboardSetup implements KeyboardSetup {
   KeyboardSetting get setting;
   @override
   List<KeyboardLayout> get layouts;
-
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2880,12 +2718,8 @@ mixin _$SourceSelection {
   @JsonKey(name: 'default')
   bool get isDefault => throw _privateConstructorUsedError;
 
-  /// Serializes this SourceSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SourceSelectionCopyWith<SourceSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2915,8 +2749,6 @@ class _$SourceSelectionCopyWithImpl<$Res, $Val extends SourceSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2981,8 +2813,6 @@ class __$$SourceSelectionImplCopyWithImpl<$Res>
       _$SourceSelectionImpl _value, $Res Function(_$SourceSelectionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3070,14 +2900,12 @@ class _$SourceSelectionImpl implements _SourceSelection {
                 other.isDefault == isDefault));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, description, id, size, variant, isDefault);
 
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
@@ -3118,11 +2946,8 @@ abstract class _SourceSelection implements SourceSelection {
   @override
   @JsonKey(name: 'default')
   bool get isDefault;
-
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3138,12 +2963,8 @@ mixin _$SourceSelectionAndSetting {
   String get currentId => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
-  /// Serializes this SourceSelectionAndSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SourceSelectionAndSettingCopyWith<SourceSelectionAndSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3169,8 +2990,6 @@ class _$SourceSelectionAndSettingCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3218,8 +3037,6 @@ class __$$SourceSelectionAndSettingImplCopyWithImpl<$Res>
       $Res Function(_$SourceSelectionAndSettingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3286,14 +3103,12 @@ class _$SourceSelectionAndSettingImpl implements _SourceSelectionAndSetting {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_sources), currentId, searchDrivers);
 
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
@@ -3323,11 +3138,8 @@ abstract class _SourceSelectionAndSetting implements SourceSelectionAndSetting {
   String get currentId;
   @override
   bool get searchDrivers;
-
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -3347,12 +3159,8 @@ mixin _$ZdevInfo {
   bool get failed => throw _privateConstructorUsedError;
   String get names => throw _privateConstructorUsedError;
 
-  /// Serializes this ZdevInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ZdevInfoCopyWith<ZdevInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3383,8 +3191,6 @@ class _$ZdevInfoCopyWithImpl<$Res, $Val extends ZdevInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3461,8 +3267,6 @@ class __$$ZdevInfoImplCopyWithImpl<$Res>
       _$ZdevInfoImpl _value, $Res Function(_$ZdevInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3565,14 +3369,12 @@ class _$ZdevInfoImpl implements _ZdevInfo {
             (identical(other.names, names) || other.names == names));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, type, on, exists, pers, auto, failed, names);
 
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
@@ -3616,11 +3418,8 @@ abstract class _ZdevInfo implements ZdevInfo {
   bool get failed;
   @override
   String get names;
-
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3635,12 +3434,8 @@ mixin _$NetworkStatus {
   PackageInstallState get wlanSupportInstallState =>
       throw _privateConstructorUsedError;
 
-  /// Serializes this NetworkStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $NetworkStatusCopyWith<NetworkStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3665,8 +3460,6 @@ class _$NetworkStatusCopyWithImpl<$Res, $Val extends NetworkStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3706,8 +3499,6 @@ class __$$NetworkStatusImplCopyWithImpl<$Res>
       _$NetworkStatusImpl _value, $Res Function(_$NetworkStatusImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3765,14 +3556,12 @@ class _$NetworkStatusImpl implements _NetworkStatus {
                 other.wlanSupportInstallState == wlanSupportInstallState));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_devices), wlanSupportInstallState);
 
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
@@ -3799,11 +3588,8 @@ abstract class _NetworkStatus implements NetworkStatus {
   List<NetDevInfo> get devices;
   @override
   PackageInstallState get wlanSupportInstallState;
-
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3819,12 +3605,8 @@ mixin _$IdentityData {
   String get cryptedPassword => throw _privateConstructorUsedError;
   String get hostname => throw _privateConstructorUsedError;
 
-  /// Serializes this IdentityData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $IdentityDataCopyWith<IdentityData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3852,8 +3634,6 @@ class _$IdentityDataCopyWithImpl<$Res, $Val extends IdentityData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3906,8 +3686,6 @@ class __$$IdentityDataImplCopyWithImpl<$Res>
       _$IdentityDataImpl _value, $Res Function(_$IdentityDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3982,14 +3760,12 @@ class _$IdentityDataImpl implements _IdentityData {
                 other.hostname == hostname));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, realname, username, cryptedPassword, hostname);
 
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
@@ -4021,11 +3797,8 @@ abstract class _IdentityData implements IdentityData {
   String get cryptedPassword;
   @override
   String get hostname;
-
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4040,12 +3813,8 @@ mixin _$SSHData {
   bool get allowPw => throw _privateConstructorUsedError;
   List<String> get authorizedKeys => throw _privateConstructorUsedError;
 
-  /// Serializes this SSHData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SSHDataCopyWith<SSHData> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4067,8 +3836,6 @@ class _$SSHDataCopyWithImpl<$Res, $Val extends SSHData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4111,8 +3878,6 @@ class __$$SSHDataImplCopyWithImpl<$Res>
       _$SSHDataImpl _value, $Res Function(_$SSHDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4179,14 +3944,12 @@ class _$SSHDataImpl implements _SSHData {
                 .equals(other._authorizedKeys, _authorizedKeys));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, installServer, allowPw,
       const DeepCollectionEquality().hash(_authorizedKeys));
 
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
@@ -4214,11 +3977,8 @@ abstract class _SSHData implements SSHData {
   bool get allowPw;
   @override
   List<String> get authorizedKeys;
-
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4234,12 +3994,8 @@ mixin _$SSHIdentity {
   String get keyComment => throw _privateConstructorUsedError;
   String get keyFingerprint => throw _privateConstructorUsedError;
 
-  /// Serializes this SSHIdentity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SSHIdentityCopyWith<SSHIdentity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4264,8 +4020,6 @@ class _$SSHIdentityCopyWithImpl<$Res, $Val extends SSHIdentity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4315,8 +4069,6 @@ class __$$SSHIdentityImplCopyWithImpl<$Res>
       _$SSHIdentityImpl _value, $Res Function(_$SSHIdentityImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4385,14 +4137,12 @@ class _$SSHIdentityImpl implements _SSHIdentity {
                 other.keyFingerprint == keyFingerprint));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, keyType, key, keyComment, keyFingerprint);
 
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
@@ -4424,11 +4174,8 @@ abstract class _SSHIdentity implements SSHIdentity {
   String get keyComment;
   @override
   String get keyFingerprint;
-
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4443,12 +4190,8 @@ mixin _$SSHFetchIdResponse {
   List<SSHIdentity>? get identities => throw _privateConstructorUsedError;
   String? get error => throw _privateConstructorUsedError;
 
-  /// Serializes this SSHFetchIdResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SSHFetchIdResponseCopyWith<SSHFetchIdResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4473,8 +4216,6 @@ class _$SSHFetchIdResponseCopyWithImpl<$Res, $Val extends SSHFetchIdResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4519,8 +4260,6 @@ class __$$SSHFetchIdResponseImplCopyWithImpl<$Res>
       $Res Function(_$SSHFetchIdResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4588,14 +4327,12 @@ class _$SSHFetchIdResponseImpl implements _SSHFetchIdResponse {
             (identical(other.error, error) || other.error == error));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status,
       const DeepCollectionEquality().hash(_identities), error);
 
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
@@ -4625,11 +4362,8 @@ abstract class _SSHFetchIdResponse implements SSHFetchIdResponse {
   List<SSHIdentity>? get identities;
   @override
   String? get error;
-
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4647,12 +4381,8 @@ mixin _$ChannelSnapInfo {
   int get size => throw _privateConstructorUsedError;
   DateTime get releasedAt => throw _privateConstructorUsedError;
 
-  /// Serializes this ChannelSnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ChannelSnapInfoCopyWith<ChannelSnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4682,8 +4412,6 @@ class _$ChannelSnapInfoCopyWithImpl<$Res, $Val extends ChannelSnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4748,8 +4476,6 @@ class __$$ChannelSnapInfoImplCopyWithImpl<$Res>
       _$ChannelSnapInfoImpl _value, $Res Function(_$ChannelSnapInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4838,14 +4564,12 @@ class _$ChannelSnapInfoImpl implements _ChannelSnapInfo {
                 other.releasedAt == releasedAt));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, channelName, revision,
       confinement, version, size, releasedAt);
 
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
@@ -4884,11 +4608,8 @@ abstract class _ChannelSnapInfo implements ChannelSnapInfo {
   int get size;
   @override
   DateTime get releasedAt;
-
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4909,12 +4630,8 @@ mixin _$SnapInfo {
   String get license => throw _privateConstructorUsedError;
   List<ChannelSnapInfo> get channels => throw _privateConstructorUsedError;
 
-  /// Serializes this SnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SnapInfoCopyWith<SnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4946,8 +4663,6 @@ class _$SnapInfoCopyWithImpl<$Res, $Val extends SnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5030,8 +4745,6 @@ class __$$SnapInfoImplCopyWithImpl<$Res>
       _$SnapInfoImpl _value, $Res Function(_$SnapInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5161,7 +4874,7 @@ class _$SnapInfoImpl implements _SnapInfo {
             const DeepCollectionEquality().equals(other._channels, _channels));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -5175,9 +4888,7 @@ class _$SnapInfoImpl implements _SnapInfo {
       license,
       const DeepCollectionEquality().hash(_channels));
 
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
@@ -5224,11 +4935,8 @@ abstract class _SnapInfo implements SnapInfo {
   String get license;
   @override
   List<ChannelSnapInfo> get channels;
-
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5244,12 +4952,8 @@ mixin _$DriversResponse {
   bool get localOnly => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
-  /// Serializes this DriversResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DriversResponseCopyWith<DriversResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5277,8 +4981,6 @@ class _$DriversResponseCopyWithImpl<$Res, $Val extends DriversResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5331,8 +5033,6 @@ class __$$DriversResponseImplCopyWithImpl<$Res>
       _$DriversResponseImpl _value, $Res Function(_$DriversResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5410,14 +5110,12 @@ class _$DriversResponseImpl implements _DriversResponse {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, install,
       const DeepCollectionEquality().hash(_drivers), localOnly, searchDrivers);
 
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
@@ -5450,11 +5148,8 @@ abstract class _DriversResponse implements DriversResponse {
   bool get localOnly;
   @override
   bool get searchDrivers;
-
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5467,12 +5162,8 @@ OEMResponse _$OEMResponseFromJson(Map<String, dynamic> json) {
 mixin _$OEMResponse {
   List<String>? get metapackages => throw _privateConstructorUsedError;
 
-  /// Serializes this OEMResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $OEMResponseCopyWith<OEMResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5496,8 +5187,6 @@ class _$OEMResponseCopyWithImpl<$Res, $Val extends OEMResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5531,8 +5220,6 @@ class __$$OEMResponseImplCopyWithImpl<$Res>
       _$OEMResponseImpl _value, $Res Function(_$OEMResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5580,14 +5267,12 @@ class _$OEMResponseImpl implements _OEMResponse {
                 .equals(other._metapackages, _metapackages));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_metapackages));
 
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
@@ -5610,11 +5295,8 @@ abstract class _OEMResponse implements OEMResponse {
 
   @override
   List<String>? get metapackages;
-
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5627,12 +5309,8 @@ CodecsData _$CodecsDataFromJson(Map<String, dynamic> json) {
 mixin _$CodecsData {
   bool get install => throw _privateConstructorUsedError;
 
-  /// Serializes this CodecsData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $CodecsDataCopyWith<CodecsData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5656,8 +5334,6 @@ class _$CodecsDataCopyWithImpl<$Res, $Val extends CodecsData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5691,8 +5367,6 @@ class __$$CodecsDataImplCopyWithImpl<$Res>
       _$CodecsDataImpl _value, $Res Function(_$CodecsDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5731,13 +5405,11 @@ class _$CodecsDataImpl implements _CodecsData {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
@@ -5759,11 +5431,8 @@ abstract class _CodecsData implements CodecsData {
 
   @override
   bool get install;
-
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5776,12 +5445,8 @@ DriversPayload _$DriversPayloadFromJson(Map<String, dynamic> json) {
 mixin _$DriversPayload {
   bool get install => throw _privateConstructorUsedError;
 
-  /// Serializes this DriversPayload to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DriversPayloadCopyWith<DriversPayload> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5805,8 +5470,6 @@ class _$DriversPayloadCopyWithImpl<$Res, $Val extends DriversPayload>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5840,8 +5503,6 @@ class __$$DriversPayloadImplCopyWithImpl<$Res>
       _$DriversPayloadImpl _value, $Res Function(_$DriversPayloadImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5880,13 +5541,11 @@ class _$DriversPayloadImpl implements _DriversPayload {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
@@ -5910,11 +5569,8 @@ abstract class _DriversPayload implements DriversPayload {
 
   @override
   bool get install;
-
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5929,12 +5585,8 @@ mixin _$SnapSelection {
   String get channel => throw _privateConstructorUsedError;
   bool get classic => throw _privateConstructorUsedError;
 
-  /// Serializes this SnapSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SnapSelectionCopyWith<SnapSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5958,8 +5610,6 @@ class _$SnapSelectionCopyWithImpl<$Res, $Val extends SnapSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6003,8 +5653,6 @@ class __$$SnapSelectionImplCopyWithImpl<$Res>
       _$SnapSelectionImpl _value, $Res Function(_$SnapSelectionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6061,13 +5709,11 @@ class _$SnapSelectionImpl implements _SnapSelection {
             (identical(other.classic, classic) || other.classic == classic));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, name, channel, classic);
 
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
@@ -6096,11 +5742,8 @@ abstract class _SnapSelection implements SnapSelection {
   String get channel;
   @override
   bool get classic;
-
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6115,12 +5758,8 @@ mixin _$SnapListResponse {
   List<SnapInfo> get snaps => throw _privateConstructorUsedError;
   List<SnapSelection> get selections => throw _privateConstructorUsedError;
 
-  /// Serializes this SnapListResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SnapListResponseCopyWith<SnapListResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6147,8 +5786,6 @@ class _$SnapListResponseCopyWithImpl<$Res, $Val extends SnapListResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6195,8 +5832,6 @@ class __$$SnapListResponseImplCopyWithImpl<$Res>
       $Res Function(_$SnapListResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6270,7 +5905,7 @@ class _$SnapListResponseImpl implements _SnapListResponse {
                 .equals(other._selections, _selections));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -6278,9 +5913,7 @@ class _$SnapListResponseImpl implements _SnapListResponse {
       const DeepCollectionEquality().hash(_snaps),
       const DeepCollectionEquality().hash(_selections));
 
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
@@ -6310,11 +5943,8 @@ abstract class _SnapListResponse implements SnapListResponse {
   List<SnapInfo> get snaps;
   @override
   List<SnapSelection> get selections;
-
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6328,12 +5958,8 @@ mixin _$TimeZoneInfo {
   String get timezone => throw _privateConstructorUsedError;
   bool get fromGeoip => throw _privateConstructorUsedError;
 
-  /// Serializes this TimeZoneInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $TimeZoneInfoCopyWith<TimeZoneInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6357,8 +5983,6 @@ class _$TimeZoneInfoCopyWithImpl<$Res, $Val extends TimeZoneInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6397,8 +6021,6 @@ class __$$TimeZoneInfoImplCopyWithImpl<$Res>
       _$TimeZoneInfoImpl _value, $Res Function(_$TimeZoneInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6447,13 +6069,11 @@ class _$TimeZoneInfoImpl implements _TimeZoneInfo {
                 other.fromGeoip == fromGeoip));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, timezone, fromGeoip);
 
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
@@ -6479,11 +6099,8 @@ abstract class _TimeZoneInfo implements TimeZoneInfo {
   String get timezone;
   @override
   bool get fromGeoip;
-
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6496,12 +6113,8 @@ UbuntuProInfo _$UbuntuProInfoFromJson(Map<String, dynamic> json) {
 mixin _$UbuntuProInfo {
   String get token => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProInfoCopyWith<UbuntuProInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6525,8 +6138,6 @@ class _$UbuntuProInfoCopyWithImpl<$Res, $Val extends UbuntuProInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6560,8 +6171,6 @@ class __$$UbuntuProInfoImplCopyWithImpl<$Res>
       _$UbuntuProInfoImpl _value, $Res Function(_$UbuntuProInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6600,13 +6209,11 @@ class _$UbuntuProInfoImpl implements _UbuntuProInfo {
             (identical(other.token, token) || other.token == token));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, token);
 
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
@@ -6629,11 +6236,8 @@ abstract class _UbuntuProInfo implements UbuntuProInfo {
 
   @override
   String get token;
-
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6647,12 +6251,8 @@ mixin _$UbuntuProResponse {
   String get token => throw _privateConstructorUsedError;
   bool get hasNetwork => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProResponseCopyWith<UbuntuProResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6676,8 +6276,6 @@ class _$UbuntuProResponseCopyWithImpl<$Res, $Val extends UbuntuProResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6716,8 +6314,6 @@ class __$$UbuntuProResponseImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6766,13 +6362,11 @@ class _$UbuntuProResponseImpl implements _UbuntuProResponse {
                 other.hasNetwork == hasNetwork));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, token, hasNetwork);
 
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
@@ -6799,11 +6393,8 @@ abstract class _UbuntuProResponse implements UbuntuProResponse {
   String get token;
   @override
   bool get hasNetwork;
-
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6818,12 +6409,8 @@ mixin _$UbuntuProGeneralInfo {
   int get universePackages => throw _privateConstructorUsedError;
   int get mainPackages => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProGeneralInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProGeneralInfoCopyWith<UbuntuProGeneralInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6848,8 +6435,6 @@ class _$UbuntuProGeneralInfoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6893,8 +6478,6 @@ class __$$UbuntuProGeneralInfoImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProGeneralInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6955,14 +6538,12 @@ class _$UbuntuProGeneralInfoImpl implements _UbuntuProGeneralInfo {
                 other.mainPackages == mainPackages));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, eolEsmYear, universePackages, mainPackages);
 
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
@@ -6993,11 +6574,8 @@ abstract class _UbuntuProGeneralInfo implements UbuntuProGeneralInfo {
   int get universePackages;
   @override
   int get mainPackages;
-
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7011,12 +6589,8 @@ mixin _$UPCSInitiateResponse {
   String get userCode => throw _privateConstructorUsedError;
   int get validitySeconds => throw _privateConstructorUsedError;
 
-  /// Serializes this UPCSInitiateResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UPCSInitiateResponseCopyWith<UPCSInitiateResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7041,8 +6615,6 @@ class _$UPCSInitiateResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7081,8 +6653,6 @@ class __$$UPCSInitiateResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSInitiateResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7132,13 +6702,11 @@ class _$UPCSInitiateResponseImpl implements _UPCSInitiateResponse {
                 other.validitySeconds == validitySeconds));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, userCode, validitySeconds);
 
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
@@ -7166,11 +6734,8 @@ abstract class _UPCSInitiateResponse implements UPCSInitiateResponse {
   String get userCode;
   @override
   int get validitySeconds;
-
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7184,12 +6749,8 @@ mixin _$UPCSWaitResponse {
   UPCSWaitStatus get status => throw _privateConstructorUsedError;
   String? get contractToken => throw _privateConstructorUsedError;
 
-  /// Serializes this UPCSWaitResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UPCSWaitResponseCopyWith<UPCSWaitResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7213,8 +6774,6 @@ class _$UPCSWaitResponseCopyWithImpl<$Res, $Val extends UPCSWaitResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7253,8 +6812,6 @@ class __$$UPCSWaitResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSWaitResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7303,13 +6860,11 @@ class _$UPCSWaitResponseImpl implements _UPCSWaitResponse {
                 other.contractToken == contractToken));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status, contractToken);
 
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
@@ -7336,11 +6891,8 @@ abstract class _UPCSWaitResponse implements UPCSWaitResponse {
   UPCSWaitStatus get status;
   @override
   String? get contractToken;
-
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7355,12 +6907,8 @@ mixin _$UbuntuProService {
   String get description => throw _privateConstructorUsedError;
   bool get autoEnabled => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProService to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProServiceCopyWith<UbuntuProService> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7384,8 +6932,6 @@ class _$UbuntuProServiceCopyWithImpl<$Res, $Val extends UbuntuProService>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7429,8 +6975,6 @@ class __$$UbuntuProServiceImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProServiceImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7490,13 +7034,11 @@ class _$UbuntuProServiceImpl implements _UbuntuProService {
                 other.autoEnabled == autoEnabled));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, name, description, autoEnabled);
 
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
@@ -7526,11 +7068,8 @@ abstract class _UbuntuProService implements UbuntuProService {
   String get description;
   @override
   bool get autoEnabled;
-
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7547,12 +7086,8 @@ mixin _$UbuntuProSubscription {
   String get contractToken => throw _privateConstructorUsedError;
   List<UbuntuProService> get services => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProSubscription to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProSubscriptionCopyWith<UbuntuProSubscription> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7581,8 +7116,6 @@ class _$UbuntuProSubscriptionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7637,8 +7170,6 @@ class __$$UbuntuProSubscriptionImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProSubscriptionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7714,14 +7245,12 @@ class _$UbuntuProSubscriptionImpl implements _UbuntuProSubscription {
             const DeepCollectionEquality().equals(other._services, _services));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, contractName, accountName,
       contractToken, const DeepCollectionEquality().hash(_services));
 
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
@@ -7755,11 +7284,8 @@ abstract class _UbuntuProSubscription implements UbuntuProSubscription {
   String get contractToken;
   @override
   List<UbuntuProService> get services;
-
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7774,12 +7300,8 @@ mixin _$UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status => throw _privateConstructorUsedError;
   UbuntuProSubscription? get subscription => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProCheckTokenAnswer to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProCheckTokenAnswerCopyWith<UbuntuProCheckTokenAnswer> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7807,8 +7329,6 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7827,8 +7347,6 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
     ) as $Val);
   }
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UbuntuProSubscriptionCopyWith<$Res>? get subscription {
@@ -7868,8 +7386,6 @@ class __$$UbuntuProCheckTokenAnswerImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProCheckTokenAnswerImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7918,13 +7434,11 @@ class _$UbuntuProCheckTokenAnswerImpl implements _UbuntuProCheckTokenAnswer {
                 other.subscription == subscription));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status, subscription);
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
@@ -7952,11 +7466,8 @@ abstract class _UbuntuProCheckTokenAnswer implements UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status;
   @override
   UbuntuProSubscription? get subscription;
-
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7971,12 +7482,8 @@ mixin _$TaskProgress {
   int get done => throw _privateConstructorUsedError;
   int get total => throw _privateConstructorUsedError;
 
-  /// Serializes this TaskProgress to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $TaskProgressCopyWith<TaskProgress> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8000,8 +7507,6 @@ class _$TaskProgressCopyWithImpl<$Res, $Val extends TaskProgress>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8045,8 +7550,6 @@ class __$$TaskProgressImplCopyWithImpl<$Res>
       _$TaskProgressImpl _value, $Res Function(_$TaskProgressImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8104,13 +7607,11 @@ class _$TaskProgressImpl implements _TaskProgress {
             (identical(other.total, total) || other.total == total));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, label, done, total);
 
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
@@ -8139,11 +7640,8 @@ abstract class _TaskProgress implements TaskProgress {
   int get done;
   @override
   int get total;
-
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8160,12 +7658,8 @@ mixin _$Task {
   TaskStatus get status => throw _privateConstructorUsedError;
   TaskProgress get progress => throw _privateConstructorUsedError;
 
-  /// Serializes this Task to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $TaskCopyWith<Task> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -8194,8 +7688,6 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8229,8 +7721,6 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
     ) as $Val);
   }
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TaskProgressCopyWith<$Res> get progress {
@@ -8265,8 +7755,6 @@ class __$$TaskImplCopyWithImpl<$Res>
   __$$TaskImplCopyWithImpl(_$TaskImpl _value, $Res Function(_$TaskImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8343,14 +7831,12 @@ class _$TaskImpl implements _Task {
                 other.progress == progress));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, kind, summary, status, progress);
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
@@ -8384,11 +7870,8 @@ abstract class _Task implements Task {
   TaskStatus get status;
   @override
   TaskProgress get progress;
-
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8408,12 +7891,8 @@ mixin _$Change {
   String? get err => throw _privateConstructorUsedError;
   dynamic get data => throw _privateConstructorUsedError;
 
-  /// Serializes this Change to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ChangeCopyWith<Change> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -8443,8 +7922,6 @@ class _$ChangeCopyWithImpl<$Res, $Val extends Change>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8520,8 +7997,6 @@ class __$$ChangeImplCopyWithImpl<$Res>
       _$ChangeImpl _value, $Res Function(_$ChangeImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8631,7 +8106,7 @@ class _$ChangeImpl implements _Change {
             const DeepCollectionEquality().equals(other.data, data));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8644,9 +8119,7 @@ class _$ChangeImpl implements _Change {
       err,
       const DeepCollectionEquality().hash(data));
 
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
@@ -8689,11 +8162,8 @@ abstract class _Change implements Change {
   String? get err;
   @override
   dynamic get data;
-
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8708,12 +8178,8 @@ mixin _$MirrorCheckResponse {
   MirrorCheckStatus get status => throw _privateConstructorUsedError;
   String get output => throw _privateConstructorUsedError;
 
-  /// Serializes this MirrorCheckResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MirrorCheckResponseCopyWith<MirrorCheckResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8737,8 +8203,6 @@ class _$MirrorCheckResponseCopyWithImpl<$Res, $Val extends MirrorCheckResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8782,8 +8246,6 @@ class __$$MirrorCheckResponseImplCopyWithImpl<$Res>
       $Res Function(_$MirrorCheckResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8839,13 +8301,11 @@ class _$MirrorCheckResponseImpl implements _MirrorCheckResponse {
             (identical(other.output, output) || other.output == output));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, url, status, output);
 
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
@@ -8875,11 +8335,8 @@ abstract class _MirrorCheckResponse implements MirrorCheckResponse {
   MirrorCheckStatus get status;
   @override
   String get output;
-
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8895,12 +8352,8 @@ mixin _$MirrorPost {
   String? get staged => throw _privateConstructorUsedError;
   bool? get useDuringInstallation => throw _privateConstructorUsedError;
 
-  /// Serializes this MirrorPost to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MirrorPostCopyWith<MirrorPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8928,8 +8381,6 @@ class _$MirrorPostCopyWithImpl<$Res, $Val extends MirrorPost>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8982,8 +8433,6 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
       _$MirrorPostImpl _value, $Res Function(_$MirrorPostImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9061,7 +8510,7 @@ class _$MirrorPostImpl implements _MirrorPost {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -9070,9 +8519,7 @@ class _$MirrorPostImpl implements _MirrorPost {
       staged,
       useDuringInstallation);
 
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
@@ -9104,11 +8551,8 @@ abstract class _MirrorPost implements MirrorPost {
   String? get staged;
   @override
   bool? get useDuringInstallation;
-
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9125,12 +8569,8 @@ mixin _$MirrorGet {
   String? get staged => throw _privateConstructorUsedError;
   bool get useDuringInstallation => throw _privateConstructorUsedError;
 
-  /// Serializes this MirrorGet to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MirrorGetCopyWith<MirrorGet> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9158,8 +8598,6 @@ class _$MirrorGetCopyWithImpl<$Res, $Val extends MirrorGet>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9218,8 +8656,6 @@ class __$$MirrorGetImplCopyWithImpl<$Res>
       _$MirrorGetImpl _value, $Res Function(_$MirrorGetImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9305,7 +8741,7 @@ class _$MirrorGetImpl implements _MirrorGet {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -9315,9 +8751,7 @@ class _$MirrorGetImpl implements _MirrorGet {
       staged,
       useDuringInstallation);
 
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
@@ -9352,11 +8786,8 @@ abstract class _MirrorGet implements MirrorGet {
   String? get staged;
   @override
   bool get useDuringInstallation;
-
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9371,12 +8802,8 @@ mixin _$AdConnectionInfo {
   String get domainName => throw _privateConstructorUsedError;
   String get password => throw _privateConstructorUsedError;
 
-  /// Serializes this AdConnectionInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $AdConnectionInfoCopyWith<AdConnectionInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9400,8 +8827,6 @@ class _$AdConnectionInfoCopyWithImpl<$Res, $Val extends AdConnectionInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9445,8 +8870,6 @@ class __$$AdConnectionInfoImplCopyWithImpl<$Res>
       $Res Function(_$AdConnectionInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9508,13 +8931,11 @@ class _$AdConnectionInfoImpl implements _AdConnectionInfo {
                 other.password == password));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, adminName, domainName, password);
 
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
@@ -9544,11 +8965,8 @@ abstract class _AdConnectionInfo implements AdConnectionInfo {
   String get domainName;
   @override
   String get password;
-
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9565,12 +8983,8 @@ mixin _$OsProber {
   String? get subpath => throw _privateConstructorUsedError;
   String? get version => throw _privateConstructorUsedError;
 
-  /// Serializes this OsProber to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $OsProberCopyWith<OsProber> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9598,8 +9012,6 @@ class _$OsProberCopyWithImpl<$Res, $Val extends OsProber>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9658,8 +9070,6 @@ class __$$OsProberImplCopyWithImpl<$Res>
       _$OsProberImpl _value, $Res Function(_$OsProberImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9735,14 +9145,12 @@ class _$OsProberImpl implements _OsProber {
             (identical(other.version, version) || other.version == version));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, long, label, type, subpath, version);
 
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
@@ -9777,11 +9185,8 @@ abstract class _OsProber implements OsProber {
   String? get subpath;
   @override
   String? get version;
-
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9889,13 +9294,8 @@ mixin _$PartitionOrGap {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
-
-  /// Serializes this PartitionOrGap to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $PartitionOrGapCopyWith<PartitionOrGap> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9919,8 +9319,6 @@ class _$PartitionOrGapCopyWithImpl<$Res, $Val extends PartitionOrGap>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9976,8 +9374,6 @@ class __$$PartitionImplCopyWithImpl<$Res>
       _$PartitionImpl _value, $Res Function(_$PartitionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10061,8 +9457,6 @@ class __$$PartitionImplCopyWithImpl<$Res>
     ));
   }
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $OsProberCopyWith<$Res>? get os {
@@ -10176,7 +9570,7 @@ class _$PartitionImpl implements Partition {
             (identical(other.isInUse, isInUse) || other.isInUse == isInUse));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -10196,9 +9590,7 @@ class _$PartitionImpl implements Partition {
       path,
       isInUse);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
@@ -10391,11 +9783,8 @@ abstract class Partition implements PartitionOrGap {
   bool? get resize;
   String? get path;
   bool get isInUse;
-
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10417,8 +9806,6 @@ class __$$GapImplCopyWithImpl<$Res>
   __$$GapImplCopyWithImpl(_$GapImpl _value, $Res Function(_$GapImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10481,13 +9868,11 @@ class _$GapImpl implements Gap {
             (identical(other.usable, usable) || other.usable == usable));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, offset, size, usable);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
@@ -10624,11 +10009,8 @@ abstract class Gap implements PartitionOrGap {
   @override
   int get size;
   GapUsable get usable;
-
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10642,12 +10024,8 @@ mixin _$ZFS {
   String get volume => throw _privateConstructorUsedError;
   Map<String, dynamic>? get properties => throw _privateConstructorUsedError;
 
-  /// Serializes this ZFS to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ZFSCopyWith<ZFS> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10668,8 +10046,6 @@ class _$ZFSCopyWithImpl<$Res, $Val extends ZFS> implements $ZFSCopyWith<$Res> {
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10704,8 +10080,6 @@ class __$$ZFSImplCopyWithImpl<$Res> extends _$ZFSCopyWithImpl<$Res, _$ZFSImpl>
   __$$ZFSImplCopyWithImpl(_$ZFSImpl _value, $Res Function(_$ZFSImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10762,14 +10136,12 @@ class _$ZFSImpl implements _ZFS {
                 .equals(other._properties, _properties));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, volume, const DeepCollectionEquality().hash(_properties));
 
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
@@ -10794,11 +10166,8 @@ abstract class _ZFS implements ZFS {
   String get volume;
   @override
   Map<String, dynamic>? get properties;
-
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10817,12 +10186,8 @@ mixin _$ZPool {
   Map<String, dynamic>? get fsProperties => throw _privateConstructorUsedError;
   bool? get defaultFeatures => throw _privateConstructorUsedError;
 
-  /// Serializes this ZPool to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ZPoolCopyWith<ZPool> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10852,8 +10217,6 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10892,8 +10255,6 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
     ) as $Val);
   }
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ZFSCopyWith<$Res>? get zfses {
@@ -10934,8 +10295,6 @@ class __$$ZPoolImplCopyWithImpl<$Res>
       _$ZPoolImpl _value, $Res Function(_$ZPoolImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11043,7 +10402,7 @@ class _$ZPoolImpl implements _ZPool {
                 other.defaultFeatures == defaultFeatures));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11054,9 +10413,7 @@ class _$ZPoolImpl implements _ZPool {
       const DeepCollectionEquality().hash(_fsProperties),
       defaultFeatures);
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
@@ -11093,11 +10450,8 @@ abstract class _ZPool implements ZPool {
   Map<String, dynamic>? get fsProperties;
   @override
   bool? get defaultFeatures;
-
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11124,12 +10478,8 @@ mixin _$Disk {
   String? get vendor => throw _privateConstructorUsedError;
   bool get hasInUsePartition => throw _privateConstructorUsedError;
 
-  /// Serializes this Disk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DiskCopyWith<Disk> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -11166,8 +10516,6 @@ class _$DiskCopyWithImpl<$Res, $Val extends Disk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11284,8 +10632,6 @@ class __$$DiskImplCopyWithImpl<$Res>
   __$$DiskImplCopyWithImpl(_$DiskImpl _value, $Res Function(_$DiskImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11473,7 +10819,7 @@ class _$DiskImpl implements _Disk {
                 other.hasInUsePartition == hasInUsePartition));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11493,9 +10839,7 @@ class _$DiskImpl implements _Disk {
       vendor,
       hasInUsePartition);
 
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
@@ -11559,11 +10903,8 @@ abstract class _Disk implements Disk {
   String? get vendor;
   @override
   bool get hasInUsePartition;
-
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11580,12 +10921,8 @@ mixin _$GuidedDisallowedCapability {
       throw _privateConstructorUsedError;
   String? get message => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedDisallowedCapability to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedDisallowedCapabilityCopyWith<GuidedDisallowedCapability>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -11614,8 +10951,6 @@ class _$GuidedDisallowedCapabilityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11665,8 +11000,6 @@ class __$$GuidedDisallowedCapabilityImplCopyWithImpl<$Res>
       $Res Function(_$GuidedDisallowedCapabilityImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11724,13 +11057,11 @@ class _$GuidedDisallowedCapabilityImpl implements _GuidedDisallowedCapability {
             (identical(other.message, message) || other.message == message));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, capability, reason, message);
 
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
@@ -11761,11 +11092,8 @@ abstract class _GuidedDisallowedCapability
   GuidedDisallowedCapabilityReason get reason;
   @override
   String? get message;
-
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -11784,12 +11112,8 @@ mixin _$StorageResponse {
   Map<String, dynamic>? get dasd => throw _privateConstructorUsedError;
   int get storageVersion => throw _privateConstructorUsedError;
 
-  /// Serializes this StorageResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $StorageResponseCopyWith<StorageResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11822,8 +11146,6 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11867,8 +11189,6 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
     ) as $Val);
   }
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -11911,8 +11231,6 @@ class __$$StorageResponseImplCopyWithImpl<$Res>
       _$StorageResponseImpl _value, $Res Function(_$StorageResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12038,7 +11356,7 @@ class _$StorageResponseImpl implements _StorageResponse {
                 other.storageVersion == storageVersion));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12050,9 +11368,7 @@ class _$StorageResponseImpl implements _StorageResponse {
       const DeepCollectionEquality().hash(_dasd),
       storageVersion);
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
@@ -12094,11 +11410,8 @@ abstract class _StorageResponse implements StorageResponse {
   Map<String, dynamic>? get dasd;
   @override
   int get storageVersion;
-
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12116,12 +11429,8 @@ mixin _$StorageResponseV2 {
   bool? get needBoot => throw _privateConstructorUsedError;
   int? get installMinimumSize => throw _privateConstructorUsedError;
 
-  /// Serializes this StorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $StorageResponseV2CopyWith<StorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12153,8 +11462,6 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12193,8 +11500,6 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
     ) as $Val);
   }
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -12236,8 +11541,6 @@ class __$$StorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$StorageResponseV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12334,7 +11637,7 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
                 other.installMinimumSize == installMinimumSize));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12345,9 +11648,7 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
       needBoot,
       installMinimumSize);
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
@@ -12386,11 +11687,8 @@ abstract class _StorageResponseV2 implements StorageResponseV2 {
   bool? get needBoot;
   @override
   int? get installMinimumSize;
-
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12406,12 +11704,8 @@ mixin _$GuidedResizeValues {
   int get recommended => throw _privateConstructorUsedError;
   int get maximum => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedResizeValues to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedResizeValuesCopyWith<GuidedResizeValues> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12435,8 +11729,6 @@ class _$GuidedResizeValuesCopyWithImpl<$Res, $Val extends GuidedResizeValues>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12485,8 +11777,6 @@ class __$$GuidedResizeValuesImplCopyWithImpl<$Res>
       $Res Function(_$GuidedResizeValuesImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12555,14 +11845,12 @@ class _$GuidedResizeValuesImpl implements _GuidedResizeValues {
             (identical(other.maximum, maximum) || other.maximum == maximum));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, installMax, minimum, recommended, maximum);
 
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
@@ -12595,11 +11883,8 @@ abstract class _GuidedResizeValues implements GuidedResizeValues {
   int get recommended;
   @override
   int get maximum;
-
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12610,6 +11895,8 @@ GuidedStorageTarget _$GuidedStorageTargetFromJson(Map<String, dynamic> json) {
       return GuidedStorageTargetReformat.fromJson(json);
     case 'GuidedStorageTargetResize':
       return GuidedStorageTargetResize.fromJson(json);
+    case 'GuidedStorageTargetEraseInstall':
+      return GuidedStorageTargetEraseInstall.fromJson(json);
     case 'GuidedStorageTargetUseGap':
       return GuidedStorageTargetUseGap.fromJson(json);
     case 'GuidedStorageTargetManual':
@@ -12643,6 +11930,12 @@ mixin _$GuidedStorageTarget {
         resize,
     required TResult Function(
             String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        eraseInstall,
+    required TResult Function(
+            String diskId,
             Gap gap,
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)
@@ -12667,6 +11960,12 @@ mixin _$GuidedStorageTarget {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult? Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -12690,6 +11989,12 @@ mixin _$GuidedStorageTarget {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -12703,6 +12008,8 @@ mixin _$GuidedStorageTarget {
   TResult map<TResult extends Object?>({
     required TResult Function(GuidedStorageTargetReformat value) reformat,
     required TResult Function(GuidedStorageTargetResize value) resize,
+    required TResult Function(GuidedStorageTargetEraseInstall value)
+        eraseInstall,
     required TResult Function(GuidedStorageTargetUseGap value) useGap,
     required TResult Function(GuidedStorageTargetManual value) manual,
   }) =>
@@ -12711,6 +12018,7 @@ mixin _$GuidedStorageTarget {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(GuidedStorageTargetReformat value)? reformat,
     TResult? Function(GuidedStorageTargetResize value)? resize,
+    TResult? Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult? Function(GuidedStorageTargetUseGap value)? useGap,
     TResult? Function(GuidedStorageTargetManual value)? manual,
   }) =>
@@ -12719,18 +12027,14 @@ mixin _$GuidedStorageTarget {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(GuidedStorageTargetReformat value)? reformat,
     TResult Function(GuidedStorageTargetResize value)? resize,
+    TResult Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult Function(GuidedStorageTargetUseGap value)? useGap,
     TResult Function(GuidedStorageTargetManual value)? manual,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
-
-  /// Serializes this GuidedStorageTarget to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedStorageTargetCopyWith<GuidedStorageTarget> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12756,8 +12060,6 @@ class _$GuidedStorageTargetCopyWithImpl<$Res, $Val extends GuidedStorageTarget>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12802,8 +12104,6 @@ class __$$GuidedStorageTargetReformatImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetReformatImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12883,7 +12183,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12891,9 +12191,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
@@ -12916,6 +12214,12 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)
         resize,
+    required TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        eraseInstall,
     required TResult Function(
             String diskId,
             Gap gap,
@@ -12945,6 +12249,12 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult? Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -12971,6 +12281,12 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -12990,6 +12306,8 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
   TResult map<TResult extends Object?>({
     required TResult Function(GuidedStorageTargetReformat value) reformat,
     required TResult Function(GuidedStorageTargetResize value) resize,
+    required TResult Function(GuidedStorageTargetEraseInstall value)
+        eraseInstall,
     required TResult Function(GuidedStorageTargetUseGap value) useGap,
     required TResult Function(GuidedStorageTargetManual value) manual,
   }) {
@@ -13001,6 +12319,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(GuidedStorageTargetReformat value)? reformat,
     TResult? Function(GuidedStorageTargetResize value)? resize,
+    TResult? Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult? Function(GuidedStorageTargetUseGap value)? useGap,
     TResult? Function(GuidedStorageTargetManual value)? manual,
   }) {
@@ -13012,6 +12331,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(GuidedStorageTargetReformat value)? reformat,
     TResult Function(GuidedStorageTargetResize value)? resize,
+    TResult Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult Function(GuidedStorageTargetUseGap value)? useGap,
     TResult Function(GuidedStorageTargetManual value)? manual,
     required TResult orElse(),
@@ -13045,11 +12365,8 @@ abstract class GuidedStorageTargetReformat implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13084,8 +12401,6 @@ class __$$GuidedStorageTargetResizeImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetResizeImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13211,7 +12526,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13224,9 +12539,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
@@ -13249,6 +12562,12 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)
         resize,
+    required TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        eraseInstall,
     required TResult Function(
             String diskId,
             Gap gap,
@@ -13279,6 +12598,12 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult? Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -13306,6 +12631,12 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -13326,6 +12657,8 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
   TResult map<TResult extends Object?>({
     required TResult Function(GuidedStorageTargetReformat value) reformat,
     required TResult Function(GuidedStorageTargetResize value) resize,
+    required TResult Function(GuidedStorageTargetEraseInstall value)
+        eraseInstall,
     required TResult Function(GuidedStorageTargetUseGap value) useGap,
     required TResult Function(GuidedStorageTargetManual value) manual,
   }) {
@@ -13337,6 +12670,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(GuidedStorageTargetReformat value)? reformat,
     TResult? Function(GuidedStorageTargetResize value)? resize,
+    TResult? Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult? Function(GuidedStorageTargetUseGap value)? useGap,
     TResult? Function(GuidedStorageTargetManual value)? manual,
   }) {
@@ -13348,6 +12682,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(GuidedStorageTargetReformat value)? reformat,
     TResult Function(GuidedStorageTargetResize value)? resize,
+    TResult Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult Function(GuidedStorageTargetUseGap value)? useGap,
     TResult Function(GuidedStorageTargetManual value)? manual,
     required TResult orElse(),
@@ -13391,12 +12726,318 @@ abstract class GuidedStorageTargetResize implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$GuidedStorageTargetEraseInstallImplCopyWith<$Res>
+    implements $GuidedStorageTargetCopyWith<$Res> {
+  factory _$$GuidedStorageTargetEraseInstallImplCopyWith(
+          _$GuidedStorageTargetEraseInstallImpl value,
+          $Res Function(_$GuidedStorageTargetEraseInstallImpl) then) =
+      __$$GuidedStorageTargetEraseInstallImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String diskId,
+      int partitionNumber,
+      List<GuidedCapability> allowed,
+      List<GuidedDisallowedCapability> disallowed});
+}
+
+/// @nodoc
+class __$$GuidedStorageTargetEraseInstallImplCopyWithImpl<$Res>
+    extends _$GuidedStorageTargetCopyWithImpl<$Res,
+        _$GuidedStorageTargetEraseInstallImpl>
+    implements _$$GuidedStorageTargetEraseInstallImplCopyWith<$Res> {
+  __$$GuidedStorageTargetEraseInstallImplCopyWithImpl(
+      _$GuidedStorageTargetEraseInstallImpl _value,
+      $Res Function(_$GuidedStorageTargetEraseInstallImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? diskId = null,
+    Object? partitionNumber = null,
+    Object? allowed = null,
+    Object? disallowed = null,
+  }) {
+    return _then(_$GuidedStorageTargetEraseInstallImpl(
+      diskId: null == diskId
+          ? _value.diskId
+          : diskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      partitionNumber: null == partitionNumber
+          ? _value.partitionNumber
+          : partitionNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      allowed: null == allowed
+          ? _value._allowed
+          : allowed // ignore: cast_nullable_to_non_nullable
+              as List<GuidedCapability>,
+      disallowed: null == disallowed
+          ? _value._disallowed
+          : disallowed // ignore: cast_nullable_to_non_nullable
+              as List<GuidedDisallowedCapability>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GuidedStorageTargetEraseInstallImpl
+    implements GuidedStorageTargetEraseInstall {
+  const _$GuidedStorageTargetEraseInstallImpl(
+      {required this.diskId,
+      required this.partitionNumber,
+      final List<GuidedCapability> allowed = const [],
+      final List<GuidedDisallowedCapability> disallowed = const [],
+      final String? $type})
+      : _allowed = allowed,
+        _disallowed = disallowed,
+        $type = $type ?? 'GuidedStorageTargetEraseInstall';
+
+  factory _$GuidedStorageTargetEraseInstallImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$GuidedStorageTargetEraseInstallImplFromJson(json);
+
+  @override
+  final String diskId;
+  @override
+  final int partitionNumber;
+  final List<GuidedCapability> _allowed;
+  @override
+  @JsonKey()
+  List<GuidedCapability> get allowed {
+    if (_allowed is EqualUnmodifiableListView) return _allowed;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_allowed);
+  }
+
+  final List<GuidedDisallowedCapability> _disallowed;
+  @override
+  @JsonKey()
+  List<GuidedDisallowedCapability> get disallowed {
+    if (_disallowed is EqualUnmodifiableListView) return _disallowed;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_disallowed);
+  }
+
+  @JsonKey(name: '\$type')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'GuidedStorageTarget.eraseInstall(diskId: $diskId, partitionNumber: $partitionNumber, allowed: $allowed, disallowed: $disallowed)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GuidedStorageTargetEraseInstallImpl &&
+            (identical(other.diskId, diskId) || other.diskId == diskId) &&
+            (identical(other.partitionNumber, partitionNumber) ||
+                other.partitionNumber == partitionNumber) &&
+            const DeepCollectionEquality().equals(other._allowed, _allowed) &&
+            const DeepCollectionEquality()
+                .equals(other._disallowed, _disallowed));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      diskId,
+      partitionNumber,
+      const DeepCollectionEquality().hash(_allowed),
+      const DeepCollectionEquality().hash(_disallowed));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GuidedStorageTargetEraseInstallImplCopyWith<
+          _$GuidedStorageTargetEraseInstallImpl>
+      get copyWith => __$$GuidedStorageTargetEraseInstallImplCopyWithImpl<
+          _$GuidedStorageTargetEraseInstallImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String diskId, List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        reformat,
+    required TResult Function(
+            String diskId,
+            int partitionNumber,
+            int newSize,
+            int? minimum,
+            int? recommended,
+            int? maximum,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        resize,
+    required TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        eraseInstall,
+    required TResult Function(
+            String diskId,
+            Gap gap,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        useGap,
+    required TResult Function(List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        manual,
+  }) {
+    return eraseInstall(diskId, partitionNumber, allowed, disallowed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String diskId, List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        reformat,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            int newSize,
+            int? minimum,
+            int? recommended,
+            int? maximum,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        resize,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
+    TResult? Function(String diskId, Gap gap, List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        useGap,
+    TResult? Function(List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        manual,
+  }) {
+    return eraseInstall?.call(diskId, partitionNumber, allowed, disallowed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String diskId, List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        reformat,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            int newSize,
+            int? minimum,
+            int? recommended,
+            int? maximum,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        resize,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
+    TResult Function(String diskId, Gap gap, List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        useGap,
+    TResult Function(List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        manual,
+    required TResult orElse(),
+  }) {
+    if (eraseInstall != null) {
+      return eraseInstall(diskId, partitionNumber, allowed, disallowed);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GuidedStorageTargetReformat value) reformat,
+    required TResult Function(GuidedStorageTargetResize value) resize,
+    required TResult Function(GuidedStorageTargetEraseInstall value)
+        eraseInstall,
+    required TResult Function(GuidedStorageTargetUseGap value) useGap,
+    required TResult Function(GuidedStorageTargetManual value) manual,
+  }) {
+    return eraseInstall(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(GuidedStorageTargetReformat value)? reformat,
+    TResult? Function(GuidedStorageTargetResize value)? resize,
+    TResult? Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
+    TResult? Function(GuidedStorageTargetUseGap value)? useGap,
+    TResult? Function(GuidedStorageTargetManual value)? manual,
+  }) {
+    return eraseInstall?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GuidedStorageTargetReformat value)? reformat,
+    TResult Function(GuidedStorageTargetResize value)? resize,
+    TResult Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
+    TResult Function(GuidedStorageTargetUseGap value)? useGap,
+    TResult Function(GuidedStorageTargetManual value)? manual,
+    required TResult orElse(),
+  }) {
+    if (eraseInstall != null) {
+      return eraseInstall(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GuidedStorageTargetEraseInstallImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class GuidedStorageTargetEraseInstall implements GuidedStorageTarget {
+  const factory GuidedStorageTargetEraseInstall(
+          {required final String diskId,
+          required final int partitionNumber,
+          final List<GuidedCapability> allowed,
+          final List<GuidedDisallowedCapability> disallowed}) =
+      _$GuidedStorageTargetEraseInstallImpl;
+
+  factory GuidedStorageTargetEraseInstall.fromJson(Map<String, dynamic> json) =
+      _$GuidedStorageTargetEraseInstallImpl.fromJson;
+
+  String get diskId;
+  int get partitionNumber;
+  @override
+  List<GuidedCapability> get allowed;
+  @override
+  List<GuidedDisallowedCapability> get disallowed;
+  @override
+  @JsonKey(ignore: true)
+  _$$GuidedStorageTargetEraseInstallImplCopyWith<
+          _$GuidedStorageTargetEraseInstallImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -13426,8 +13067,6 @@ class __$$GuidedStorageTargetUseGapImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetUseGapImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13515,7 +13154,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13524,9 +13163,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
@@ -13549,6 +13186,12 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)
         resize,
+    required TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        eraseInstall,
     required TResult Function(
             String diskId,
             Gap gap,
@@ -13578,6 +13221,12 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult? Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -13604,6 +13253,12 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -13623,6 +13278,8 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
   TResult map<TResult extends Object?>({
     required TResult Function(GuidedStorageTargetReformat value) reformat,
     required TResult Function(GuidedStorageTargetResize value) resize,
+    required TResult Function(GuidedStorageTargetEraseInstall value)
+        eraseInstall,
     required TResult Function(GuidedStorageTargetUseGap value) useGap,
     required TResult Function(GuidedStorageTargetManual value) manual,
   }) {
@@ -13634,6 +13291,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(GuidedStorageTargetReformat value)? reformat,
     TResult? Function(GuidedStorageTargetResize value)? resize,
+    TResult? Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult? Function(GuidedStorageTargetUseGap value)? useGap,
     TResult? Function(GuidedStorageTargetManual value)? manual,
   }) {
@@ -13645,6 +13303,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(GuidedStorageTargetReformat value)? reformat,
     TResult Function(GuidedStorageTargetResize value)? resize,
+    TResult Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult Function(GuidedStorageTargetUseGap value)? useGap,
     TResult Function(GuidedStorageTargetManual value)? manual,
     required TResult orElse(),
@@ -13680,11 +13339,8 @@ abstract class GuidedStorageTargetUseGap implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13713,8 +13369,6 @@ class __$$GuidedStorageTargetManualImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetManualImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13783,16 +13437,14 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
@@ -13815,6 +13467,12 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)
         resize,
+    required TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)
+        eraseInstall,
     required TResult Function(
             String diskId,
             Gap gap,
@@ -13844,6 +13502,12 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult? Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult? Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -13870,6 +13534,12 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
             List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         resize,
+    TResult Function(
+            String diskId,
+            int partitionNumber,
+            List<GuidedCapability> allowed,
+            List<GuidedDisallowedCapability> disallowed)?
+        eraseInstall,
     TResult Function(String diskId, Gap gap, List<GuidedCapability> allowed,
             List<GuidedDisallowedCapability> disallowed)?
         useGap,
@@ -13889,6 +13559,8 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
   TResult map<TResult extends Object?>({
     required TResult Function(GuidedStorageTargetReformat value) reformat,
     required TResult Function(GuidedStorageTargetResize value) resize,
+    required TResult Function(GuidedStorageTargetEraseInstall value)
+        eraseInstall,
     required TResult Function(GuidedStorageTargetUseGap value) useGap,
     required TResult Function(GuidedStorageTargetManual value) manual,
   }) {
@@ -13900,6 +13572,7 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(GuidedStorageTargetReformat value)? reformat,
     TResult? Function(GuidedStorageTargetResize value)? resize,
+    TResult? Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult? Function(GuidedStorageTargetUseGap value)? useGap,
     TResult? Function(GuidedStorageTargetManual value)? manual,
   }) {
@@ -13911,6 +13584,7 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(GuidedStorageTargetReformat value)? reformat,
     TResult Function(GuidedStorageTargetResize value)? resize,
+    TResult Function(GuidedStorageTargetEraseInstall value)? eraseInstall,
     TResult Function(GuidedStorageTargetUseGap value)? useGap,
     TResult Function(GuidedStorageTargetManual value)? manual,
     required TResult orElse(),
@@ -13942,11 +13616,8 @@ abstract class GuidedStorageTargetManual implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13960,12 +13631,8 @@ mixin _$RecoveryKey {
   String? get liveLocation => throw _privateConstructorUsedError;
   String? get backupLocation => throw _privateConstructorUsedError;
 
-  /// Serializes this RecoveryKey to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $RecoveryKeyCopyWith<RecoveryKey> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13989,8 +13656,6 @@ class _$RecoveryKeyCopyWithImpl<$Res, $Val extends RecoveryKey>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14029,8 +13694,6 @@ class __$$RecoveryKeyImplCopyWithImpl<$Res>
       _$RecoveryKeyImpl _value, $Res Function(_$RecoveryKeyImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14079,13 +13742,11 @@ class _$RecoveryKeyImpl implements _RecoveryKey {
                 other.backupLocation == backupLocation));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, liveLocation, backupLocation);
 
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
@@ -14111,11 +13772,8 @@ abstract class _RecoveryKey implements RecoveryKey {
   String? get liveLocation;
   @override
   String? get backupLocation;
-
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14134,12 +13792,8 @@ mixin _$GuidedChoiceV2 {
   bool get resetPartition => throw _privateConstructorUsedError;
   int? get resetPartitionSize => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedChoiceV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedChoiceV2CopyWith<GuidedChoiceV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14173,8 +13827,6 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14218,8 +13870,6 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     ) as $Val);
   }
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedStorageTargetCopyWith<$Res> get target {
@@ -14228,8 +13878,6 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     });
   }
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RecoveryKeyCopyWith<$Res>? get recoveryKey {
@@ -14274,8 +13922,6 @@ class __$$GuidedChoiceV2ImplCopyWithImpl<$Res>
       _$GuidedChoiceV2Impl _value, $Res Function(_$GuidedChoiceV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14376,14 +14022,12 @@ class _$GuidedChoiceV2Impl implements _GuidedChoiceV2 {
                 other.resetPartitionSize == resetPartitionSize));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, target, capability, password,
       recoveryKey, sizingPolicy, resetPartition, resetPartitionSize);
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
@@ -14425,11 +14069,8 @@ abstract class _GuidedChoiceV2 implements GuidedChoiceV2 {
   bool get resetPartition;
   @override
   int? get resetPartitionSize;
-
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14446,12 +14087,8 @@ mixin _$GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured => throw _privateConstructorUsedError;
   List<GuidedStorageTarget> get targets => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedStorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedStorageResponseV2CopyWith<GuidedStorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14483,8 +14120,6 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14513,8 +14148,6 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     ) as $Val);
   }
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -14527,8 +14160,6 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     });
   }
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedChoiceV2CopyWith<$Res>? get configured {
@@ -14573,8 +14204,6 @@ class __$$GuidedStorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageResponseV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14650,14 +14279,12 @@ class _$GuidedStorageResponseV2Impl implements _GuidedStorageResponseV2 {
             const DeepCollectionEquality().equals(other._targets, _targets));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status, errorReport, configured,
       const DeepCollectionEquality().hash(_targets));
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
@@ -14690,11 +14317,8 @@ abstract class _GuidedStorageResponseV2 implements GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured;
   @override
   List<GuidedStorageTarget> get targets;
-
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -14709,12 +14333,8 @@ mixin _$AddPartitionV2 {
   Partition get partition => throw _privateConstructorUsedError;
   Gap get gap => throw _privateConstructorUsedError;
 
-  /// Serializes this AddPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $AddPartitionV2CopyWith<AddPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14738,8 +14358,6 @@ class _$AddPartitionV2CopyWithImpl<$Res, $Val extends AddPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14783,8 +14401,6 @@ class __$$AddPartitionV2ImplCopyWithImpl<$Res>
       _$AddPartitionV2Impl _value, $Res Function(_$AddPartitionV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14840,7 +14456,7 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
             const DeepCollectionEquality().equals(other.gap, gap));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -14848,9 +14464,7 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
       const DeepCollectionEquality().hash(partition),
       const DeepCollectionEquality().hash(gap));
 
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
@@ -14880,11 +14494,8 @@ abstract class _AddPartitionV2 implements AddPartitionV2 {
   Partition get partition;
   @override
   Gap get gap;
-
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14898,12 +14509,8 @@ mixin _$ModifyPartitionV2 {
   String get diskId => throw _privateConstructorUsedError;
   Partition get partition => throw _privateConstructorUsedError;
 
-  /// Serializes this ModifyPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ModifyPartitionV2CopyWith<ModifyPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14927,8 +14534,6 @@ class _$ModifyPartitionV2CopyWithImpl<$Res, $Val extends ModifyPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14967,8 +14572,6 @@ class __$$ModifyPartitionV2ImplCopyWithImpl<$Res>
       $Res Function(_$ModifyPartitionV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15016,14 +14619,12 @@ class _$ModifyPartitionV2Impl implements _ModifyPartitionV2 {
             const DeepCollectionEquality().equals(other.partition, partition));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, diskId, const DeepCollectionEquality().hash(partition));
 
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
@@ -15050,11 +14651,8 @@ abstract class _ModifyPartitionV2 implements ModifyPartitionV2 {
   String get diskId;
   @override
   Partition get partition;
-
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15068,12 +14666,8 @@ mixin _$ReformatDisk {
   String get diskId => throw _privateConstructorUsedError;
   String? get ptable => throw _privateConstructorUsedError;
 
-  /// Serializes this ReformatDisk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ReformatDiskCopyWith<ReformatDisk> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15097,8 +14691,6 @@ class _$ReformatDiskCopyWithImpl<$Res, $Val extends ReformatDisk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15137,8 +14729,6 @@ class __$$ReformatDiskImplCopyWithImpl<$Res>
       _$ReformatDiskImpl _value, $Res Function(_$ReformatDiskImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15185,13 +14775,11 @@ class _$ReformatDiskImpl implements _ReformatDisk {
             (identical(other.ptable, ptable) || other.ptable == ptable));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, diskId, ptable);
 
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
@@ -15217,11 +14805,8 @@ abstract class _ReformatDisk implements ReformatDisk {
   String get diskId;
   @override
   String? get ptable;
-
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -26,8 +26,12 @@ mixin _$ErrorReportRef {
   bool get seen => throw _privateConstructorUsedError;
   String? get oopsId => throw _privateConstructorUsedError;
 
+  /// Serializes this ErrorReportRef to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ErrorReportRefCopyWith<ErrorReportRef> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -56,6 +60,8 @@ class _$ErrorReportRefCopyWithImpl<$Res, $Val extends ErrorReportRef>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -114,6 +120,8 @@ class __$$ErrorReportRefImplCopyWithImpl<$Res>
       _$ErrorReportRefImpl _value, $Res Function(_$ErrorReportRefImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -189,11 +197,13 @@ class _$ErrorReportRefImpl implements _ErrorReportRef {
             (identical(other.oopsId, oopsId) || other.oopsId == oopsId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, state, base, kind, seen, oopsId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
@@ -229,8 +239,11 @@ abstract class _ErrorReportRef implements ErrorReportRef {
   bool get seen;
   @override
   String? get oopsId;
+
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -245,8 +258,12 @@ mixin _$NonReportableError {
   String get message => throw _privateConstructorUsedError;
   String? get details => throw _privateConstructorUsedError;
 
+  /// Serializes this NonReportableError to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NonReportableErrorCopyWith<NonReportableError> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -270,6 +287,8 @@ class _$NonReportableErrorCopyWithImpl<$Res, $Val extends NonReportableError>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -313,6 +332,8 @@ class __$$NonReportableErrorImplCopyWithImpl<$Res>
       $Res Function(_$NonReportableErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -368,11 +389,13 @@ class _$NonReportableErrorImpl implements _NonReportableError {
             (identical(other.details, details) || other.details == details));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, cause, message, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
@@ -402,8 +425,11 @@ abstract class _NonReportableError implements NonReportableError {
   String get message;
   @override
   String? get details;
+
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -425,8 +451,12 @@ mixin _$ApplicationStatus {
   String get logSyslogId => throw _privateConstructorUsedError;
   String get eventSyslogId => throw _privateConstructorUsedError;
 
+  /// Serializes this ApplicationStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ApplicationStatusCopyWith<ApplicationStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -462,6 +492,8 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -515,6 +547,8 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     ) as $Val);
   }
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get error {
@@ -527,6 +561,8 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     });
   }
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $NonReportableErrorCopyWith<$Res>? get nonreportableError {
@@ -574,6 +610,8 @@ class __$$ApplicationStatusImplCopyWithImpl<$Res>
       $Res Function(_$ApplicationStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -692,7 +730,7 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
                 other.eventSyslogId == eventSyslogId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -706,7 +744,9 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
       logSyslogId,
       eventSyslogId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
@@ -754,8 +794,11 @@ abstract class _ApplicationStatus implements ApplicationStatus {
   String get logSyslogId;
   @override
   String get eventSyslogId;
+
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -769,8 +812,12 @@ mixin _$KeyFingerprint {
   String get keytype => throw _privateConstructorUsedError;
   String get fingerprint => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyFingerprint to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyFingerprintCopyWith<KeyFingerprint> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -794,6 +841,8 @@ class _$KeyFingerprintCopyWithImpl<$Res, $Val extends KeyFingerprint>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -832,6 +881,8 @@ class __$$KeyFingerprintImplCopyWithImpl<$Res>
       _$KeyFingerprintImpl _value, $Res Function(_$KeyFingerprintImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -880,11 +931,13 @@ class _$KeyFingerprintImpl implements _KeyFingerprint {
                 other.fingerprint == fingerprint));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, keytype, fingerprint);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
@@ -911,8 +964,11 @@ abstract class _KeyFingerprint implements KeyFingerprint {
   String get keytype;
   @override
   String get fingerprint;
+
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -932,8 +988,12 @@ mixin _$LiveSessionSSHInfo {
   List<KeyFingerprint> get hostKeyFingerprints =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this LiveSessionSSHInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $LiveSessionSSHInfoCopyWith<LiveSessionSSHInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -963,6 +1023,8 @@ class _$LiveSessionSSHInfoCopyWithImpl<$Res, $Val extends LiveSessionSSHInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1027,6 +1089,8 @@ class __$$LiveSessionSSHInfoImplCopyWithImpl<$Res>
       $Res Function(_$LiveSessionSSHInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1138,7 +1202,7 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
                 .equals(other._hostKeyFingerprints, _hostKeyFingerprints));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1149,7 +1213,9 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
       const DeepCollectionEquality().hash(_ips),
       const DeepCollectionEquality().hash(_hostKeyFingerprints));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
@@ -1189,8 +1255,11 @@ abstract class _LiveSessionSSHInfo implements LiveSessionSSHInfo {
   List<String> get ips;
   @override
   List<KeyFingerprint> get hostKeyFingerprints;
+
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1205,8 +1274,12 @@ mixin _$RefreshStatus {
   String get currentSnapVersion => throw _privateConstructorUsedError;
   String get newSnapVersion => throw _privateConstructorUsedError;
 
+  /// Serializes this RefreshStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RefreshStatusCopyWith<RefreshStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1233,6 +1306,8 @@ class _$RefreshStatusCopyWithImpl<$Res, $Val extends RefreshStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1279,6 +1354,8 @@ class __$$RefreshStatusImplCopyWithImpl<$Res>
       _$RefreshStatusImpl _value, $Res Function(_$RefreshStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1341,12 +1418,14 @@ class _$RefreshStatusImpl implements _RefreshStatus {
                 other.newSnapVersion == newSnapVersion));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, availability, currentSnapVersion, newSnapVersion);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
@@ -1375,8 +1454,11 @@ abstract class _RefreshStatus implements RefreshStatus {
   String get currentSnapVersion;
   @override
   String get newSnapVersion;
+
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1446,6 +1528,8 @@ mixin _$AnyStep {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this AnyStep to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -1464,6 +1548,9 @@ class _$AnyStepCopyWithImpl<$Res, $Val extends AnyStep>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1483,6 +1570,8 @@ class __$$StepPressKeyImplCopyWithImpl<$Res>
       _$StepPressKeyImpl _value, $Res Function(_$StepPressKeyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1550,14 +1639,16 @@ class _$StepPressKeyImpl implements StepPressKey {
             const DeepCollectionEquality().equals(other._keycodes, _keycodes));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_symbols),
       const DeepCollectionEquality().hash(_keycodes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
@@ -1653,7 +1744,10 @@ abstract class StepPressKey implements AnyStep {
 
   List<String> get symbols;
   Map<int, String> get keycodes;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1675,6 +1769,8 @@ class __$$StepKeyPresentImplCopyWithImpl<$Res>
       _$StepKeyPresentImpl _value, $Res Function(_$StepKeyPresentImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1737,11 +1833,13 @@ class _$StepKeyPresentImpl implements StepKeyPresent {
             (identical(other.no, no) || other.no == no));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, symbol, yes, no);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
@@ -1840,7 +1938,10 @@ abstract class StepKeyPresent implements AnyStep {
   String get symbol;
   String get yes;
   String get no;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1862,6 +1963,8 @@ class __$$StepResultImplCopyWithImpl<$Res>
       _$StepResultImpl _value, $Res Function(_$StepResultImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1913,11 +2016,13 @@ class _$StepResultImpl implements StepResult {
             (identical(other.variant, variant) || other.variant == variant));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
@@ -2013,7 +2118,10 @@ abstract class StepResult implements AnyStep {
 
   String get layout;
   String get variant;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2028,8 +2136,12 @@ mixin _$KeyboardSetting {
   String get variant => throw _privateConstructorUsedError;
   String? get toggle => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardSettingCopyWith<KeyboardSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2053,6 +2165,8 @@ class _$KeyboardSettingCopyWithImpl<$Res, $Val extends KeyboardSetting>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2096,6 +2210,8 @@ class __$$KeyboardSettingImplCopyWithImpl<$Res>
       _$KeyboardSettingImpl _value, $Res Function(_$KeyboardSettingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2152,11 +2268,13 @@ class _$KeyboardSettingImpl implements _KeyboardSetting {
             (identical(other.toggle, toggle) || other.toggle == toggle));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant, toggle);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
@@ -2186,8 +2304,11 @@ abstract class _KeyboardSetting implements KeyboardSetting {
   String get variant;
   @override
   String? get toggle;
+
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2201,8 +2322,12 @@ mixin _$KeyboardVariant {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardVariant to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardVariantCopyWith<KeyboardVariant> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2226,6 +2351,8 @@ class _$KeyboardVariantCopyWithImpl<$Res, $Val extends KeyboardVariant>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2264,6 +2391,8 @@ class __$$KeyboardVariantImplCopyWithImpl<$Res>
       _$KeyboardVariantImpl _value, $Res Function(_$KeyboardVariantImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2310,11 +2439,13 @@ class _$KeyboardVariantImpl implements _KeyboardVariant {
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
@@ -2341,8 +2472,11 @@ abstract class _KeyboardVariant implements KeyboardVariant {
   String get code;
   @override
   String get name;
+
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2357,8 +2491,12 @@ mixin _$KeyboardLayout {
   String get name => throw _privateConstructorUsedError;
   List<KeyboardVariant> get variants => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardLayout to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardLayoutCopyWith<KeyboardLayout> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2382,6 +2520,8 @@ class _$KeyboardLayoutCopyWithImpl<$Res, $Val extends KeyboardLayout>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2425,6 +2565,8 @@ class __$$KeyboardLayoutImplCopyWithImpl<$Res>
       _$KeyboardLayoutImpl _value, $Res Function(_$KeyboardLayoutImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2488,12 +2630,14 @@ class _$KeyboardLayoutImpl implements _KeyboardLayout {
             const DeepCollectionEquality().equals(other._variants, _variants));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, const DeepCollectionEquality().hash(_variants));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
@@ -2523,8 +2667,11 @@ abstract class _KeyboardLayout implements KeyboardLayout {
   String get name;
   @override
   List<KeyboardVariant> get variants;
+
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2538,8 +2685,12 @@ mixin _$KeyboardSetup {
   KeyboardSetting get setting => throw _privateConstructorUsedError;
   List<KeyboardLayout> get layouts => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardSetup to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardSetupCopyWith<KeyboardSetup> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2565,6 +2716,8 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2583,6 +2736,8 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
     ) as $Val);
   }
 
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $KeyboardSettingCopyWith<$Res> get setting {
@@ -2614,6 +2769,8 @@ class __$$KeyboardSetupImplCopyWithImpl<$Res>
       _$KeyboardSetupImpl _value, $Res Function(_$KeyboardSetupImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2667,12 +2824,14 @@ class _$KeyboardSetupImpl implements _KeyboardSetup {
             const DeepCollectionEquality().equals(other._layouts, _layouts));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, setting, const DeepCollectionEquality().hash(_layouts));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
@@ -2698,8 +2857,11 @@ abstract class _KeyboardSetup implements KeyboardSetup {
   KeyboardSetting get setting;
   @override
   List<KeyboardLayout> get layouts;
+
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2718,8 +2880,12 @@ mixin _$SourceSelection {
   @JsonKey(name: 'default')
   bool get isDefault => throw _privateConstructorUsedError;
 
+  /// Serializes this SourceSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SourceSelectionCopyWith<SourceSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2749,6 +2915,8 @@ class _$SourceSelectionCopyWithImpl<$Res, $Val extends SourceSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2813,6 +2981,8 @@ class __$$SourceSelectionImplCopyWithImpl<$Res>
       _$SourceSelectionImpl _value, $Res Function(_$SourceSelectionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2900,12 +3070,14 @@ class _$SourceSelectionImpl implements _SourceSelection {
                 other.isDefault == isDefault));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, description, id, size, variant, isDefault);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
@@ -2946,8 +3118,11 @@ abstract class _SourceSelection implements SourceSelection {
   @override
   @JsonKey(name: 'default')
   bool get isDefault;
+
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2963,8 +3138,12 @@ mixin _$SourceSelectionAndSetting {
   String get currentId => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
+  /// Serializes this SourceSelectionAndSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SourceSelectionAndSettingCopyWith<SourceSelectionAndSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2990,6 +3169,8 @@ class _$SourceSelectionAndSettingCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3037,6 +3218,8 @@ class __$$SourceSelectionAndSettingImplCopyWithImpl<$Res>
       $Res Function(_$SourceSelectionAndSettingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3103,12 +3286,14 @@ class _$SourceSelectionAndSettingImpl implements _SourceSelectionAndSetting {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_sources), currentId, searchDrivers);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
@@ -3138,8 +3323,11 @@ abstract class _SourceSelectionAndSetting implements SourceSelectionAndSetting {
   String get currentId;
   @override
   bool get searchDrivers;
+
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -3159,8 +3347,12 @@ mixin _$ZdevInfo {
   bool get failed => throw _privateConstructorUsedError;
   String get names => throw _privateConstructorUsedError;
 
+  /// Serializes this ZdevInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ZdevInfoCopyWith<ZdevInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3191,6 +3383,8 @@ class _$ZdevInfoCopyWithImpl<$Res, $Val extends ZdevInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3267,6 +3461,8 @@ class __$$ZdevInfoImplCopyWithImpl<$Res>
       _$ZdevInfoImpl _value, $Res Function(_$ZdevInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3369,12 +3565,14 @@ class _$ZdevInfoImpl implements _ZdevInfo {
             (identical(other.names, names) || other.names == names));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, type, on, exists, pers, auto, failed, names);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
@@ -3418,8 +3616,11 @@ abstract class _ZdevInfo implements ZdevInfo {
   bool get failed;
   @override
   String get names;
+
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3434,8 +3635,12 @@ mixin _$NetworkStatus {
   PackageInstallState get wlanSupportInstallState =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this NetworkStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NetworkStatusCopyWith<NetworkStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3460,6 +3665,8 @@ class _$NetworkStatusCopyWithImpl<$Res, $Val extends NetworkStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3499,6 +3706,8 @@ class __$$NetworkStatusImplCopyWithImpl<$Res>
       _$NetworkStatusImpl _value, $Res Function(_$NetworkStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3556,12 +3765,14 @@ class _$NetworkStatusImpl implements _NetworkStatus {
                 other.wlanSupportInstallState == wlanSupportInstallState));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_devices), wlanSupportInstallState);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
@@ -3588,8 +3799,11 @@ abstract class _NetworkStatus implements NetworkStatus {
   List<NetDevInfo> get devices;
   @override
   PackageInstallState get wlanSupportInstallState;
+
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3605,8 +3819,12 @@ mixin _$IdentityData {
   String get cryptedPassword => throw _privateConstructorUsedError;
   String get hostname => throw _privateConstructorUsedError;
 
+  /// Serializes this IdentityData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $IdentityDataCopyWith<IdentityData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3634,6 +3852,8 @@ class _$IdentityDataCopyWithImpl<$Res, $Val extends IdentityData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3686,6 +3906,8 @@ class __$$IdentityDataImplCopyWithImpl<$Res>
       _$IdentityDataImpl _value, $Res Function(_$IdentityDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3760,12 +3982,14 @@ class _$IdentityDataImpl implements _IdentityData {
                 other.hostname == hostname));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, realname, username, cryptedPassword, hostname);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
@@ -3797,8 +4021,11 @@ abstract class _IdentityData implements IdentityData {
   String get cryptedPassword;
   @override
   String get hostname;
+
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3813,8 +4040,12 @@ mixin _$SSHData {
   bool get allowPw => throw _privateConstructorUsedError;
   List<String> get authorizedKeys => throw _privateConstructorUsedError;
 
+  /// Serializes this SSHData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SSHDataCopyWith<SSHData> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -3836,6 +4067,8 @@ class _$SSHDataCopyWithImpl<$Res, $Val extends SSHData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3878,6 +4111,8 @@ class __$$SSHDataImplCopyWithImpl<$Res>
       _$SSHDataImpl _value, $Res Function(_$SSHDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3944,12 +4179,14 @@ class _$SSHDataImpl implements _SSHData {
                 .equals(other._authorizedKeys, _authorizedKeys));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, installServer, allowPw,
       const DeepCollectionEquality().hash(_authorizedKeys));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
@@ -3977,8 +4214,11 @@ abstract class _SSHData implements SSHData {
   bool get allowPw;
   @override
   List<String> get authorizedKeys;
+
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3994,8 +4234,12 @@ mixin _$SSHIdentity {
   String get keyComment => throw _privateConstructorUsedError;
   String get keyFingerprint => throw _privateConstructorUsedError;
 
+  /// Serializes this SSHIdentity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SSHIdentityCopyWith<SSHIdentity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4020,6 +4264,8 @@ class _$SSHIdentityCopyWithImpl<$Res, $Val extends SSHIdentity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4069,6 +4315,8 @@ class __$$SSHIdentityImplCopyWithImpl<$Res>
       _$SSHIdentityImpl _value, $Res Function(_$SSHIdentityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4137,12 +4385,14 @@ class _$SSHIdentityImpl implements _SSHIdentity {
                 other.keyFingerprint == keyFingerprint));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, keyType, key, keyComment, keyFingerprint);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
@@ -4174,8 +4424,11 @@ abstract class _SSHIdentity implements SSHIdentity {
   String get keyComment;
   @override
   String get keyFingerprint;
+
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4190,8 +4443,12 @@ mixin _$SSHFetchIdResponse {
   List<SSHIdentity>? get identities => throw _privateConstructorUsedError;
   String? get error => throw _privateConstructorUsedError;
 
+  /// Serializes this SSHFetchIdResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SSHFetchIdResponseCopyWith<SSHFetchIdResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4216,6 +4473,8 @@ class _$SSHFetchIdResponseCopyWithImpl<$Res, $Val extends SSHFetchIdResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4260,6 +4519,8 @@ class __$$SSHFetchIdResponseImplCopyWithImpl<$Res>
       $Res Function(_$SSHFetchIdResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4327,12 +4588,14 @@ class _$SSHFetchIdResponseImpl implements _SSHFetchIdResponse {
             (identical(other.error, error) || other.error == error));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status,
       const DeepCollectionEquality().hash(_identities), error);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
@@ -4362,8 +4625,11 @@ abstract class _SSHFetchIdResponse implements SSHFetchIdResponse {
   List<SSHIdentity>? get identities;
   @override
   String? get error;
+
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4381,8 +4647,12 @@ mixin _$ChannelSnapInfo {
   int get size => throw _privateConstructorUsedError;
   DateTime get releasedAt => throw _privateConstructorUsedError;
 
+  /// Serializes this ChannelSnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ChannelSnapInfoCopyWith<ChannelSnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4412,6 +4682,8 @@ class _$ChannelSnapInfoCopyWithImpl<$Res, $Val extends ChannelSnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4476,6 +4748,8 @@ class __$$ChannelSnapInfoImplCopyWithImpl<$Res>
       _$ChannelSnapInfoImpl _value, $Res Function(_$ChannelSnapInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4564,12 +4838,14 @@ class _$ChannelSnapInfoImpl implements _ChannelSnapInfo {
                 other.releasedAt == releasedAt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, channelName, revision,
       confinement, version, size, releasedAt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
@@ -4608,8 +4884,11 @@ abstract class _ChannelSnapInfo implements ChannelSnapInfo {
   int get size;
   @override
   DateTime get releasedAt;
+
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4630,8 +4909,12 @@ mixin _$SnapInfo {
   String get license => throw _privateConstructorUsedError;
   List<ChannelSnapInfo> get channels => throw _privateConstructorUsedError;
 
+  /// Serializes this SnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SnapInfoCopyWith<SnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4663,6 +4946,8 @@ class _$SnapInfoCopyWithImpl<$Res, $Val extends SnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4745,6 +5030,8 @@ class __$$SnapInfoImplCopyWithImpl<$Res>
       _$SnapInfoImpl _value, $Res Function(_$SnapInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4874,7 +5161,7 @@ class _$SnapInfoImpl implements _SnapInfo {
             const DeepCollectionEquality().equals(other._channels, _channels));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -4888,7 +5175,9 @@ class _$SnapInfoImpl implements _SnapInfo {
       license,
       const DeepCollectionEquality().hash(_channels));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
@@ -4935,8 +5224,11 @@ abstract class _SnapInfo implements SnapInfo {
   String get license;
   @override
   List<ChannelSnapInfo> get channels;
+
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4952,8 +5244,12 @@ mixin _$DriversResponse {
   bool get localOnly => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
+  /// Serializes this DriversResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DriversResponseCopyWith<DriversResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4981,6 +5277,8 @@ class _$DriversResponseCopyWithImpl<$Res, $Val extends DriversResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5033,6 +5331,8 @@ class __$$DriversResponseImplCopyWithImpl<$Res>
       _$DriversResponseImpl _value, $Res Function(_$DriversResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5110,12 +5410,14 @@ class _$DriversResponseImpl implements _DriversResponse {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, install,
       const DeepCollectionEquality().hash(_drivers), localOnly, searchDrivers);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
@@ -5148,8 +5450,11 @@ abstract class _DriversResponse implements DriversResponse {
   bool get localOnly;
   @override
   bool get searchDrivers;
+
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5162,8 +5467,12 @@ OEMResponse _$OEMResponseFromJson(Map<String, dynamic> json) {
 mixin _$OEMResponse {
   List<String>? get metapackages => throw _privateConstructorUsedError;
 
+  /// Serializes this OEMResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OEMResponseCopyWith<OEMResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5187,6 +5496,8 @@ class _$OEMResponseCopyWithImpl<$Res, $Val extends OEMResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5220,6 +5531,8 @@ class __$$OEMResponseImplCopyWithImpl<$Res>
       _$OEMResponseImpl _value, $Res Function(_$OEMResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5267,12 +5580,14 @@ class _$OEMResponseImpl implements _OEMResponse {
                 .equals(other._metapackages, _metapackages));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_metapackages));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
@@ -5295,8 +5610,11 @@ abstract class _OEMResponse implements OEMResponse {
 
   @override
   List<String>? get metapackages;
+
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5309,8 +5627,12 @@ CodecsData _$CodecsDataFromJson(Map<String, dynamic> json) {
 mixin _$CodecsData {
   bool get install => throw _privateConstructorUsedError;
 
+  /// Serializes this CodecsData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CodecsDataCopyWith<CodecsData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5334,6 +5656,8 @@ class _$CodecsDataCopyWithImpl<$Res, $Val extends CodecsData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5367,6 +5691,8 @@ class __$$CodecsDataImplCopyWithImpl<$Res>
       _$CodecsDataImpl _value, $Res Function(_$CodecsDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5405,11 +5731,13 @@ class _$CodecsDataImpl implements _CodecsData {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
@@ -5431,8 +5759,11 @@ abstract class _CodecsData implements CodecsData {
 
   @override
   bool get install;
+
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5445,8 +5776,12 @@ DriversPayload _$DriversPayloadFromJson(Map<String, dynamic> json) {
 mixin _$DriversPayload {
   bool get install => throw _privateConstructorUsedError;
 
+  /// Serializes this DriversPayload to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DriversPayloadCopyWith<DriversPayload> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5470,6 +5805,8 @@ class _$DriversPayloadCopyWithImpl<$Res, $Val extends DriversPayload>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5503,6 +5840,8 @@ class __$$DriversPayloadImplCopyWithImpl<$Res>
       _$DriversPayloadImpl _value, $Res Function(_$DriversPayloadImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5541,11 +5880,13 @@ class _$DriversPayloadImpl implements _DriversPayload {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
@@ -5569,8 +5910,11 @@ abstract class _DriversPayload implements DriversPayload {
 
   @override
   bool get install;
+
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5585,8 +5929,12 @@ mixin _$SnapSelection {
   String get channel => throw _privateConstructorUsedError;
   bool get classic => throw _privateConstructorUsedError;
 
+  /// Serializes this SnapSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SnapSelectionCopyWith<SnapSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5610,6 +5958,8 @@ class _$SnapSelectionCopyWithImpl<$Res, $Val extends SnapSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5653,6 +6003,8 @@ class __$$SnapSelectionImplCopyWithImpl<$Res>
       _$SnapSelectionImpl _value, $Res Function(_$SnapSelectionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5709,11 +6061,13 @@ class _$SnapSelectionImpl implements _SnapSelection {
             (identical(other.classic, classic) || other.classic == classic));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, channel, classic);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
@@ -5742,8 +6096,11 @@ abstract class _SnapSelection implements SnapSelection {
   String get channel;
   @override
   bool get classic;
+
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5758,8 +6115,12 @@ mixin _$SnapListResponse {
   List<SnapInfo> get snaps => throw _privateConstructorUsedError;
   List<SnapSelection> get selections => throw _privateConstructorUsedError;
 
+  /// Serializes this SnapListResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SnapListResponseCopyWith<SnapListResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5786,6 +6147,8 @@ class _$SnapListResponseCopyWithImpl<$Res, $Val extends SnapListResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5832,6 +6195,8 @@ class __$$SnapListResponseImplCopyWithImpl<$Res>
       $Res Function(_$SnapListResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5905,7 +6270,7 @@ class _$SnapListResponseImpl implements _SnapListResponse {
                 .equals(other._selections, _selections));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -5913,7 +6278,9 @@ class _$SnapListResponseImpl implements _SnapListResponse {
       const DeepCollectionEquality().hash(_snaps),
       const DeepCollectionEquality().hash(_selections));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
@@ -5943,8 +6310,11 @@ abstract class _SnapListResponse implements SnapListResponse {
   List<SnapInfo> get snaps;
   @override
   List<SnapSelection> get selections;
+
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5958,8 +6328,12 @@ mixin _$TimeZoneInfo {
   String get timezone => throw _privateConstructorUsedError;
   bool get fromGeoip => throw _privateConstructorUsedError;
 
+  /// Serializes this TimeZoneInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TimeZoneInfoCopyWith<TimeZoneInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5983,6 +6357,8 @@ class _$TimeZoneInfoCopyWithImpl<$Res, $Val extends TimeZoneInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6021,6 +6397,8 @@ class __$$TimeZoneInfoImplCopyWithImpl<$Res>
       _$TimeZoneInfoImpl _value, $Res Function(_$TimeZoneInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6069,11 +6447,13 @@ class _$TimeZoneInfoImpl implements _TimeZoneInfo {
                 other.fromGeoip == fromGeoip));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, timezone, fromGeoip);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
@@ -6099,8 +6479,11 @@ abstract class _TimeZoneInfo implements TimeZoneInfo {
   String get timezone;
   @override
   bool get fromGeoip;
+
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6113,8 +6496,12 @@ UbuntuProInfo _$UbuntuProInfoFromJson(Map<String, dynamic> json) {
 mixin _$UbuntuProInfo {
   String get token => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProInfoCopyWith<UbuntuProInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6138,6 +6525,8 @@ class _$UbuntuProInfoCopyWithImpl<$Res, $Val extends UbuntuProInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6171,6 +6560,8 @@ class __$$UbuntuProInfoImplCopyWithImpl<$Res>
       _$UbuntuProInfoImpl _value, $Res Function(_$UbuntuProInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6209,11 +6600,13 @@ class _$UbuntuProInfoImpl implements _UbuntuProInfo {
             (identical(other.token, token) || other.token == token));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, token);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
@@ -6236,8 +6629,11 @@ abstract class _UbuntuProInfo implements UbuntuProInfo {
 
   @override
   String get token;
+
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6251,8 +6647,12 @@ mixin _$UbuntuProResponse {
   String get token => throw _privateConstructorUsedError;
   bool get hasNetwork => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProResponseCopyWith<UbuntuProResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6276,6 +6676,8 @@ class _$UbuntuProResponseCopyWithImpl<$Res, $Val extends UbuntuProResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6314,6 +6716,8 @@ class __$$UbuntuProResponseImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6362,11 +6766,13 @@ class _$UbuntuProResponseImpl implements _UbuntuProResponse {
                 other.hasNetwork == hasNetwork));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, token, hasNetwork);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
@@ -6393,8 +6799,11 @@ abstract class _UbuntuProResponse implements UbuntuProResponse {
   String get token;
   @override
   bool get hasNetwork;
+
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6409,8 +6818,12 @@ mixin _$UbuntuProGeneralInfo {
   int get universePackages => throw _privateConstructorUsedError;
   int get mainPackages => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProGeneralInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProGeneralInfoCopyWith<UbuntuProGeneralInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6435,6 +6848,8 @@ class _$UbuntuProGeneralInfoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6478,6 +6893,8 @@ class __$$UbuntuProGeneralInfoImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProGeneralInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6538,12 +6955,14 @@ class _$UbuntuProGeneralInfoImpl implements _UbuntuProGeneralInfo {
                 other.mainPackages == mainPackages));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, eolEsmYear, universePackages, mainPackages);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
@@ -6574,8 +6993,11 @@ abstract class _UbuntuProGeneralInfo implements UbuntuProGeneralInfo {
   int get universePackages;
   @override
   int get mainPackages;
+
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -6589,8 +7011,12 @@ mixin _$UPCSInitiateResponse {
   String get userCode => throw _privateConstructorUsedError;
   int get validitySeconds => throw _privateConstructorUsedError;
 
+  /// Serializes this UPCSInitiateResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UPCSInitiateResponseCopyWith<UPCSInitiateResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6615,6 +7041,8 @@ class _$UPCSInitiateResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6653,6 +7081,8 @@ class __$$UPCSInitiateResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSInitiateResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6702,11 +7132,13 @@ class _$UPCSInitiateResponseImpl implements _UPCSInitiateResponse {
                 other.validitySeconds == validitySeconds));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, userCode, validitySeconds);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
@@ -6734,8 +7166,11 @@ abstract class _UPCSInitiateResponse implements UPCSInitiateResponse {
   String get userCode;
   @override
   int get validitySeconds;
+
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -6749,8 +7184,12 @@ mixin _$UPCSWaitResponse {
   UPCSWaitStatus get status => throw _privateConstructorUsedError;
   String? get contractToken => throw _privateConstructorUsedError;
 
+  /// Serializes this UPCSWaitResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UPCSWaitResponseCopyWith<UPCSWaitResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6774,6 +7213,8 @@ class _$UPCSWaitResponseCopyWithImpl<$Res, $Val extends UPCSWaitResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6812,6 +7253,8 @@ class __$$UPCSWaitResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSWaitResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6860,11 +7303,13 @@ class _$UPCSWaitResponseImpl implements _UPCSWaitResponse {
                 other.contractToken == contractToken));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, contractToken);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
@@ -6891,8 +7336,11 @@ abstract class _UPCSWaitResponse implements UPCSWaitResponse {
   UPCSWaitStatus get status;
   @override
   String? get contractToken;
+
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6907,8 +7355,12 @@ mixin _$UbuntuProService {
   String get description => throw _privateConstructorUsedError;
   bool get autoEnabled => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProService to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProServiceCopyWith<UbuntuProService> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6932,6 +7384,8 @@ class _$UbuntuProServiceCopyWithImpl<$Res, $Val extends UbuntuProService>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6975,6 +7429,8 @@ class __$$UbuntuProServiceImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProServiceImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7034,11 +7490,13 @@ class _$UbuntuProServiceImpl implements _UbuntuProService {
                 other.autoEnabled == autoEnabled));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, description, autoEnabled);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
@@ -7068,8 +7526,11 @@ abstract class _UbuntuProService implements UbuntuProService {
   String get description;
   @override
   bool get autoEnabled;
+
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7086,8 +7547,12 @@ mixin _$UbuntuProSubscription {
   String get contractToken => throw _privateConstructorUsedError;
   List<UbuntuProService> get services => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProSubscription to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProSubscriptionCopyWith<UbuntuProSubscription> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7116,6 +7581,8 @@ class _$UbuntuProSubscriptionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7170,6 +7637,8 @@ class __$$UbuntuProSubscriptionImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProSubscriptionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7245,12 +7714,14 @@ class _$UbuntuProSubscriptionImpl implements _UbuntuProSubscription {
             const DeepCollectionEquality().equals(other._services, _services));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, contractName, accountName,
       contractToken, const DeepCollectionEquality().hash(_services));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
@@ -7284,8 +7755,11 @@ abstract class _UbuntuProSubscription implements UbuntuProSubscription {
   String get contractToken;
   @override
   List<UbuntuProService> get services;
+
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7300,8 +7774,12 @@ mixin _$UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status => throw _privateConstructorUsedError;
   UbuntuProSubscription? get subscription => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProCheckTokenAnswer to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProCheckTokenAnswerCopyWith<UbuntuProCheckTokenAnswer> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7329,6 +7807,8 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7347,6 +7827,8 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UbuntuProSubscriptionCopyWith<$Res>? get subscription {
@@ -7386,6 +7868,8 @@ class __$$UbuntuProCheckTokenAnswerImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProCheckTokenAnswerImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7434,11 +7918,13 @@ class _$UbuntuProCheckTokenAnswerImpl implements _UbuntuProCheckTokenAnswer {
                 other.subscription == subscription));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, subscription);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
@@ -7466,8 +7952,11 @@ abstract class _UbuntuProCheckTokenAnswer implements UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status;
   @override
   UbuntuProSubscription? get subscription;
+
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7482,8 +7971,12 @@ mixin _$TaskProgress {
   int get done => throw _privateConstructorUsedError;
   int get total => throw _privateConstructorUsedError;
 
+  /// Serializes this TaskProgress to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TaskProgressCopyWith<TaskProgress> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7507,6 +8000,8 @@ class _$TaskProgressCopyWithImpl<$Res, $Val extends TaskProgress>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7550,6 +8045,8 @@ class __$$TaskProgressImplCopyWithImpl<$Res>
       _$TaskProgressImpl _value, $Res Function(_$TaskProgressImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7607,11 +8104,13 @@ class _$TaskProgressImpl implements _TaskProgress {
             (identical(other.total, total) || other.total == total));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, label, done, total);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
@@ -7640,8 +8139,11 @@ abstract class _TaskProgress implements TaskProgress {
   int get done;
   @override
   int get total;
+
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7658,8 +8160,12 @@ mixin _$Task {
   TaskStatus get status => throw _privateConstructorUsedError;
   TaskProgress get progress => throw _privateConstructorUsedError;
 
+  /// Serializes this Task to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TaskCopyWith<Task> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -7688,6 +8194,8 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7721,6 +8229,8 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
     ) as $Val);
   }
 
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TaskProgressCopyWith<$Res> get progress {
@@ -7755,6 +8265,8 @@ class __$$TaskImplCopyWithImpl<$Res>
   __$$TaskImplCopyWithImpl(_$TaskImpl _value, $Res Function(_$TaskImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7831,12 +8343,14 @@ class _$TaskImpl implements _Task {
                 other.progress == progress));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, kind, summary, status, progress);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
@@ -7870,8 +8384,11 @@ abstract class _Task implements Task {
   TaskStatus get status;
   @override
   TaskProgress get progress;
+
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7891,8 +8408,12 @@ mixin _$Change {
   String? get err => throw _privateConstructorUsedError;
   dynamic get data => throw _privateConstructorUsedError;
 
+  /// Serializes this Change to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ChangeCopyWith<Change> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -7922,6 +8443,8 @@ class _$ChangeCopyWithImpl<$Res, $Val extends Change>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7997,6 +8520,8 @@ class __$$ChangeImplCopyWithImpl<$Res>
       _$ChangeImpl _value, $Res Function(_$ChangeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8106,7 +8631,7 @@ class _$ChangeImpl implements _Change {
             const DeepCollectionEquality().equals(other.data, data));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8119,7 +8644,9 @@ class _$ChangeImpl implements _Change {
       err,
       const DeepCollectionEquality().hash(data));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
@@ -8162,8 +8689,11 @@ abstract class _Change implements Change {
   String? get err;
   @override
   dynamic get data;
+
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8178,8 +8708,12 @@ mixin _$MirrorCheckResponse {
   MirrorCheckStatus get status => throw _privateConstructorUsedError;
   String get output => throw _privateConstructorUsedError;
 
+  /// Serializes this MirrorCheckResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MirrorCheckResponseCopyWith<MirrorCheckResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8203,6 +8737,8 @@ class _$MirrorCheckResponseCopyWithImpl<$Res, $Val extends MirrorCheckResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8246,6 +8782,8 @@ class __$$MirrorCheckResponseImplCopyWithImpl<$Res>
       $Res Function(_$MirrorCheckResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8301,11 +8839,13 @@ class _$MirrorCheckResponseImpl implements _MirrorCheckResponse {
             (identical(other.output, output) || other.output == output));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, url, status, output);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
@@ -8335,8 +8875,11 @@ abstract class _MirrorCheckResponse implements MirrorCheckResponse {
   MirrorCheckStatus get status;
   @override
   String get output;
+
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8352,8 +8895,12 @@ mixin _$MirrorPost {
   String? get staged => throw _privateConstructorUsedError;
   bool? get useDuringInstallation => throw _privateConstructorUsedError;
 
+  /// Serializes this MirrorPost to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MirrorPostCopyWith<MirrorPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8381,6 +8928,8 @@ class _$MirrorPostCopyWithImpl<$Res, $Val extends MirrorPost>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8433,6 +8982,8 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
       _$MirrorPostImpl _value, $Res Function(_$MirrorPostImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8510,7 +9061,7 @@ class _$MirrorPostImpl implements _MirrorPost {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8519,7 +9070,9 @@ class _$MirrorPostImpl implements _MirrorPost {
       staged,
       useDuringInstallation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
@@ -8551,8 +9104,11 @@ abstract class _MirrorPost implements MirrorPost {
   String? get staged;
   @override
   bool? get useDuringInstallation;
+
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8569,8 +9125,12 @@ mixin _$MirrorGet {
   String? get staged => throw _privateConstructorUsedError;
   bool get useDuringInstallation => throw _privateConstructorUsedError;
 
+  /// Serializes this MirrorGet to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MirrorGetCopyWith<MirrorGet> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8598,6 +9158,8 @@ class _$MirrorGetCopyWithImpl<$Res, $Val extends MirrorGet>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8656,6 +9218,8 @@ class __$$MirrorGetImplCopyWithImpl<$Res>
       _$MirrorGetImpl _value, $Res Function(_$MirrorGetImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8741,7 +9305,7 @@ class _$MirrorGetImpl implements _MirrorGet {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8751,7 +9315,9 @@ class _$MirrorGetImpl implements _MirrorGet {
       staged,
       useDuringInstallation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
@@ -8786,8 +9352,11 @@ abstract class _MirrorGet implements MirrorGet {
   String? get staged;
   @override
   bool get useDuringInstallation;
+
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8802,8 +9371,12 @@ mixin _$AdConnectionInfo {
   String get domainName => throw _privateConstructorUsedError;
   String get password => throw _privateConstructorUsedError;
 
+  /// Serializes this AdConnectionInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AdConnectionInfoCopyWith<AdConnectionInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8827,6 +9400,8 @@ class _$AdConnectionInfoCopyWithImpl<$Res, $Val extends AdConnectionInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8870,6 +9445,8 @@ class __$$AdConnectionInfoImplCopyWithImpl<$Res>
       $Res Function(_$AdConnectionInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8931,11 +9508,13 @@ class _$AdConnectionInfoImpl implements _AdConnectionInfo {
                 other.password == password));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, adminName, domainName, password);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
@@ -8965,8 +9544,11 @@ abstract class _AdConnectionInfo implements AdConnectionInfo {
   String get domainName;
   @override
   String get password;
+
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8983,8 +9565,12 @@ mixin _$OsProber {
   String? get subpath => throw _privateConstructorUsedError;
   String? get version => throw _privateConstructorUsedError;
 
+  /// Serializes this OsProber to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OsProberCopyWith<OsProber> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9012,6 +9598,8 @@ class _$OsProberCopyWithImpl<$Res, $Val extends OsProber>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9070,6 +9658,8 @@ class __$$OsProberImplCopyWithImpl<$Res>
       _$OsProberImpl _value, $Res Function(_$OsProberImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9145,12 +9735,14 @@ class _$OsProberImpl implements _OsProber {
             (identical(other.version, version) || other.version == version));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, long, label, type, subpath, version);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
@@ -9185,8 +9777,11 @@ abstract class _OsProber implements OsProber {
   String? get subpath;
   @override
   String? get version;
+
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9294,8 +9889,13 @@ mixin _$PartitionOrGap {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this PartitionOrGap to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PartitionOrGapCopyWith<PartitionOrGap> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9319,6 +9919,8 @@ class _$PartitionOrGapCopyWithImpl<$Res, $Val extends PartitionOrGap>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9374,6 +9976,8 @@ class __$$PartitionImplCopyWithImpl<$Res>
       _$PartitionImpl _value, $Res Function(_$PartitionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9457,6 +10061,8 @@ class __$$PartitionImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $OsProberCopyWith<$Res>? get os {
@@ -9570,7 +10176,7 @@ class _$PartitionImpl implements Partition {
             (identical(other.isInUse, isInUse) || other.isInUse == isInUse));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -9590,7 +10196,9 @@ class _$PartitionImpl implements Partition {
       path,
       isInUse);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
@@ -9783,8 +10391,11 @@ abstract class Partition implements PartitionOrGap {
   bool? get resize;
   String? get path;
   bool get isInUse;
+
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9806,6 +10417,8 @@ class __$$GapImplCopyWithImpl<$Res>
   __$$GapImplCopyWithImpl(_$GapImpl _value, $Res Function(_$GapImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9868,11 +10481,13 @@ class _$GapImpl implements Gap {
             (identical(other.usable, usable) || other.usable == usable));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, offset, size, usable);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
@@ -10009,8 +10624,11 @@ abstract class Gap implements PartitionOrGap {
   @override
   int get size;
   GapUsable get usable;
+
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10024,8 +10642,12 @@ mixin _$ZFS {
   String get volume => throw _privateConstructorUsedError;
   Map<String, dynamic>? get properties => throw _privateConstructorUsedError;
 
+  /// Serializes this ZFS to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ZFSCopyWith<ZFS> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10046,6 +10668,8 @@ class _$ZFSCopyWithImpl<$Res, $Val extends ZFS> implements $ZFSCopyWith<$Res> {
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10080,6 +10704,8 @@ class __$$ZFSImplCopyWithImpl<$Res> extends _$ZFSCopyWithImpl<$Res, _$ZFSImpl>
   __$$ZFSImplCopyWithImpl(_$ZFSImpl _value, $Res Function(_$ZFSImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10136,12 +10762,14 @@ class _$ZFSImpl implements _ZFS {
                 .equals(other._properties, _properties));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, volume, const DeepCollectionEquality().hash(_properties));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
@@ -10166,8 +10794,11 @@ abstract class _ZFS implements ZFS {
   String get volume;
   @override
   Map<String, dynamic>? get properties;
+
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10186,8 +10817,12 @@ mixin _$ZPool {
   Map<String, dynamic>? get fsProperties => throw _privateConstructorUsedError;
   bool? get defaultFeatures => throw _privateConstructorUsedError;
 
+  /// Serializes this ZPool to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ZPoolCopyWith<ZPool> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10217,6 +10852,8 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10255,6 +10892,8 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
     ) as $Val);
   }
 
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ZFSCopyWith<$Res>? get zfses {
@@ -10295,6 +10934,8 @@ class __$$ZPoolImplCopyWithImpl<$Res>
       _$ZPoolImpl _value, $Res Function(_$ZPoolImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10402,7 +11043,7 @@ class _$ZPoolImpl implements _ZPool {
                 other.defaultFeatures == defaultFeatures));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -10413,7 +11054,9 @@ class _$ZPoolImpl implements _ZPool {
       const DeepCollectionEquality().hash(_fsProperties),
       defaultFeatures);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
@@ -10450,8 +11093,11 @@ abstract class _ZPool implements ZPool {
   Map<String, dynamic>? get fsProperties;
   @override
   bool? get defaultFeatures;
+
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10478,8 +11124,12 @@ mixin _$Disk {
   String? get vendor => throw _privateConstructorUsedError;
   bool get hasInUsePartition => throw _privateConstructorUsedError;
 
+  /// Serializes this Disk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DiskCopyWith<Disk> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10516,6 +11166,8 @@ class _$DiskCopyWithImpl<$Res, $Val extends Disk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10632,6 +11284,8 @@ class __$$DiskImplCopyWithImpl<$Res>
   __$$DiskImplCopyWithImpl(_$DiskImpl _value, $Res Function(_$DiskImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10819,7 +11473,7 @@ class _$DiskImpl implements _Disk {
                 other.hasInUsePartition == hasInUsePartition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -10839,7 +11493,9 @@ class _$DiskImpl implements _Disk {
       vendor,
       hasInUsePartition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
@@ -10903,8 +11559,11 @@ abstract class _Disk implements Disk {
   String? get vendor;
   @override
   bool get hasInUsePartition;
+
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10921,8 +11580,12 @@ mixin _$GuidedDisallowedCapability {
       throw _privateConstructorUsedError;
   String? get message => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedDisallowedCapability to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedDisallowedCapabilityCopyWith<GuidedDisallowedCapability>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -10951,6 +11614,8 @@ class _$GuidedDisallowedCapabilityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11000,6 +11665,8 @@ class __$$GuidedDisallowedCapabilityImplCopyWithImpl<$Res>
       $Res Function(_$GuidedDisallowedCapabilityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11057,11 +11724,13 @@ class _$GuidedDisallowedCapabilityImpl implements _GuidedDisallowedCapability {
             (identical(other.message, message) || other.message == message));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, capability, reason, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
@@ -11092,8 +11761,11 @@ abstract class _GuidedDisallowedCapability
   GuidedDisallowedCapabilityReason get reason;
   @override
   String? get message;
+
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -11112,8 +11784,12 @@ mixin _$StorageResponse {
   Map<String, dynamic>? get dasd => throw _privateConstructorUsedError;
   int get storageVersion => throw _privateConstructorUsedError;
 
+  /// Serializes this StorageResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $StorageResponseCopyWith<StorageResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11146,6 +11822,8 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11189,6 +11867,8 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
     ) as $Val);
   }
 
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -11231,6 +11911,8 @@ class __$$StorageResponseImplCopyWithImpl<$Res>
       _$StorageResponseImpl _value, $Res Function(_$StorageResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11356,7 +12038,7 @@ class _$StorageResponseImpl implements _StorageResponse {
                 other.storageVersion == storageVersion));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11368,7 +12050,9 @@ class _$StorageResponseImpl implements _StorageResponse {
       const DeepCollectionEquality().hash(_dasd),
       storageVersion);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
@@ -11410,8 +12094,11 @@ abstract class _StorageResponse implements StorageResponse {
   Map<String, dynamic>? get dasd;
   @override
   int get storageVersion;
+
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11429,8 +12116,12 @@ mixin _$StorageResponseV2 {
   bool? get needBoot => throw _privateConstructorUsedError;
   int? get installMinimumSize => throw _privateConstructorUsedError;
 
+  /// Serializes this StorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $StorageResponseV2CopyWith<StorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11462,6 +12153,8 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11500,6 +12193,8 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
     ) as $Val);
   }
 
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -11541,6 +12236,8 @@ class __$$StorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$StorageResponseV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11637,7 +12334,7 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
                 other.installMinimumSize == installMinimumSize));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11648,7 +12345,9 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
       needBoot,
       installMinimumSize);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
@@ -11687,8 +12386,11 @@ abstract class _StorageResponseV2 implements StorageResponseV2 {
   bool? get needBoot;
   @override
   int? get installMinimumSize;
+
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11704,8 +12406,12 @@ mixin _$GuidedResizeValues {
   int get recommended => throw _privateConstructorUsedError;
   int get maximum => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedResizeValues to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedResizeValuesCopyWith<GuidedResizeValues> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11729,6 +12435,8 @@ class _$GuidedResizeValuesCopyWithImpl<$Res, $Val extends GuidedResizeValues>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11777,6 +12485,8 @@ class __$$GuidedResizeValuesImplCopyWithImpl<$Res>
       $Res Function(_$GuidedResizeValuesImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11845,12 +12555,14 @@ class _$GuidedResizeValuesImpl implements _GuidedResizeValues {
             (identical(other.maximum, maximum) || other.maximum == maximum));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, installMax, minimum, recommended, maximum);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
@@ -11883,8 +12595,11 @@ abstract class _GuidedResizeValues implements GuidedResizeValues {
   int get recommended;
   @override
   int get maximum;
+
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12033,8 +12748,13 @@ mixin _$GuidedStorageTarget {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this GuidedStorageTarget to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedStorageTargetCopyWith<GuidedStorageTarget> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12060,6 +12780,8 @@ class _$GuidedStorageTargetCopyWithImpl<$Res, $Val extends GuidedStorageTarget>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12104,6 +12826,8 @@ class __$$GuidedStorageTargetReformatImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetReformatImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12183,7 +12907,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12191,7 +12915,9 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
@@ -12365,8 +13091,11 @@ abstract class GuidedStorageTargetReformat implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -12401,6 +13130,8 @@ class __$$GuidedStorageTargetResizeImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetResizeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12526,7 +13257,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12539,7 +13270,9 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
@@ -12726,8 +13459,11 @@ abstract class GuidedStorageTargetResize implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -12758,6 +13494,8 @@ class __$$GuidedStorageTargetEraseInstallImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetEraseInstallImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12848,7 +13586,7 @@ class _$GuidedStorageTargetEraseInstallImpl
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12857,7 +13595,9 @@ class _$GuidedStorageTargetEraseInstallImpl
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetEraseInstallImplCopyWith<
@@ -13034,8 +13774,11 @@ abstract class GuidedStorageTargetEraseInstall implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetEraseInstallImplCopyWith<
           _$GuidedStorageTargetEraseInstallImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -13067,6 +13810,8 @@ class __$$GuidedStorageTargetUseGapImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetUseGapImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13154,7 +13899,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13163,7 +13908,9 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
@@ -13339,8 +14086,11 @@ abstract class GuidedStorageTargetUseGap implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13369,6 +14119,8 @@ class __$$GuidedStorageTargetManualImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetManualImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13437,14 +14189,16 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
@@ -13616,8 +14370,11 @@ abstract class GuidedStorageTargetManual implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13631,8 +14388,12 @@ mixin _$RecoveryKey {
   String? get liveLocation => throw _privateConstructorUsedError;
   String? get backupLocation => throw _privateConstructorUsedError;
 
+  /// Serializes this RecoveryKey to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RecoveryKeyCopyWith<RecoveryKey> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13656,6 +14417,8 @@ class _$RecoveryKeyCopyWithImpl<$Res, $Val extends RecoveryKey>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13694,6 +14457,8 @@ class __$$RecoveryKeyImplCopyWithImpl<$Res>
       _$RecoveryKeyImpl _value, $Res Function(_$RecoveryKeyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13742,11 +14507,13 @@ class _$RecoveryKeyImpl implements _RecoveryKey {
                 other.backupLocation == backupLocation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, liveLocation, backupLocation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
@@ -13772,8 +14539,11 @@ abstract class _RecoveryKey implements RecoveryKey {
   String? get liveLocation;
   @override
   String? get backupLocation;
+
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13792,8 +14562,12 @@ mixin _$GuidedChoiceV2 {
   bool get resetPartition => throw _privateConstructorUsedError;
   int? get resetPartitionSize => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedChoiceV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedChoiceV2CopyWith<GuidedChoiceV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13827,6 +14601,8 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13870,6 +14646,8 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     ) as $Val);
   }
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedStorageTargetCopyWith<$Res> get target {
@@ -13878,6 +14656,8 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     });
   }
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RecoveryKeyCopyWith<$Res>? get recoveryKey {
@@ -13922,6 +14702,8 @@ class __$$GuidedChoiceV2ImplCopyWithImpl<$Res>
       _$GuidedChoiceV2Impl _value, $Res Function(_$GuidedChoiceV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14022,12 +14804,14 @@ class _$GuidedChoiceV2Impl implements _GuidedChoiceV2 {
                 other.resetPartitionSize == resetPartitionSize));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, target, capability, password,
       recoveryKey, sizingPolicy, resetPartition, resetPartitionSize);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
@@ -14069,8 +14853,11 @@ abstract class _GuidedChoiceV2 implements GuidedChoiceV2 {
   bool get resetPartition;
   @override
   int? get resetPartitionSize;
+
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14087,8 +14874,12 @@ mixin _$GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured => throw _privateConstructorUsedError;
   List<GuidedStorageTarget> get targets => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedStorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedStorageResponseV2CopyWith<GuidedStorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14120,6 +14911,8 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14148,6 +14941,8 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -14160,6 +14955,8 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     });
   }
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedChoiceV2CopyWith<$Res>? get configured {
@@ -14204,6 +15001,8 @@ class __$$GuidedStorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageResponseV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14279,12 +15078,14 @@ class _$GuidedStorageResponseV2Impl implements _GuidedStorageResponseV2 {
             const DeepCollectionEquality().equals(other._targets, _targets));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, errorReport, configured,
       const DeepCollectionEquality().hash(_targets));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
@@ -14317,8 +15118,11 @@ abstract class _GuidedStorageResponseV2 implements GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured;
   @override
   List<GuidedStorageTarget> get targets;
+
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -14333,8 +15137,12 @@ mixin _$AddPartitionV2 {
   Partition get partition => throw _privateConstructorUsedError;
   Gap get gap => throw _privateConstructorUsedError;
 
+  /// Serializes this AddPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AddPartitionV2CopyWith<AddPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14358,6 +15166,8 @@ class _$AddPartitionV2CopyWithImpl<$Res, $Val extends AddPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14401,6 +15211,8 @@ class __$$AddPartitionV2ImplCopyWithImpl<$Res>
       _$AddPartitionV2Impl _value, $Res Function(_$AddPartitionV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14456,7 +15268,7 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
             const DeepCollectionEquality().equals(other.gap, gap));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -14464,7 +15276,9 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
       const DeepCollectionEquality().hash(partition),
       const DeepCollectionEquality().hash(gap));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
@@ -14494,8 +15308,11 @@ abstract class _AddPartitionV2 implements AddPartitionV2 {
   Partition get partition;
   @override
   Gap get gap;
+
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14509,8 +15326,12 @@ mixin _$ModifyPartitionV2 {
   String get diskId => throw _privateConstructorUsedError;
   Partition get partition => throw _privateConstructorUsedError;
 
+  /// Serializes this ModifyPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ModifyPartitionV2CopyWith<ModifyPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14534,6 +15355,8 @@ class _$ModifyPartitionV2CopyWithImpl<$Res, $Val extends ModifyPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14572,6 +15395,8 @@ class __$$ModifyPartitionV2ImplCopyWithImpl<$Res>
       $Res Function(_$ModifyPartitionV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14619,12 +15444,14 @@ class _$ModifyPartitionV2Impl implements _ModifyPartitionV2 {
             const DeepCollectionEquality().equals(other.partition, partition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, diskId, const DeepCollectionEquality().hash(partition));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
@@ -14651,8 +15478,11 @@ abstract class _ModifyPartitionV2 implements ModifyPartitionV2 {
   String get diskId;
   @override
   Partition get partition;
+
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14666,8 +15496,12 @@ mixin _$ReformatDisk {
   String get diskId => throw _privateConstructorUsedError;
   String? get ptable => throw _privateConstructorUsedError;
 
+  /// Serializes this ReformatDisk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ReformatDiskCopyWith<ReformatDisk> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14691,6 +15525,8 @@ class _$ReformatDiskCopyWithImpl<$Res, $Val extends ReformatDisk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14729,6 +15565,8 @@ class __$$ReformatDiskImplCopyWithImpl<$Res>
       _$ReformatDiskImpl _value, $Res Function(_$ReformatDiskImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14775,11 +15613,13 @@ class _$ReformatDiskImpl implements _ReformatDisk {
             (identical(other.ptable, ptable) || other.ptable == ptable));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, diskId, ptable);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
@@ -14805,8 +15645,11 @@ abstract class _ReformatDisk implements ReformatDisk {
   String get diskId;
   @override
   String? get ptable;
+
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -1219,6 +1219,34 @@ Map<String, dynamic> _$$GuidedStorageTargetResizeImplToJson(
       r'$type': instance.$type,
     };
 
+_$GuidedStorageTargetEraseInstallImpl
+    _$$GuidedStorageTargetEraseInstallImplFromJson(Map<String, dynamic> json) =>
+        _$GuidedStorageTargetEraseInstallImpl(
+          diskId: json['disk_id'] as String,
+          partitionNumber: (json['partition_number'] as num).toInt(),
+          allowed: (json['allowed'] as List<dynamic>?)
+                  ?.map((e) => $enumDecode(_$GuidedCapabilityEnumMap, e))
+                  .toList() ??
+              const [],
+          disallowed: (json['disallowed'] as List<dynamic>?)
+                  ?.map((e) => GuidedDisallowedCapability.fromJson(
+                      e as Map<String, dynamic>))
+                  .toList() ??
+              const [],
+          $type: json[r'$type'] as String?,
+        );
+
+Map<String, dynamic> _$$GuidedStorageTargetEraseInstallImplToJson(
+        _$GuidedStorageTargetEraseInstallImpl instance) =>
+    <String, dynamic>{
+      'disk_id': instance.diskId,
+      'partition_number': instance.partitionNumber,
+      'allowed':
+          instance.allowed.map((e) => _$GuidedCapabilityEnumMap[e]!).toList(),
+      'disallowed': instance.disallowed.map((e) => e.toJson()).toList(),
+      r'$type': instance.$type,
+    };
+
 _$GuidedStorageTargetUseGapImpl _$$GuidedStorageTargetUseGapImplFromJson(
         Map<String, dynamic> json) =>
     _$GuidedStorageTargetUseGapImpl(

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
@@ -23,8 +23,12 @@ mixin _$PageConfigEntry {
   String? get image => throw _privateConstructorUsedError;
   bool get visible => throw _privateConstructorUsedError;
 
+  /// Serializes this PageConfigEntry to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PageConfigEntryCopyWith<PageConfigEntry> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -48,6 +52,8 @@ class _$PageConfigEntryCopyWithImpl<$Res, $Val extends PageConfigEntry>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -86,6 +92,8 @@ class __$$PageConfigEntryImplCopyWithImpl<$Res>
       _$PageConfigEntryImpl _value, $Res Function(_$PageConfigEntryImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -133,11 +141,13 @@ class _$PageConfigEntryImpl implements _PageConfigEntry {
             (identical(other.visible, visible) || other.visible == visible));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, image, visible);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
@@ -163,8 +173,11 @@ abstract class _PageConfigEntry implements PageConfigEntry {
   String? get image;
   @override
   bool get visible;
+
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -178,8 +191,12 @@ mixin _$PageConfig {
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages => throw _privateConstructorUsedError;
 
+  /// Serializes this PageConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PageConfigCopyWith<PageConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -203,6 +220,8 @@ class _$PageConfigCopyWithImpl<$Res, $Val extends PageConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -236,6 +255,8 @@ class __$$PageConfigImplCopyWithImpl<$Res>
       _$PageConfigImpl _value, $Res Function(_$PageConfigImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -284,12 +305,14 @@ class _$PageConfigImpl implements _PageConfig {
             const DeepCollectionEquality().equals(other._pages, _pages));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_pages));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
@@ -314,8 +337,11 @@ abstract class _PageConfig implements PageConfig {
   @override
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages;
+
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
@@ -23,12 +23,8 @@ mixin _$PageConfigEntry {
   String? get image => throw _privateConstructorUsedError;
   bool get visible => throw _privateConstructorUsedError;
 
-  /// Serializes this PageConfigEntry to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $PageConfigEntryCopyWith<PageConfigEntry> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -52,8 +48,6 @@ class _$PageConfigEntryCopyWithImpl<$Res, $Val extends PageConfigEntry>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -92,8 +86,6 @@ class __$$PageConfigEntryImplCopyWithImpl<$Res>
       _$PageConfigEntryImpl _value, $Res Function(_$PageConfigEntryImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -141,13 +133,11 @@ class _$PageConfigEntryImpl implements _PageConfigEntry {
             (identical(other.visible, visible) || other.visible == visible));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, image, visible);
 
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
@@ -173,11 +163,8 @@ abstract class _PageConfigEntry implements PageConfigEntry {
   String? get image;
   @override
   bool get visible;
-
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -191,12 +178,8 @@ mixin _$PageConfig {
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages => throw _privateConstructorUsedError;
 
-  /// Serializes this PageConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $PageConfigCopyWith<PageConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -220,8 +203,6 @@ class _$PageConfigCopyWithImpl<$Res, $Val extends PageConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -255,8 +236,6 @@ class __$$PageConfigImplCopyWithImpl<$Res>
       _$PageConfigImpl _value, $Res Function(_$PageConfigImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -305,14 +284,12 @@ class _$PageConfigImpl implements _PageConfig {
             const DeepCollectionEquality().equals(other._pages, _pages));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_pages));
 
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
@@ -337,11 +314,8 @@ abstract class _PageConfig implements PageConfig {
   @override
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages;
-
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -24,8 +24,12 @@ mixin _$ThemeConfig {
   String? get elevatedButtonColor => throw _privateConstructorUsedError;
   String? get elevatedButtonTextColor => throw _privateConstructorUsedError;
 
+  /// Serializes this ThemeConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ThemeConfigCopyWith<ThemeConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -52,6 +56,8 @@ class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,6 +104,8 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
       _$ThemeConfigImpl _value, $Res Function(_$ThemeConfigImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -159,12 +167,14 @@ class _$ThemeConfigImpl implements _ThemeConfig {
                 other.elevatedButtonTextColor == elevatedButtonTextColor));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, accentColor, elevatedButtonColor, elevatedButtonTextColor);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
@@ -193,8 +203,11 @@ abstract class _ThemeConfig implements ThemeConfig {
   String? get elevatedButtonColor;
   @override
   String? get elevatedButtonTextColor;
+
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -24,12 +24,8 @@ mixin _$ThemeConfig {
   String? get elevatedButtonColor => throw _privateConstructorUsedError;
   String? get elevatedButtonTextColor => throw _privateConstructorUsedError;
 
-  /// Serializes this ThemeConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ThemeConfigCopyWith<ThemeConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -56,8 +52,6 @@ class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -104,8 +98,6 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
       _$ThemeConfigImpl _value, $Res Function(_$ThemeConfigImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -167,14 +159,12 @@ class _$ThemeConfigImpl implements _ThemeConfig {
                 other.elevatedButtonTextColor == elevatedButtonTextColor));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, accentColor, elevatedButtonColor, elevatedButtonTextColor);
 
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
@@ -203,11 +193,8 @@ abstract class _ThemeConfig implements ThemeConfig {
   String? get elevatedButtonColor;
   @override
   String? get elevatedButtonTextColor;
-
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
This is work in progress for adding support for "Erase & Install" based the Subiquity work being done [here](https://github.com/canonical/subiquity/pull/2117). We wont be able to land this before [this bug](https://bugs.launchpad.net/subiquity/+bug/2091172) around logical partitions being re-labelled and breaking the mapping between installed OS and partition is fixed.

There are a still few UI quirks that need sorting out before this is production ready but the core functionality is now in place:

- [x] Selecting a guided target that requires scrolling on the "Disk Setup" page results in the list of targets jumping to the top, hiding the selection.
- [x] Hovering over a target that is partially scrolled off the bottom of the view results in broken background colors as the partially obscured widget applies its background color incorrectly (see second screenshot below).
- [ ] Text for the "Disk setup" section on the "Ready to Install" page can end up wrapping in an ugly way for erase & install targets (see third screenshot below).

cc. @anasereijo

![guided-targets](https://github.com/user-attachments/assets/8860d399-a3a3-40d9-b493-1c4c48247fdd)

![broken-background](https://github.com/user-attachments/assets/b1da2761-8064-4904-bdc7-8c08b2674171)

![confirmation](https://github.com/user-attachments/assets/dc6af65c-f1f0-4b6f-96ab-ad738d1815a6)


UDENG-5549