### PR TITLE
chore: pin pdfrx due to breaking changes

### DIFF
--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   meta: ^1.11.0
   nm: ^0.5.0
   path: ^1.8.3
-  pdfrx: ^1.0.52
+  pdfrx: <=1.0.99 # FIXME: pinned for compatibility with Flutter < 3.27
   platform: ^3.1.2
   safe_change_notifier: ^0.4.0
   stdlibc: ^0.1.4


### PR DESCRIPTION
Currently the CI [fails](https://github.com/canonical/ubuntu-desktop-provision/actions/runs/12812302578) on `main` due to a breaking change in `pdfrx`:
the package now seems to assume Flutter >=3.27 without having changed its dependencies.