### PR TITLE
feat: supporting setting a passphrase with TPM FDE

### DIFF
--- a/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -261,8 +261,58 @@ void main() {
     );
 
     await tester.testRecoveryKeyPage();
-    await tester.tapNext();
+    await tester.testPassphrasePage(passphrase: '', skip: true);
+
+    await tester.testIdentityPage(identity: identity, password: 'password');
+    await expectIdentity(identity);
+
+    await tester.testTimezonePage();
+    await tester.testConfirmPage();
+    await tester.testInstallPage();
+
+    final windowClosed = YaruTestWindow.waitForClosed();
+    await tester.tapContinueTesting();
+    await expectLater(windowClosed, completes);
+
+    await verifySubiquityConfig(
+      identity: identity,
+      capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+    );
+  });
+
+  testWidgets('tpm with passphrase', (tester) async {
+    const identity = Identity(
+      realname: 'User',
+      hostname: 'ubuntu',
+      username: 'user',
+    );
+
+    await tester.runApp(
+      () => app.main([
+        '--source-catalog=examples/sources/tpm.yaml',
+        '--dry-run-config=examples/dry-run-configs/tpm.yaml',
+        '--',
+        '--bootloader=uefi',
+      ]),
+    );
+
     await tester.pumpAndSettle();
+    await tester.testLocalePage();
+    await tester.testAccessibilityPage();
+    await tester.testKeyboardPage();
+    await tester.testNetworkPage(mode: ConnectMode.none);
+    await tester.testRefreshPage();
+    await tester.testAutoinstallPage();
+    await tester.testSourceSelectionPage();
+    await tester.testCodecsAndDriversPage();
+
+    await tester.testStoragePage(
+      type: StorageType.erase,
+      guidedCapability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+    );
+
+    await tester.testRecoveryKeyPage();
+    await tester.testPassphrasePage(passphrase: 'passphrase');
 
     await tester.testIdentityPage(identity: identity, password: 'password');
     await expectIdentity(identity);

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -185,6 +185,10 @@
   "choosePassphraseMismatch": "The passphrases do not match",
   "choosePassphraseInfoHeader": "Make sure you save your passphrase",
   "choosePassphraseInfoBody": "If you lose your passphrase, you will lose all of your data.",
+  "chooseOptionalPassphraseHeader": "Create a passphrase (Optional)",
+  "chooseOptionalPassphraseBody": "A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.",
+  "chooseOptionalPassphraseInfoHeader": "A passphrase does not replace your recovery keys",
+  "chooseOptionalPassphraseInfoBody": "Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.",
   "createPassphrase": "Create a passphrase",
   "confirmPassphrase": "Confirm the passphrase",
   "installationTypeTitle": "Disk setup",
@@ -929,15 +933,19 @@
     }
   },
   "recoveryKeyTitle": "TPM recovery key",
-  "recoveryKeyCommand": "You can access your recovery key after installation with the following command:",
-  "recoveryKeyWarning": "<font color=\"{color}\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.",
-  "@recoveryKeyWarning": {
+  "recoveryKeyHeader": "Getting a recovery key",
+  "recoveryKeyInfoHeader": "You might lose all of your data without a recovery key",
+  "recoveryKeyInfoBody": "Get a recovery key as soon as you first boot into {distro} and store it somewhere safe.",
+  "@recoveryKeyInfoBody": {
     "placeholders": {
-      "color": {
+      "distro": {
         "type": "String"
       }
     }
   },
+  "recoveryKeyCommand": "You can access your recovery key after installation with the following command:",
+  "recoveryKeyStorageAdvice": "Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.",
+  "recoveryKeyConfirmation": "I understand that I may lose all of my data if I do not have a recovery key",
   "landscapeMagicAttachInstructions": "Scan the QR code or enter the code below at <a href=\"https://{url}\">{url}</a>",
   "@landscapeMagicAttachInstructions": {
     "type": "text",

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -183,12 +183,12 @@
   "choosePassphraseConfirmHint": "Confirm the passphrase",
   "choosePassphraseRequired": "A passphrase is required",
   "choosePassphraseMismatch": "The passphrases do not match",
-  "choosePassphraseInfoHeader": "Make sure you save your passphrase",
-  "choosePassphraseInfoBody": "If you lose your passphrase, you will lose all of your data.",
-  "chooseOptionalPassphraseHeader": "Create a passphrase (Optional)",
-  "chooseOptionalPassphraseBody": "A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.",
-  "chooseOptionalPassphraseInfoHeader": "A passphrase does not replace your recovery keys",
-  "chooseOptionalPassphraseInfoBody": "Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.",
+  "choosePassphraseInfoHeader": "Store your passphrase somewhere safe",
+  "choosePassphraseInfoBody": "If you lose your passphrase, you will lose all your data.",
+  "chooseOptionalPassphraseHeader": "Create a passphrase (optional)",
+  "chooseOptionalPassphraseBody": "A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later",
+  "chooseOptionalPassphraseInfoHeader": "Store your passphrase and recovery key somewhere safe",
+  "chooseOptionalPassphraseInfoBody": "If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.",
   "createPassphrase": "Create a passphrase",
   "confirmPassphrase": "Confirm the passphrase",
   "installationTypeTitle": "Disk setup",
@@ -933,9 +933,9 @@
     }
   },
   "recoveryKeyTitle": "TPM recovery key",
-  "recoveryKeyHeader": "Getting a recovery key",
-  "recoveryKeyInfoHeader": "You might lose all of your data without a recovery key",
-  "recoveryKeyInfoBody": "Get a recovery key as soon as you first boot into {distro} and store it somewhere safe.",
+  "recoveryKeyHeader": "Get a recovery key",
+  "recoveryKeyInfoHeader": "You may lose all your data without a recovery key",
+  "recoveryKeyInfoBody": "Get a recovery key as soon as you first log into {distro} and store it somewhere safe.",
   "@recoveryKeyInfoBody": {
     "placeholders": {
       "distro": {
@@ -943,9 +943,9 @@
       }
     }
   },
-  "recoveryKeyCommand": "You can access your recovery key after installation with the following command:",
-  "recoveryKeyStorageAdvice": "Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.",
-  "recoveryKeyConfirmation": "I understand that I may lose all of my data if I do not have a recovery key",
+  "recoveryKeyCommand": "To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:",
+  "recoveryKeyStorageAdvice": "Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.",
+  "recoveryKeyConfirmation": "I understand I may lose all my data if I don't have a recovery key",
   "landscapeMagicAttachInstructions": "Scan the QR code or enter the code below at <a href=\"https://{url}\">{url}</a>",
   "@landscapeMagicAttachInstructions": {
     "type": "text",

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -761,6 +761,30 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'If you lose your passphrase, you will lose all of your data.'**
   String get choosePassphraseInfoBody;
 
+  /// No description provided for @chooseOptionalPassphraseHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Create a passphrase (Optional)'**
+  String get chooseOptionalPassphraseHeader;
+
+  /// No description provided for @chooseOptionalPassphraseBody.
+  ///
+  /// In en, this message translates to:
+  /// **'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.'**
+  String get chooseOptionalPassphraseBody;
+
+  /// No description provided for @chooseOptionalPassphraseInfoHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'A passphrase does not replace your recovery keys'**
+  String get chooseOptionalPassphraseInfoHeader;
+
+  /// No description provided for @chooseOptionalPassphraseInfoBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.'**
+  String get chooseOptionalPassphraseInfoBody;
+
   /// No description provided for @createPassphrase.
   ///
   /// In en, this message translates to:
@@ -1955,17 +1979,41 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'TPM recovery key'**
   String get recoveryKeyTitle;
 
+  /// No description provided for @recoveryKeyHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Getting a recovery key'**
+  String get recoveryKeyHeader;
+
+  /// No description provided for @recoveryKeyInfoHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'You might lose all of your data without a recovery key'**
+  String get recoveryKeyInfoHeader;
+
+  /// No description provided for @recoveryKeyInfoBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Get a recovery key as soon as you first boot into {distro} and store it somewhere safe.'**
+  String recoveryKeyInfoBody(String distro);
+
   /// No description provided for @recoveryKeyCommand.
   ///
   /// In en, this message translates to:
   /// **'You can access your recovery key after installation with the following command:'**
   String get recoveryKeyCommand;
 
-  /// No description provided for @recoveryKeyWarning.
+  /// No description provided for @recoveryKeyStorageAdvice.
   ///
   /// In en, this message translates to:
-  /// **'<font color=\"{color}\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.'**
-  String recoveryKeyWarning(String color);
+  /// **'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.'**
+  String get recoveryKeyStorageAdvice;
+
+  /// No description provided for @recoveryKeyConfirmation.
+  ///
+  /// In en, this message translates to:
+  /// **'I understand that I may lose all of my data if I do not have a recovery key'**
+  String get recoveryKeyConfirmation;
 
   /// No description provided for @landscapeMagicAttachInstructions.
   ///

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -752,37 +752,37 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @choosePassphraseInfoHeader.
   ///
   /// In en, this message translates to:
-  /// **'Make sure you save your passphrase'**
+  /// **'Store your passphrase somewhere safe'**
   String get choosePassphraseInfoHeader;
 
   /// No description provided for @choosePassphraseInfoBody.
   ///
   /// In en, this message translates to:
-  /// **'If you lose your passphrase, you will lose all of your data.'**
+  /// **'If you lose your passphrase, you will lose all your data.'**
   String get choosePassphraseInfoBody;
 
   /// No description provided for @chooseOptionalPassphraseHeader.
   ///
   /// In en, this message translates to:
-  /// **'Create a passphrase (Optional)'**
+  /// **'Create a passphrase (optional)'**
   String get chooseOptionalPassphraseHeader;
 
   /// No description provided for @chooseOptionalPassphraseBody.
   ///
   /// In en, this message translates to:
-  /// **'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.'**
+  /// **'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later'**
   String get chooseOptionalPassphraseBody;
 
   /// No description provided for @chooseOptionalPassphraseInfoHeader.
   ///
   /// In en, this message translates to:
-  /// **'A passphrase does not replace your recovery keys'**
+  /// **'Store your passphrase and recovery key somewhere safe'**
   String get chooseOptionalPassphraseInfoHeader;
 
   /// No description provided for @chooseOptionalPassphraseInfoBody.
   ///
   /// In en, this message translates to:
-  /// **'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.'**
+  /// **'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.'**
   String get chooseOptionalPassphraseInfoBody;
 
   /// No description provided for @createPassphrase.
@@ -1982,37 +1982,37 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @recoveryKeyHeader.
   ///
   /// In en, this message translates to:
-  /// **'Getting a recovery key'**
+  /// **'Get a recovery key'**
   String get recoveryKeyHeader;
 
   /// No description provided for @recoveryKeyInfoHeader.
   ///
   /// In en, this message translates to:
-  /// **'You might lose all of your data without a recovery key'**
+  /// **'You may lose all your data without a recovery key'**
   String get recoveryKeyInfoHeader;
 
   /// No description provided for @recoveryKeyInfoBody.
   ///
   /// In en, this message translates to:
-  /// **'Get a recovery key as soon as you first boot into {distro} and store it somewhere safe.'**
+  /// **'Get a recovery key as soon as you first log into {distro} and store it somewhere safe.'**
   String recoveryKeyInfoBody(String distro);
 
   /// No description provided for @recoveryKeyCommand.
   ///
   /// In en, this message translates to:
-  /// **'You can access your recovery key after installation with the following command:'**
+  /// **'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:'**
   String get recoveryKeyCommand;
 
   /// No description provided for @recoveryKeyStorageAdvice.
   ///
   /// In en, this message translates to:
-  /// **'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.'**
+  /// **'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.'**
   String get recoveryKeyStorageAdvice;
 
   /// No description provided for @recoveryKeyConfirmation.
   ///
   /// In en, this message translates to:
-  /// **'I understand that I may lose all of my data if I do not have a recovery key'**
+  /// **'I understand I may lose all my data if I don\'t have a recovery key'**
   String get recoveryKeyConfirmation;
 
   /// No description provided for @landscapeMagicAttachInstructions.

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Калі будзе страчана парольная фраза, будуць страчаны і ўсе вашы даныя.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Стварыць парольную фразу';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ аднаўлення TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Вы можаце атрымаць доступ да ключа аднаўлення пасля ўсталявання з дапамогай наступнай каманды:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Калі будзе страчана парольная фраза, будуць страчаны і ўсе вашы даныя.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Стварыць парольную фразу';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ аднаўлення TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Вы можаце атрымаць доступ да ключа аднаўлення пасля ўсталявання з дапамогай наступнай каманды:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Папярэджанне:</font> калі вы страціце гэты ключ бяспекі, то разам з ім вы згубіце ўсе даныя. Пры неабходнасці запішыце і захоўвайце яго ў надзейным месцы.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Pokud ztratíte přístupové heslo, ztratíte všechna svá data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Vytvořit přístupové heslo';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Obnovovací klíč k TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Po dokončení instalace je možné si nechat obnovovací klíč zobrazit pomocí následujícího příkazu:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Pokud ztratíte přístupové heslo, ztratíte všechna svá data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Vytvořit přístupové heslo';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Obnovovací klíč k TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Po dokončení instalace je možné si nechat obnovovací klíč zobrazit pomocí následujícího příkazu:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Varování:</font> Pokud klíč k zabezpečení ztratíte, budou veškerá data ztracena. Pokud vám to pomůže, šifrovací klíč si zapište na papír a ten si bezpečně uložte někam mimo počítač.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Hvis du mister din adgangskode, går alle dine data tabt.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Opret en adgangskode';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-genoprettelsesnøgle';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Du kan tilgå din genoprettelsesnøgle efter installation med følgende kommando:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Advarsel:</font> Hvis du mister denne sikkerhedsnøgle, tabes alle data. Hvis du har brug for det, så skriv din nøgle ned og gem den på et andet, sikkert sted.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Hvis du mister din adgangskode, går alle dine data tabt.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Opret en adgangskode';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-genoprettelsesnøgle';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Du kan tilgå din genoprettelsesnøgle efter installation med følgende kommando:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Wenn Sie Ihre Passphrase verlieren, verlieren Sie alle Ihre Daten.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Passphrase erstellen';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-Wiederherstellungsschlüssel';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Sie können nach der Installation mit folgendem Befehl auf Ihren Wiederherstellungsschlüssel zugreifen:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Wenn Sie Ihre Passphrase verlieren, verlieren Sie alle Ihre Daten.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Passphrase erstellen';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-Wiederherstellungsschlüssel';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Sie können nach der Installation mit folgendem Befehl auf Ihren Wiederherstellungsschlüssel zugreifen:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warnung:</font> Wenn Sie diesen Sicherheitsschlüssel verlieren, sind alle Daten verloren. Bei Bedarf notieren Sie sich den Schlüssel und bewahren ihn an einem sicheren Ort auf.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Se vi forgesos vian pasfrazon, vi perdos ĉiom da viaj datenoj.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Krei pasfrazon';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ŝlosilo por aparato-baza ĉifrado';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Post instalo, vi povas legi vian restaŭran ŝlosilon per la jena komando:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Averto:</font> Se vi perdos ĉi tiun sekurigan ŝlosilon, vi perdos ĉiom da datenoj. Skribu vian ŝlosilon kaj konservu ĝin en sekura alia loko, se tio necesas.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Se vi forgesos vian pasfrazon, vi perdos ĉiom da viaj datenoj.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Krei pasfrazon';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ŝlosilo por aparato-baza ĉifrado';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Post instalo, vi povas legi vian restaŭran ŝlosilon per la jena komando:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Si pierde su contraseña, perderá todos sus datos.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Crear una contraseña';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clave de recuperación para el TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Puede acceder a tu clave de recuperación después de la instalación con el siguiente comando:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Si pierde su contraseña, perderá todos sus datos.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Crear una contraseña';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clave de recuperación para el TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Puede acceder a tu clave de recuperación después de la instalación con el siguiente comando:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Advertencia:</font> Si pierdes esta clave de seguridad, se perderán todos los datos. Si lo necesitas, anota tu clave y guárdala en un lugar seguro.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'اگر عبارت عبورتان را گم کنید، همهٔ داده‌هایتان از دست خواهد رفت.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'ایجاد عبارت عبور';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'کلید بازیابی TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
   String get choosePassphraseInfoBody => 'اگر عبارت عبورتان را گم کنید، همهٔ داده‌هایتان از دست خواهد رفت.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'ایجاد عبارت عبور';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'کلید بازیابی TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Jos unohdat tai kadotat tunnuslauseen, menetät pääsyn dataan.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Luo tunnuslause';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-palautusavain';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Pääset palautusavaimeesi asennuksen jälkeen seuraavalla komennolla:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Varoitus:</font> Jos kadotat tämän turva-avaimen, kaikki data menetetään. Kirjoita tarvittaessa avain muistiin johonkin turvalliseen paikkaan.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Jos unohdat tai kadotat tunnuslauseen, menetät pääsyn dataan.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Luo tunnuslause';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-palautusavain';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Pääset palautusavaimeesi asennuksen jälkeen seuraavalla komennolla:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Si vous perdez votre phrase secrète, vous perdrez toutes vos données.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Créer une phrase secrète';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clé de récupération du TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Vous pouvez accéder à votre clé de récupération après l\'installation avec la commande suivante :';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Si vous perdez votre phrase secrète, vous perdrez toutes vos données.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Créer une phrase secrète';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clé de récupération du TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Vous pouvez accéder à votre clé de récupération après l\'installation avec la commande suivante :';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Attention :</font> Si vous oubliez cette clé de sécurité, toutes les données seront perdues. Si vous avez besoin, notez votre clé et conservez-la dans un endroit sûr.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Má chailleann tú do phasfhrása, caillfidh tú do chuid sonraí go léir.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Cruthaigh pasfhrása';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Eochair aisghabhála TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Is féidir leat rochtain a fháil ar d\'eochair a ghnóthú tar éis a shuiteáil leis an ordú seo a leanas:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Rabhadh:</font> Má chailleann tú an eochair shlándála seo, caillfear na sonraí go léir. Más gá duit, scríobh síos d’eochair agus coinnigh in áit shábháilte í.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Má chailleann tú do phasfhrása, caillfidh tú do chuid sonraí go léir.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Cruthaigh pasfhrása';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Eochair aisghabhála TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Is féidir leat rochtain a fháil ar d\'eochair a ghnóthú tar éis a shuiteáil leis an ordú seo a leanas:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'אובדן מילת הצופן יוביל לאובדן המידע שלך.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'יצירת מילת צופן';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'מפתח שחזור TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'הגישה למפתח השחזור שלך לאחר ההתקנה אפשרית באמצעות הפקודה:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">אזהרה:</font> איבוד מפתח האבטחה יוביל לאיבוד הנתונים שלך. במידת הצורך, כדאי לכתוב את המפתח שלך על נייר ולשמור אותו במקום בטוח בנפרד.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'אובדן מילת הצופן יוביל לאובדן המידע שלך.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'יצירת מילת צופן';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'מפתח שחזור TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'הגישה למפתח השחזור שלך לאחר ההתקנה אפשרית באמצעות הפקודה:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Ha elveszíti a jelmondatot, elveszíti az összes adatát.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Jelmondat létrehozása';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM helyreállítási kulcs';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'A helyreállítási kulcsot a telepítés után érheti el a következő paranccsal:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Figyelmeztetés:</font> ha elveszíti ezt a biztonsági kulcsot, akkor az összes adat elvész. Ha szükséges, írja le a kulcsot, és tartsa valahol máshol egy biztonságos helyen.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Ha elveszíti a jelmondatot, elveszíti az összes adatát.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Jelmondat létrehozása';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM helyreállítási kulcs';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'A helyreállítási kulcsot a telepítés után érheti el a következő paranccsal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Jika Anda kehilangan frasa sandi Anda, Anda akan kehilangan semua data Anda.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Buat frasa sandi';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Kunci pemulihan TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Anda dapat mengakses kunci keamanan setelah instalasi dengan perintah berikut:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Peringatan:</font> Jika Anda kehilangan kunci keamanan, semua data akan hilang. Jika perlu, tuliskan kunci Anda dan simpan di tempat yang aman.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Jika Anda kehilangan frasa sandi Anda, Anda akan kehilangan semua data Anda.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Buat frasa sandi';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Kunci pemulihan TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Anda dapat mengakses kunci keamanan setelah instalasi dengan perintah berikut:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'もしパスフレーズを失うと、すべてのデータが消失します。';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'パスフレーズを作成';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPMリカバリーキー';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'インストール後、次のコマンドでリカバリーキーがわかります:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'もしパスフレーズを失うと、すべてのデータが消失します。';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'パスフレーズを作成';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPMリカバリーキー';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'インストール後、次のコマンドでリカバリーキーがわかります:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">警告:</font> セキュリティキーを紛失すると、すべてのデータを失います。必要であればキーを書き出し、安全な場所に保管してください。';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => '암호를 분실하면 모든 데이터를 잃게 됩니다.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => '암호 만들기';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 복구 키';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => '설치 후 다음 명령을 사용하여 복구 키에 액세스할 수 있습니다:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => '암호를 분실하면 모든 데이터를 잃게 됩니다.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => '암호 만들기';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 복구 키';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => '설치 후 다음 명령을 사용하여 복구 키에 액세스할 수 있습니다:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">경고:</font> 이 보안 키를 분실하면 모든 데이터가 손실됩니다. 필요한 경우 키를 적어서 다른 안전한 곳에 보관하세요.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Įspėjimas:</font> Jei prarasite šį saugumo raktą, visi duomenys bus prarasti. Rekomenduojame užsirašyti šį raktą ir laikyti jį saugioje vietoje atokiai nuo šio kompiuterio.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Mister du passordet mister du også all dataen din.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Opprett et passord';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-gjenopprettingsnøkkel';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Mister du passordet mister du også all dataen din.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Opprett et passord';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-gjenopprettingsnøkkel';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Se perdètz vòstra frasa secrèta, perdretz totas vòstras donadas.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Crear una frasa secrèta';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clau de recuperacion del TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Podètz accedir a vòstra clau de recuperacion aprèp l’installacion amb la comanda seguenta :';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Atencion :</font> S’oblidetz aquesta clau de seguretat, totas las donadas seràn perdudas. Se cal, notatz vòstra clau e servatz-la dins un endrech segur.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Se perdètz vòstra frasa secrèta, perdretz totas vòstras donadas.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Crear una frasa secrèta';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clau de recuperacion del TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Podètz accedir a vòstra clau de recuperacion aprèp l’installacion amb la comanda seguenta :';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Jeśli zgubisz hasło, utracisz wszystkie swoje dane.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Utwórz hasło';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Klucz odzyskiwania modułu TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Możesz uzyskać dostęp do klucza odzyskiwania po instalacji za pomocą następującego polecenia:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Jeśli zgubisz hasło, utracisz wszystkie swoje dane.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Utwórz hasło';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Klucz odzyskiwania modułu TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Możesz uzyskać dostęp do klucza odzyskiwania po instalacji za pomocą następującego polecenia:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Ostrzeżenie:</font> jeśli zgubisz ten klucz bezpieczeństwa, wszystkie dane zostaną utracone. W razie potrzeby zapisz swój klucz i przechowuj go w bezpiecznym miejscu gdzie indziej.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Se perder a sua palavra-passe, perderá todos os seus dados.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Crie uma palavra-passe';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Chave de recuperação TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Você pode acessar à sua chave de recuperação após a instalação com o seguinte comando:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Se perder a sua palavra-passe, perderá todos os seus dados.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Crie uma palavra-passe';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Chave de recuperação TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Você pode acessar à sua chave de recuperação após a instalação com o seguinte comando:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Aviso:</font> Se você perder esta chave de segurança, todos os dados serão perdidos. Se precisar, anote a sua chave e guarde-a num local seguro noutro lugar.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {
@@ -2030,9 +2054,4 @@ class UbuntuBootstrapLocalizationsPtBr extends UbuntuBootstrapLocalizationsPt {
 
   @override
   String get recoveryKeyCommand => 'Você pode acessar sua chave de recuperação após a instalação com o seguinte comando:';
-
-  @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Atenção:</font> Se você perder essa chave de segurança, todos os dados serão perdidos. Se precisar, anote sua chave e guarde-a em um lugar seguro externo.';
-  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Если Вы потеряете парольную фразу, Вы потеряете все свои данные.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Создать парольную фразу';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ восстановления TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Вы можете получить доступ к ключу восстановления после установки с помощью следующей команды:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Предупреждение:</font> Если вы потеряете этот ключ безопасности, то все данные будут потеряны. Если вам нужно, запишите свой ключ и храните его в любом безопасном месте.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Если Вы потеряете парольную фразу, Вы потеряете все свои данные.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Создать парольную фразу';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ восстановления TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Вы можете получить доступ к ключу восстановления после установки с помощью следующей команды:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM ප්‍රතිසාධන කේතය';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM ප්‍රතිසාධන කේතය';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Ak stratíte prístupovú frázu, stratíte všetky svoje údaje.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Vytvoriť prístupovú frázu';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kľúč na obnovenie';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'K obnovovaciemu kľúču sa dostanete po inštalácii pomocou nasledujúceho príkazu:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Upozornenie:</font> Pokiaľ tento bezpečnostný kľúč zabudnete, k svojim dátam sa už nedostanete. Ak vám to pomôže, bezpečnostný kľúč si zapíšte na papier a ten si bezpečne uložte niekam mimo počítača.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Ak stratíte prístupovú frázu, stratíte všetky svoje údaje.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Vytvoriť prístupovú frázu';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kľúč na obnovenie';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'K obnovovaciemu kľúču sa dostanete po inštalácii pomocou nasledujúceho príkazu:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Ако изгубите лозинку, изгубићете све своје податке.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Направите лозинку';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM кључ за опоравак';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Можете приступити свом кључу за опоравак након инсталације помоћу следеће команде:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Упозорење:</font> Ако изгубите овај безбедносни кључ, сви подаци ће бити изгубљени. Ако је потребно, запишите свој кључ и чувајте га на безбедном месту.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Ако изгубите лозинку, изгубићете све своје податке.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Направите лозинку';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM кључ за опоравак';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Можете приступити свом кључу за опоравак након инсталације помоћу следеће команде:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Om du tappar bort din lösenfras kommer du att förlora all din data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Skapa en lösenfras';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM återställningsnyckel';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Du kan komma åt din återställningsnyckel efter installationen med följande kommando:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Varning:</font> Om du förlorar denna säkerhetsnyckel, så kommer all data att gå förlorad. Om du behöver, skriv ner din nyckel och förvara den på ett säkert ställe någon annanstans.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Om du tappar bort din lösenfras kommer du att förlora all din data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Skapa en lösenfras';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM återställningsnyckel';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Du kan komma åt din återställningsnyckel efter installationen med följande kommando:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kurtarma anahtarı';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Kurtarma anahtarınıza kurulumdan sonra aşağıdaki komutla erişebilirsiniz:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Uyarı:</font> Bu güvenlik anahtarını kaybederseniz tüm veriler kaybolur. Gerekirse, anahtarınızı bir yere yazın ve güvenli başka bir yerde saklayın.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kurtarma anahtarı';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Kurtarma anahtarınıza kurulumdan sonra aşağıdaki komutla erişebilirsiniz:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Якщо ви втратите парольну фразу, ви втратите всі свої дані.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Створіть парольну фразу';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ відновлення TPM';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'Ви можете отримати доступ до ключа відновлення після встановлення за допомогою такої команди:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Попередження:</font> Якщо ви втратите цей ключ безпеки, всі дані буде втрачено. Якщо вам потрібно, запишіть свій ключ і зберігайте його в безпечному місці.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'Якщо ви втратите парольну фразу, ви втратите всі свої дані.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Створіть парольну фразу';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ відновлення TPM';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => 'Ви можете отримати доступ до ключа відновлення після встановлення за допомогою такої команди:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => 'Create a passphrase';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">Warning:</font> If you lose this security key, all data will be lost. If you need to, write down your key and keep it in a safe place elsewhere.';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -290,22 +290,22 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get choosePassphraseMismatch => 'The passphrases do not match';
 
   @override
-  String get choosePassphraseInfoHeader => 'Make sure you save your passphrase';
+  String get choosePassphraseInfoHeader => 'Store your passphrase somewhere safe';
 
   @override
-  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all of your data.';
+  String get choosePassphraseInfoBody => 'If you lose your passphrase, you will lose all your data.';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => 'Create a passphrase';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
-  String get recoveryKeyCommand => 'You can access your recovery key after installation with the following command:';
+  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -296,6 +296,18 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => '如果您丢失了密码，所有数据都将丢失。';
 
   @override
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+
+  @override
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+
+  @override
+  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+
+  @override
+  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+
+  @override
   String get createPassphrase => '创建密码';
 
   @override
@@ -1033,12 +1045,24 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 恢复密钥';
 
   @override
+  String get recoveryKeyHeader => 'Getting a recovery key';
+
+  @override
+  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+
+  @override
+  String recoveryKeyInfoBody(String distro) {
+    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+  }
+
+  @override
   String get recoveryKeyCommand => '在安装完成后，您可以使用如下命令获取恢复密钥：';
 
   @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">警告：</font>如果您丢失了恢复密钥，所有数据都将丢失。如果需要，请写下恢复密钥，将其保存在其他安全的地方。';
-  }
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+
+  @override
+  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {
@@ -2030,9 +2054,4 @@ class UbuntuBootstrapLocalizationsZhTw extends UbuntuBootstrapLocalizationsZh {
 
   @override
   String get recoveryKeyCommand => '安裝後，您可以透過以下指令來取得您的復原密鑰：';
-
-  @override
-  String recoveryKeyWarning(String color) {
-    return '<font color=\"$color\">警告：</font>若您遺失此安全密鑰，您將無法存取您的資料。若有必要，請將安全密鑰寫下，並保存在安全的地方。';
-  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -296,16 +296,16 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get choosePassphraseInfoBody => '如果您丢失了密码，所有数据都将丢失。';
 
   @override
-  String get chooseOptionalPassphraseHeader => 'Create a passphrase (Optional)';
+  String get chooseOptionalPassphraseHeader => 'Create a passphrase (optional)';
 
   @override
-  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will be able to change the passphrase later but not remove it.';
+  String get chooseOptionalPassphraseBody => 'A passphrase can help protect your data even if your hardware gets compromised. You will need to enter the passphrase every time you turn on your computer. You will not be able to remove it later';
 
   @override
-  String get chooseOptionalPassphraseInfoHeader => 'A passphrase does not replace your recovery keys';
+  String get chooseOptionalPassphraseInfoHeader => 'Store your passphrase and recovery key somewhere safe';
 
   @override
-  String get chooseOptionalPassphraseInfoBody => 'Save both of them somewhere safe: if you lose them, you will lose all of your data. You can manage your passphrase and recovery keys with the snap command in the terminal.';
+  String get chooseOptionalPassphraseInfoBody => 'If you lose your passphrase, you will lose all your data. The passphrase does not replace the recovery key or your user password.';
 
   @override
   String get createPassphrase => '创建密码';
@@ -1045,24 +1045,24 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 恢复密钥';
 
   @override
-  String get recoveryKeyHeader => 'Getting a recovery key';
+  String get recoveryKeyHeader => 'Get a recovery key';
 
   @override
-  String get recoveryKeyInfoHeader => 'You might lose all of your data without a recovery key';
+  String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
   String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first boot into $distro and store it somewhere safe.';
+    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
   }
 
   @override
   String get recoveryKeyCommand => '在安装完成后，您可以使用如下命令获取恢复密钥：';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Recovery keys let you decrypt the disk if the system detects any hardware changes on boot.';
+  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
 
   @override
-  String get recoveryKeyConfirmation => 'I understand that I may lose all of my data if I do not have a recovery key';
+  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
 
   @override
   String landscapeMagicAttachInstructions(Object url) {

--- a/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_model.dart
@@ -50,7 +50,7 @@ class PassphraseModel extends SafeChangeNotifier {
       passphrase.isNotEmpty && passphrase == confirmedPassphrase;
 
   /// Whether the user can skip providing a passphrase
-  bool get canSkip => isTpm ? passphrase.isEmpty : false;
+  bool get canSkip => isTpm && passphrase.isEmpty;
 
   /// Initializes the model.
   Future<bool> init() async {

--- a/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
@@ -25,7 +25,7 @@ class PassphrasePage extends ConsumerWidget {
       passphraseModelProvider.select((model) => model.isTpm),
     );
     final lang = UbuntuBootstrapLocalizations.of(context);
-    final l10n = UbuntuLocalizations.of(context);
+    final ulang = UbuntuLocalizations.of(context);
 
     return HorizontalPage(
       windowTitle: lang.choosePassphraseTitle,
@@ -45,8 +45,8 @@ class PassphrasePage extends ConsumerWidget {
             label: ref.watch(
               passphraseModelProvider.select((model) => model.canSkip),
             )
-                ? l10n.skipLabel
-                : l10n.nextLabel,
+                ? ulang.skipLabel
+                : ulang.nextLabel,
           ),
         ],
       ),

--- a/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_page.dart
@@ -21,29 +21,48 @@ class PassphrasePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isTpm = ref.watch(
+      passphraseModelProvider.select((model) => model.isTpm),
+    );
     final lang = UbuntuBootstrapLocalizations.of(context);
+    final l10n = UbuntuLocalizations.of(context);
+
     return HorizontalPage(
       windowTitle: lang.choosePassphraseTitle,
-      title: lang.choosePassphraseHeader,
+      title: isTpm
+          ? lang.chooseOptionalPassphraseHeader
+          : lang.choosePassphraseHeader,
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
         trailing: [
           NextWizardButton(
             enabled: ref.watch(
-              passphraseModelProvider.select((model) => model.isValid),
+              passphraseModelProvider
+                  .select((model) => model.isValid || model.canSkip),
             ),
             onNext: ref.read(passphraseModelProvider).savePassphrase,
             onReturn: ref.read(passphraseModelProvider).loadPassphrase,
+            label: ref.watch(
+              passphraseModelProvider.select((model) => model.canSkip),
+            )
+                ? l10n.skipLabel
+                : l10n.nextLabel,
           ),
         ],
       ),
       children: <Widget>[
-        Text(lang.choosePassphraseBody),
+        Text(
+          isTpm ? lang.chooseOptionalPassphraseBody : lang.choosePassphraseBody,
+        ),
         const PassphraseFormField(),
         const ConfirmPassphraseFormField(),
         InfoBox(
-          title: lang.choosePassphraseInfoHeader,
-          subtitle: lang.choosePassphraseInfoBody,
+          title: isTpm
+              ? lang.choosePassphraseInfoHeader
+              : lang.choosePassphraseInfoHeader,
+          subtitle: isTpm
+              ? lang.chooseOptionalPassphraseInfoBody
+              : lang.choosePassphraseInfoBody,
           type: InfoBoxType.warning,
           isThreeLine: true,
         ),

--- a/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_widgets.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_widgets.dart
@@ -6,6 +6,8 @@ import 'package:ubuntu_bootstrap/pages/storage/passphrase/passphrase_model.dart'
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru/icons.dart';
 
+// TODO: this will need to be conditionally hooked up to the /storage/v2/calculate_entropy
+//       endpoint in Subiquity once it is available
 class PassphraseFormField extends ConsumerWidget {
   const PassphraseFormField({super.key, this.fieldWidth});
 

--- a/apps/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_model.dart
@@ -1,18 +1,34 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_bootstrap/services/storage_service.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 const kRecoveryKeyCommand = 'snap recovery --show-keys';
 
-final recoveryKeyModelProvider = Provider(
-  (_) => RecoveryKeyModel(getService<StorageService>()),
+final recoveryKeyModelProvider = ChangeNotifierProvider(
+  (_) => RecoveryKeyModel(storage: getService<StorageService>()),
 );
 
-class RecoveryKeyModel {
-  RecoveryKeyModel(this._storage);
+class RecoveryKeyModel extends SafeChangeNotifier {
+  RecoveryKeyModel({
+    required StorageService storage,
+    bool confirmed = false,
+  })  : _storage = storage,
+        _confirmed = confirmed;
 
   final StorageService _storage;
+  bool _confirmed;
+
+  bool get confirmed => _confirmed;
+
+  void setConfirmed(bool? confirmed) {
+    if (confirmed == null || _confirmed == confirmed) {
+      return;
+    }
+    _confirmed = confirmed;
+    notifyListeners();
+  }
 
   Future<bool> init() async {
     return switch (_storage.guidedCapability) {

--- a/apps/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/recovery_key/recovery_key_page.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/recovery_key/recovery_key_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
+import 'package:ubuntu_bootstrap/widgets/info_box.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
+import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
-class RecoveryKeyPage extends StatelessWidget {
+class RecoveryKeyPage extends ConsumerWidget {
   const RecoveryKeyPage({super.key});
 
   static Future<bool> load(WidgetRef ref) {
@@ -19,51 +21,51 @@ class RecoveryKeyPage extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = UbuntuBootstrapLocalizations.of(context);
-    return WizardPage(
-      title: YaruWindowTitleBar(
-        title: Text(l10n.recoveryKeyTitle),
-      ),
-      content: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(l10n.recoveryKeyCommand),
-          const SizedBox(height: kWizardSpacing / 2),
-          Container(
-            color: Theme.of(context).highlightColor,
-            padding:
-                const EdgeInsetsDirectional.only(start: 4, top: 2, bottom: 3),
-            child: SelectableText(
-              kRecoveryKeyCommand,
-              style: TextStyle(
-                inherit: false,
-                fontFamily: 'Ubuntu Mono',
-                fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
-                textBaseline: TextBaseline.alphabetic,
-              ),
-            ),
-          ),
-          const SizedBox(height: kWizardSpacing),
-          FractionallySizedBox(
-            widthFactor: kWizardWidthFraction,
-            child: Html(
-              data: l10n.recoveryKeyWarning(
-                Theme.of(context).colorScheme.error.toHex(),
-              ),
-              style: {
-                'body': Style(margin: Margins.zero),
-              },
-            ),
-          ),
-        ],
-      ),
-      bottomBar: const WizardBar(
-        leading: BackWizardButton(),
+    final model = ref.watch(recoveryKeyModelProvider);
+    final flavor = ref.watch(flavorProvider);
+
+    return HorizontalPage(
+      windowTitle: l10n.recoveryKeyTitle,
+      title: l10n.recoveryKeyHeader,
+      bottomBar: WizardBar(
+        leading: const BackWizardButton(),
         trailing: [
-          NextWizardButton(),
+          NextWizardButton(
+            enabled: ref.watch(
+              recoveryKeyModelProvider.select((model) => model.confirmed),
+            ),
+          ),
         ],
       ),
+      children: <Widget>[
+        InfoBox(
+          title: l10n.recoveryKeyInfoHeader,
+          subtitle: l10n.recoveryKeyInfoBody(flavor.displayName),
+          type: InfoBoxType.warning,
+          isThreeLine: true,
+        ),
+        Text(l10n.recoveryKeyCommand),
+        SelectableText(
+          kRecoveryKeyCommand,
+          style: TextStyle(
+            fontFamily: 'Ubuntu Mono',
+            fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+            textBaseline: TextBaseline.alphabetic,
+          ),
+        ),
+        Text(l10n.recoveryKeyStorageAdvice),
+        YaruCheckButton(
+          title: Text(
+            l10n.recoveryKeyConfirmation,
+            maxLines: 2,
+          ),
+          contentPadding: kWizardPadding,
+          value: model.confirmed,
+          onChanged: model.setConfirmed,
+        ),
+      ].withSpacing(kWizardSpacing),
     );
   }
 }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_routes.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_routes.dart
@@ -6,6 +6,5 @@ enum StorageSteps with RouteName {
   guidedResize,
   manual,
   passphrase,
-  tpmPassphrase,
   recoveryKey;
 }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_routes.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_routes.dart
@@ -6,5 +6,6 @@ enum StorageSteps with RouteName {
   guidedResize,
   manual,
   passphrase,
+  tpmPassphrase,
   recoveryKey;
 }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
@@ -57,15 +57,15 @@ class StorageWizard extends ConsumerWidget with ProvisioningPage {
         userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
         onLoad: (_) => ManualStoragePage.load(ref),
       ),
-      StorageSteps.passphrase.route: WizardRoute(
-        builder: (_) => const PassphrasePage(),
-        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
-        onLoad: (_) => PassphrasePage.load(ref),
-      ),
       StorageSteps.recoveryKey.route: WizardRoute(
         builder: (_) => const RecoveryKeyPage(),
         userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
         onLoad: (_) => RecoveryKeyPage.load(ref),
+      ),
+      StorageSteps.passphrase.route: WizardRoute(
+        builder: (_) => const PassphrasePage(),
+        userData: WizardRouteData(step: InstallationStep.storage.pageIndex),
+        onLoad: (_) => PassphrasePage.load(ref),
       ),
     };
 

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/passphrase_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/passphrase_page_test.dart
@@ -85,4 +85,29 @@ void main() {
     await tester.tapNext();
     verify(model.savePassphrase()).called(1);
   });
+
+  testWidgets('can skip', (tester) async {
+    final model = buildPassphraseModel(isTpm: true);
+    await tester.pumpApp((_) => buildPage(model));
+
+    expect(find.button(find.ul10n((l10n) => l10n.skipLabel)), isEnabled);
+    expect(find.button(find.nextLabel), findsNothing);
+  });
+
+  testWidgets('tpm can not skip', (tester) async {
+    final model =
+        buildPassphraseModel(isTpm: true, isValid: false, passphrase: 'foo');
+    await tester.pumpApp((_) => buildPage(model));
+
+    expect(find.button(find.ul10n((l10n) => l10n.skipLabel)), findsNothing);
+    expect(find.button(find.nextLabel), isDisabled);
+  });
+
+  testWidgets('luks can not skip', (tester) async {
+    final model = buildPassphraseModel(isTpm: false, isValid: false);
+    await tester.pumpApp((_) => buildPage(model));
+
+    expect(find.button(find.ul10n((l10n) => l10n.skipLabel)), findsNothing);
+    expect(find.button(find.nextLabel), isDisabled);
+  });
 }

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.dart
@@ -9,6 +9,7 @@ export 'test_passphrase.mocks.dart';
 @GenerateMocks([PassphraseModel])
 PassphraseModel buildPassphraseModel({
   bool? isValid,
+  bool? isTpm,
   String? passphrase,
   String? confirmedPassphrase,
   bool? showPassphrase,
@@ -16,7 +17,10 @@ PassphraseModel buildPassphraseModel({
 }) {
   final model = MockPassphraseModel();
   when(model.isValid).thenReturn(isValid ?? true);
+  when(model.isTpm).thenReturn(isTpm ?? false);
   when(model.passphrase).thenReturn(passphrase ?? '');
+  when(model.canSkip)
+      .thenReturn(model.isTpm ? model.passphrase.isEmpty : false);
   when(model.confirmedPassphrase).thenReturn(confirmedPassphrase ?? '');
   when(model.showPassphrase).thenReturn(showPassphrase ?? false);
   when(model.init()).thenAnswer((_) async => usePassphrase ?? true);

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
@@ -84,8 +84,29 @@ class MockPassphraseModel extends _i1.Mock implements _i2.PassphraseModel {
       );
 
   @override
+  bool get isTpm => (super.noSuchMethod(
+        Invocation.getter(#isTpm),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  set isTpm(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #isTpm,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get isValid => (super.noSuchMethod(
         Invocation.getter(#isValid),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get canSkip => (super.noSuchMethod(
+        Invocation.getter(#canSkip),
         returnValue: false,
       ) as bool);
 

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
@@ -90,15 +90,6 @@ class MockPassphraseModel extends _i1.Mock implements _i2.PassphraseModel {
       ) as bool);
 
   @override
-  set isTpm(bool? value) => super.noSuchMethod(
-        Invocation.setter(
-          #isTpm,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
   bool get isValid => (super.noSuchMethod(
         Invocation.getter(#isValid),
         returnValue: false,

--- a/apps/ubuntu_bootstrap/test/storage/recovery_key/recovery_key_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/recovery_key/recovery_key_model_test.dart
@@ -8,7 +8,7 @@ import 'test_recovery_key.dart';
 void main() {
   test('init', () async {
     final storage = MockStorageService();
-    final model = RecoveryKeyModel(storage);
+    final model = RecoveryKeyModel(storage: storage);
 
     when(storage.guidedCapability).thenReturn(GuidedCapability.DIRECT);
     expect(await model.init(), isFalse);

--- a/apps/ubuntu_bootstrap/test/storage/recovery_key/recovery_key_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/recovery_key/recovery_key_page_test.dart
@@ -3,13 +3,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ubuntu_bootstrap/pages/storage/recovery_key/recovery_key_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/recovery_key/recovery_key_page.dart';
+import 'package:ubuntu_provision/ubuntu_provision.dart';
 
 import 'test_recovery_key.dart';
 
 void main() {
   Widget buildPage(RecoveryKeyModel model) {
+    final pageImages = PageImages.internal(
+      MockPageConfigService(),
+      MockThemeVariantService(),
+    );
     return ProviderScope(
-      overrides: [recoveryKeyModelProvider.overrideWith((_) => model)],
+      overrides: [
+        recoveryKeyModelProvider.overrideWith((_) => model),
+        pageImagesProvider.overrideWith((_) => pageImages),
+      ],
       child: const RecoveryKeyPage(),
     );
   }

--- a/apps/ubuntu_bootstrap/test/storage/recovery_key/test_recovery_key.dart
+++ b/apps/ubuntu_bootstrap/test/storage/recovery_key/test_recovery_key.dart
@@ -10,5 +10,6 @@ export 'test_recovery_key.mocks.dart';
 RecoveryKeyModel buildRecoveryKeyModel({bool? init}) {
   final model = MockRecoveryKeyModel();
   when(model.init()).thenAnswer((_) async => init ?? false);
+  when(model.confirmed).thenReturn(true);
   return model;
 }

--- a/apps/ubuntu_bootstrap/test/storage/recovery_key/test_recovery_key.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/recovery_key/test_recovery_key.mocks.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
+import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:ubuntu_bootstrap/pages/storage/recovery_key/recovery_key_model.dart'
@@ -31,6 +32,33 @@ class MockRecoveryKeyModel extends _i1.Mock implements _i2.RecoveryKeyModel {
   }
 
   @override
+  bool get confirmed => (super.noSuchMethod(
+        Invocation.getter(#confirmed),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  bool get isDisposed => (super.noSuchMethod(
+        Invocation.getter(#isDisposed),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  void setConfirmed(bool? confirmed) => super.noSuchMethod(
+        Invocation.method(
+          #setConfirmed,
+          [confirmed],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i3.Future<bool> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -38,4 +66,40 @@ class MockRecoveryKeyModel extends _i1.Mock implements _i2.RecoveryKeyModel {
         ),
         returnValue: _i3.Future<bool>.value(false),
       ) as _i3.Future<bool>);
+
+  @override
+  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }

--- a/apps/ubuntu_init/test/init_model_test.mocks.dart
+++ b/apps/ubuntu_init/test/init_model_test.mocks.dart
@@ -191,13 +191,15 @@ class MockIdentityService extends _i1.Mock implements _i2.IdentityService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<dynamic> validateUsername(String? username) => (super.noSuchMethod(
+  _i4.Future<_i2.UsernameValidation> validateUsername(String? username) =>
+      (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
-        returnValue: _i4.Future<dynamic>.value(),
-      ) as _i4.Future<dynamic>);
+        returnValue:
+            _i4.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
+      ) as _i4.Future<_i2.UsernameValidation>);
 }
 
 /// A class which mocks [GdmService].

--- a/apps/ubuntu_init/test/init_model_test.mocks.dart
+++ b/apps/ubuntu_init/test/init_model_test.mocks.dart
@@ -191,15 +191,13 @@ class MockIdentityService extends _i1.Mock implements _i2.IdentityService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<_i2.UsernameValidation> validateUsername(String? username) =>
-      (super.noSuchMethod(
+  _i4.Future<dynamic> validateUsername(String? username) => (super.noSuchMethod(
         Invocation.method(
           #validateUsername,
           [username],
         ),
-        returnValue:
-            _i4.Future<_i2.UsernameValidation>.value(_i2.UsernameValidation.OK),
-      ) as _i4.Future<_i2.UsernameValidation>);
+        returnValue: _i4.Future<dynamic>.value(),
+      ) as _i4.Future<dynamic>);
 }
 
 /// A class which mocks [GdmService].

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -26,12 +26,8 @@ mixin _$ErrorReportRef {
   bool get seen => throw _privateConstructorUsedError;
   String? get oopsId => throw _privateConstructorUsedError;
 
-  /// Serializes this ErrorReportRef to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ErrorReportRefCopyWith<ErrorReportRef> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -60,8 +56,6 @@ class _$ErrorReportRefCopyWithImpl<$Res, $Val extends ErrorReportRef>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -120,8 +114,6 @@ class __$$ErrorReportRefImplCopyWithImpl<$Res>
       _$ErrorReportRefImpl _value, $Res Function(_$ErrorReportRefImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -197,13 +189,11 @@ class _$ErrorReportRefImpl implements _ErrorReportRef {
             (identical(other.oopsId, oopsId) || other.oopsId == oopsId));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, state, base, kind, seen, oopsId);
 
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
@@ -239,11 +229,8 @@ abstract class _ErrorReportRef implements ErrorReportRef {
   bool get seen;
   @override
   String? get oopsId;
-
-  /// Create a copy of ErrorReportRef
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -258,12 +245,8 @@ mixin _$NonReportableError {
   String get message => throw _privateConstructorUsedError;
   String? get details => throw _privateConstructorUsedError;
 
-  /// Serializes this NonReportableError to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $NonReportableErrorCopyWith<NonReportableError> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -287,8 +270,6 @@ class _$NonReportableErrorCopyWithImpl<$Res, $Val extends NonReportableError>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -332,8 +313,6 @@ class __$$NonReportableErrorImplCopyWithImpl<$Res>
       $Res Function(_$NonReportableErrorImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -389,13 +368,11 @@ class _$NonReportableErrorImpl implements _NonReportableError {
             (identical(other.details, details) || other.details == details));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, cause, message, details);
 
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
@@ -425,11 +402,8 @@ abstract class _NonReportableError implements NonReportableError {
   String get message;
   @override
   String? get details;
-
-  /// Create a copy of NonReportableError
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -451,12 +425,8 @@ mixin _$ApplicationStatus {
   String get logSyslogId => throw _privateConstructorUsedError;
   String get eventSyslogId => throw _privateConstructorUsedError;
 
-  /// Serializes this ApplicationStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ApplicationStatusCopyWith<ApplicationStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -492,8 +462,6 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -547,8 +515,6 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     ) as $Val);
   }
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get error {
@@ -561,8 +527,6 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     });
   }
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $NonReportableErrorCopyWith<$Res>? get nonreportableError {
@@ -610,8 +574,6 @@ class __$$ApplicationStatusImplCopyWithImpl<$Res>
       $Res Function(_$ApplicationStatusImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -730,7 +692,7 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
                 other.eventSyslogId == eventSyslogId));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -744,9 +706,7 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
       logSyslogId,
       eventSyslogId);
 
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
@@ -794,11 +754,8 @@ abstract class _ApplicationStatus implements ApplicationStatus {
   String get logSyslogId;
   @override
   String get eventSyslogId;
-
-  /// Create a copy of ApplicationStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -812,12 +769,8 @@ mixin _$KeyFingerprint {
   String get keytype => throw _privateConstructorUsedError;
   String get fingerprint => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyFingerprint to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyFingerprintCopyWith<KeyFingerprint> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -841,8 +794,6 @@ class _$KeyFingerprintCopyWithImpl<$Res, $Val extends KeyFingerprint>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -881,8 +832,6 @@ class __$$KeyFingerprintImplCopyWithImpl<$Res>
       _$KeyFingerprintImpl _value, $Res Function(_$KeyFingerprintImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -931,13 +880,11 @@ class _$KeyFingerprintImpl implements _KeyFingerprint {
                 other.fingerprint == fingerprint));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, keytype, fingerprint);
 
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
@@ -964,11 +911,8 @@ abstract class _KeyFingerprint implements KeyFingerprint {
   String get keytype;
   @override
   String get fingerprint;
-
-  /// Create a copy of KeyFingerprint
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -988,12 +932,8 @@ mixin _$LiveSessionSSHInfo {
   List<KeyFingerprint> get hostKeyFingerprints =>
       throw _privateConstructorUsedError;
 
-  /// Serializes this LiveSessionSSHInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $LiveSessionSSHInfoCopyWith<LiveSessionSSHInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1023,8 +963,6 @@ class _$LiveSessionSSHInfoCopyWithImpl<$Res, $Val extends LiveSessionSSHInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1089,8 +1027,6 @@ class __$$LiveSessionSSHInfoImplCopyWithImpl<$Res>
       $Res Function(_$LiveSessionSSHInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1202,7 +1138,7 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
                 .equals(other._hostKeyFingerprints, _hostKeyFingerprints));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1213,9 +1149,7 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
       const DeepCollectionEquality().hash(_ips),
       const DeepCollectionEquality().hash(_hostKeyFingerprints));
 
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
@@ -1255,11 +1189,8 @@ abstract class _LiveSessionSSHInfo implements LiveSessionSSHInfo {
   List<String> get ips;
   @override
   List<KeyFingerprint> get hostKeyFingerprints;
-
-  /// Create a copy of LiveSessionSSHInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1274,12 +1205,8 @@ mixin _$RefreshStatus {
   String get currentSnapVersion => throw _privateConstructorUsedError;
   String get newSnapVersion => throw _privateConstructorUsedError;
 
-  /// Serializes this RefreshStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $RefreshStatusCopyWith<RefreshStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1306,8 +1233,6 @@ class _$RefreshStatusCopyWithImpl<$Res, $Val extends RefreshStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1354,8 +1279,6 @@ class __$$RefreshStatusImplCopyWithImpl<$Res>
       _$RefreshStatusImpl _value, $Res Function(_$RefreshStatusImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1418,14 +1341,12 @@ class _$RefreshStatusImpl implements _RefreshStatus {
                 other.newSnapVersion == newSnapVersion));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, availability, currentSnapVersion, newSnapVersion);
 
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
@@ -1454,11 +1375,8 @@ abstract class _RefreshStatus implements RefreshStatus {
   String get currentSnapVersion;
   @override
   String get newSnapVersion;
-
-  /// Create a copy of RefreshStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1528,8 +1446,6 @@ mixin _$AnyStep {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
-
-  /// Serializes this AnyStep to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -1548,9 +1464,6 @@ class _$AnyStepCopyWithImpl<$Res, $Val extends AnyStep>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1570,8 +1483,6 @@ class __$$StepPressKeyImplCopyWithImpl<$Res>
       _$StepPressKeyImpl _value, $Res Function(_$StepPressKeyImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1639,16 +1550,14 @@ class _$StepPressKeyImpl implements StepPressKey {
             const DeepCollectionEquality().equals(other._keycodes, _keycodes));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_symbols),
       const DeepCollectionEquality().hash(_keycodes));
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
@@ -1744,10 +1653,7 @@ abstract class StepPressKey implements AnyStep {
 
   List<String> get symbols;
   Map<int, String> get keycodes;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1769,8 +1675,6 @@ class __$$StepKeyPresentImplCopyWithImpl<$Res>
       _$StepKeyPresentImpl _value, $Res Function(_$StepKeyPresentImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1833,13 +1737,11 @@ class _$StepKeyPresentImpl implements StepKeyPresent {
             (identical(other.no, no) || other.no == no));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, symbol, yes, no);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
@@ -1938,10 +1840,7 @@ abstract class StepKeyPresent implements AnyStep {
   String get symbol;
   String get yes;
   String get no;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1963,8 +1862,6 @@ class __$$StepResultImplCopyWithImpl<$Res>
       _$StepResultImpl _value, $Res Function(_$StepResultImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2016,13 +1913,11 @@ class _$StepResultImpl implements StepResult {
             (identical(other.variant, variant) || other.variant == variant));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant);
 
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
@@ -2118,10 +2013,7 @@ abstract class StepResult implements AnyStep {
 
   String get layout;
   String get variant;
-
-  /// Create a copy of AnyStep
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2136,12 +2028,8 @@ mixin _$KeyboardSetting {
   String get variant => throw _privateConstructorUsedError;
   String? get toggle => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardSettingCopyWith<KeyboardSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2165,8 +2053,6 @@ class _$KeyboardSettingCopyWithImpl<$Res, $Val extends KeyboardSetting>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2210,8 +2096,6 @@ class __$$KeyboardSettingImplCopyWithImpl<$Res>
       _$KeyboardSettingImpl _value, $Res Function(_$KeyboardSettingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2268,13 +2152,11 @@ class _$KeyboardSettingImpl implements _KeyboardSetting {
             (identical(other.toggle, toggle) || other.toggle == toggle));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant, toggle);
 
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
@@ -2304,11 +2186,8 @@ abstract class _KeyboardSetting implements KeyboardSetting {
   String get variant;
   @override
   String? get toggle;
-
-  /// Create a copy of KeyboardSetting
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2322,12 +2201,8 @@ mixin _$KeyboardVariant {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardVariant to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardVariantCopyWith<KeyboardVariant> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2351,8 +2226,6 @@ class _$KeyboardVariantCopyWithImpl<$Res, $Val extends KeyboardVariant>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2391,8 +2264,6 @@ class __$$KeyboardVariantImplCopyWithImpl<$Res>
       _$KeyboardVariantImpl _value, $Res Function(_$KeyboardVariantImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2439,13 +2310,11 @@ class _$KeyboardVariantImpl implements _KeyboardVariant {
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
@@ -2472,11 +2341,8 @@ abstract class _KeyboardVariant implements KeyboardVariant {
   String get code;
   @override
   String get name;
-
-  /// Create a copy of KeyboardVariant
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2491,12 +2357,8 @@ mixin _$KeyboardLayout {
   String get name => throw _privateConstructorUsedError;
   List<KeyboardVariant> get variants => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardLayout to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardLayoutCopyWith<KeyboardLayout> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2520,8 +2382,6 @@ class _$KeyboardLayoutCopyWithImpl<$Res, $Val extends KeyboardLayout>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2565,8 +2425,6 @@ class __$$KeyboardLayoutImplCopyWithImpl<$Res>
       _$KeyboardLayoutImpl _value, $Res Function(_$KeyboardLayoutImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2630,14 +2488,12 @@ class _$KeyboardLayoutImpl implements _KeyboardLayout {
             const DeepCollectionEquality().equals(other._variants, _variants));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, const DeepCollectionEquality().hash(_variants));
 
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
@@ -2667,11 +2523,8 @@ abstract class _KeyboardLayout implements KeyboardLayout {
   String get name;
   @override
   List<KeyboardVariant> get variants;
-
-  /// Create a copy of KeyboardLayout
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2685,12 +2538,8 @@ mixin _$KeyboardSetup {
   KeyboardSetting get setting => throw _privateConstructorUsedError;
   List<KeyboardLayout> get layouts => throw _privateConstructorUsedError;
 
-  /// Serializes this KeyboardSetup to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $KeyboardSetupCopyWith<KeyboardSetup> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2716,8 +2565,6 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2736,8 +2583,6 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
     ) as $Val);
   }
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $KeyboardSettingCopyWith<$Res> get setting {
@@ -2769,8 +2614,6 @@ class __$$KeyboardSetupImplCopyWithImpl<$Res>
       _$KeyboardSetupImpl _value, $Res Function(_$KeyboardSetupImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2824,14 +2667,12 @@ class _$KeyboardSetupImpl implements _KeyboardSetup {
             const DeepCollectionEquality().equals(other._layouts, _layouts));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, setting, const DeepCollectionEquality().hash(_layouts));
 
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
@@ -2857,11 +2698,8 @@ abstract class _KeyboardSetup implements KeyboardSetup {
   KeyboardSetting get setting;
   @override
   List<KeyboardLayout> get layouts;
-
-  /// Create a copy of KeyboardSetup
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2880,12 +2718,8 @@ mixin _$SourceSelection {
   @JsonKey(name: 'default')
   bool get isDefault => throw _privateConstructorUsedError;
 
-  /// Serializes this SourceSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SourceSelectionCopyWith<SourceSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2915,8 +2749,6 @@ class _$SourceSelectionCopyWithImpl<$Res, $Val extends SourceSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2981,8 +2813,6 @@ class __$$SourceSelectionImplCopyWithImpl<$Res>
       _$SourceSelectionImpl _value, $Res Function(_$SourceSelectionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3070,14 +2900,12 @@ class _$SourceSelectionImpl implements _SourceSelection {
                 other.isDefault == isDefault));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, description, id, size, variant, isDefault);
 
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
@@ -3118,11 +2946,8 @@ abstract class _SourceSelection implements SourceSelection {
   @override
   @JsonKey(name: 'default')
   bool get isDefault;
-
-  /// Create a copy of SourceSelection
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3138,12 +2963,8 @@ mixin _$SourceSelectionAndSetting {
   String get currentId => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
-  /// Serializes this SourceSelectionAndSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SourceSelectionAndSettingCopyWith<SourceSelectionAndSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3169,8 +2990,6 @@ class _$SourceSelectionAndSettingCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3218,8 +3037,6 @@ class __$$SourceSelectionAndSettingImplCopyWithImpl<$Res>
       $Res Function(_$SourceSelectionAndSettingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3286,14 +3103,12 @@ class _$SourceSelectionAndSettingImpl implements _SourceSelectionAndSetting {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_sources), currentId, searchDrivers);
 
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
@@ -3323,11 +3138,8 @@ abstract class _SourceSelectionAndSetting implements SourceSelectionAndSetting {
   String get currentId;
   @override
   bool get searchDrivers;
-
-  /// Create a copy of SourceSelectionAndSetting
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -3347,12 +3159,8 @@ mixin _$ZdevInfo {
   bool get failed => throw _privateConstructorUsedError;
   String get names => throw _privateConstructorUsedError;
 
-  /// Serializes this ZdevInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ZdevInfoCopyWith<ZdevInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3383,8 +3191,6 @@ class _$ZdevInfoCopyWithImpl<$Res, $Val extends ZdevInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3461,8 +3267,6 @@ class __$$ZdevInfoImplCopyWithImpl<$Res>
       _$ZdevInfoImpl _value, $Res Function(_$ZdevInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3565,14 +3369,12 @@ class _$ZdevInfoImpl implements _ZdevInfo {
             (identical(other.names, names) || other.names == names));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, type, on, exists, pers, auto, failed, names);
 
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
@@ -3616,11 +3418,8 @@ abstract class _ZdevInfo implements ZdevInfo {
   bool get failed;
   @override
   String get names;
-
-  /// Create a copy of ZdevInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3635,12 +3434,8 @@ mixin _$NetworkStatus {
   PackageInstallState get wlanSupportInstallState =>
       throw _privateConstructorUsedError;
 
-  /// Serializes this NetworkStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $NetworkStatusCopyWith<NetworkStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3665,8 +3460,6 @@ class _$NetworkStatusCopyWithImpl<$Res, $Val extends NetworkStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3706,8 +3499,6 @@ class __$$NetworkStatusImplCopyWithImpl<$Res>
       _$NetworkStatusImpl _value, $Res Function(_$NetworkStatusImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3765,14 +3556,12 @@ class _$NetworkStatusImpl implements _NetworkStatus {
                 other.wlanSupportInstallState == wlanSupportInstallState));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_devices), wlanSupportInstallState);
 
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
@@ -3799,11 +3588,8 @@ abstract class _NetworkStatus implements NetworkStatus {
   List<NetDevInfo> get devices;
   @override
   PackageInstallState get wlanSupportInstallState;
-
-  /// Create a copy of NetworkStatus
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3819,12 +3605,8 @@ mixin _$IdentityData {
   String get cryptedPassword => throw _privateConstructorUsedError;
   String get hostname => throw _privateConstructorUsedError;
 
-  /// Serializes this IdentityData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $IdentityDataCopyWith<IdentityData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3852,8 +3634,6 @@ class _$IdentityDataCopyWithImpl<$Res, $Val extends IdentityData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3906,8 +3686,6 @@ class __$$IdentityDataImplCopyWithImpl<$Res>
       _$IdentityDataImpl _value, $Res Function(_$IdentityDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3982,14 +3760,12 @@ class _$IdentityDataImpl implements _IdentityData {
                 other.hostname == hostname));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, realname, username, cryptedPassword, hostname);
 
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
@@ -4021,11 +3797,8 @@ abstract class _IdentityData implements IdentityData {
   String get cryptedPassword;
   @override
   String get hostname;
-
-  /// Create a copy of IdentityData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4040,12 +3813,8 @@ mixin _$SSHData {
   bool get allowPw => throw _privateConstructorUsedError;
   List<String> get authorizedKeys => throw _privateConstructorUsedError;
 
-  /// Serializes this SSHData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SSHDataCopyWith<SSHData> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4067,8 +3836,6 @@ class _$SSHDataCopyWithImpl<$Res, $Val extends SSHData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4111,8 +3878,6 @@ class __$$SSHDataImplCopyWithImpl<$Res>
       _$SSHDataImpl _value, $Res Function(_$SSHDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4179,14 +3944,12 @@ class _$SSHDataImpl implements _SSHData {
                 .equals(other._authorizedKeys, _authorizedKeys));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, installServer, allowPw,
       const DeepCollectionEquality().hash(_authorizedKeys));
 
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
@@ -4214,11 +3977,8 @@ abstract class _SSHData implements SSHData {
   bool get allowPw;
   @override
   List<String> get authorizedKeys;
-
-  /// Create a copy of SSHData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4234,12 +3994,8 @@ mixin _$SSHIdentity {
   String get keyComment => throw _privateConstructorUsedError;
   String get keyFingerprint => throw _privateConstructorUsedError;
 
-  /// Serializes this SSHIdentity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SSHIdentityCopyWith<SSHIdentity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4264,8 +4020,6 @@ class _$SSHIdentityCopyWithImpl<$Res, $Val extends SSHIdentity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4315,8 +4069,6 @@ class __$$SSHIdentityImplCopyWithImpl<$Res>
       _$SSHIdentityImpl _value, $Res Function(_$SSHIdentityImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4385,14 +4137,12 @@ class _$SSHIdentityImpl implements _SSHIdentity {
                 other.keyFingerprint == keyFingerprint));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, keyType, key, keyComment, keyFingerprint);
 
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
@@ -4424,11 +4174,8 @@ abstract class _SSHIdentity implements SSHIdentity {
   String get keyComment;
   @override
   String get keyFingerprint;
-
-  /// Create a copy of SSHIdentity
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4443,12 +4190,8 @@ mixin _$SSHFetchIdResponse {
   List<SSHIdentity>? get identities => throw _privateConstructorUsedError;
   String? get error => throw _privateConstructorUsedError;
 
-  /// Serializes this SSHFetchIdResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SSHFetchIdResponseCopyWith<SSHFetchIdResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4473,8 +4216,6 @@ class _$SSHFetchIdResponseCopyWithImpl<$Res, $Val extends SSHFetchIdResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4519,8 +4260,6 @@ class __$$SSHFetchIdResponseImplCopyWithImpl<$Res>
       $Res Function(_$SSHFetchIdResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4588,14 +4327,12 @@ class _$SSHFetchIdResponseImpl implements _SSHFetchIdResponse {
             (identical(other.error, error) || other.error == error));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status,
       const DeepCollectionEquality().hash(_identities), error);
 
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
@@ -4625,11 +4362,8 @@ abstract class _SSHFetchIdResponse implements SSHFetchIdResponse {
   List<SSHIdentity>? get identities;
   @override
   String? get error;
-
-  /// Create a copy of SSHFetchIdResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4647,12 +4381,8 @@ mixin _$ChannelSnapInfo {
   int get size => throw _privateConstructorUsedError;
   DateTime get releasedAt => throw _privateConstructorUsedError;
 
-  /// Serializes this ChannelSnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ChannelSnapInfoCopyWith<ChannelSnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4682,8 +4412,6 @@ class _$ChannelSnapInfoCopyWithImpl<$Res, $Val extends ChannelSnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4748,8 +4476,6 @@ class __$$ChannelSnapInfoImplCopyWithImpl<$Res>
       _$ChannelSnapInfoImpl _value, $Res Function(_$ChannelSnapInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4838,14 +4564,12 @@ class _$ChannelSnapInfoImpl implements _ChannelSnapInfo {
                 other.releasedAt == releasedAt));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, channelName, revision,
       confinement, version, size, releasedAt);
 
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
@@ -4884,11 +4608,8 @@ abstract class _ChannelSnapInfo implements ChannelSnapInfo {
   int get size;
   @override
   DateTime get releasedAt;
-
-  /// Create a copy of ChannelSnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4909,12 +4630,8 @@ mixin _$SnapInfo {
   String get license => throw _privateConstructorUsedError;
   List<ChannelSnapInfo> get channels => throw _privateConstructorUsedError;
 
-  /// Serializes this SnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SnapInfoCopyWith<SnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4946,8 +4663,6 @@ class _$SnapInfoCopyWithImpl<$Res, $Val extends SnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5030,8 +4745,6 @@ class __$$SnapInfoImplCopyWithImpl<$Res>
       _$SnapInfoImpl _value, $Res Function(_$SnapInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5161,7 +4874,7 @@ class _$SnapInfoImpl implements _SnapInfo {
             const DeepCollectionEquality().equals(other._channels, _channels));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -5175,9 +4888,7 @@ class _$SnapInfoImpl implements _SnapInfo {
       license,
       const DeepCollectionEquality().hash(_channels));
 
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
@@ -5224,11 +4935,8 @@ abstract class _SnapInfo implements SnapInfo {
   String get license;
   @override
   List<ChannelSnapInfo> get channels;
-
-  /// Create a copy of SnapInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5244,12 +4952,8 @@ mixin _$DriversResponse {
   bool get localOnly => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
-  /// Serializes this DriversResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DriversResponseCopyWith<DriversResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5277,8 +4981,6 @@ class _$DriversResponseCopyWithImpl<$Res, $Val extends DriversResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5331,8 +5033,6 @@ class __$$DriversResponseImplCopyWithImpl<$Res>
       _$DriversResponseImpl _value, $Res Function(_$DriversResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5410,14 +5110,12 @@ class _$DriversResponseImpl implements _DriversResponse {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, install,
       const DeepCollectionEquality().hash(_drivers), localOnly, searchDrivers);
 
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
@@ -5450,11 +5148,8 @@ abstract class _DriversResponse implements DriversResponse {
   bool get localOnly;
   @override
   bool get searchDrivers;
-
-  /// Create a copy of DriversResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5467,12 +5162,8 @@ OEMResponse _$OEMResponseFromJson(Map<String, dynamic> json) {
 mixin _$OEMResponse {
   List<String>? get metapackages => throw _privateConstructorUsedError;
 
-  /// Serializes this OEMResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $OEMResponseCopyWith<OEMResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5496,8 +5187,6 @@ class _$OEMResponseCopyWithImpl<$Res, $Val extends OEMResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5531,8 +5220,6 @@ class __$$OEMResponseImplCopyWithImpl<$Res>
       _$OEMResponseImpl _value, $Res Function(_$OEMResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5580,14 +5267,12 @@ class _$OEMResponseImpl implements _OEMResponse {
                 .equals(other._metapackages, _metapackages));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_metapackages));
 
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
@@ -5610,11 +5295,8 @@ abstract class _OEMResponse implements OEMResponse {
 
   @override
   List<String>? get metapackages;
-
-  /// Create a copy of OEMResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5627,12 +5309,8 @@ CodecsData _$CodecsDataFromJson(Map<String, dynamic> json) {
 mixin _$CodecsData {
   bool get install => throw _privateConstructorUsedError;
 
-  /// Serializes this CodecsData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $CodecsDataCopyWith<CodecsData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5656,8 +5334,6 @@ class _$CodecsDataCopyWithImpl<$Res, $Val extends CodecsData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5691,8 +5367,6 @@ class __$$CodecsDataImplCopyWithImpl<$Res>
       _$CodecsDataImpl _value, $Res Function(_$CodecsDataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5731,13 +5405,11 @@ class _$CodecsDataImpl implements _CodecsData {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
@@ -5759,11 +5431,8 @@ abstract class _CodecsData implements CodecsData {
 
   @override
   bool get install;
-
-  /// Create a copy of CodecsData
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5776,12 +5445,8 @@ DriversPayload _$DriversPayloadFromJson(Map<String, dynamic> json) {
 mixin _$DriversPayload {
   bool get install => throw _privateConstructorUsedError;
 
-  /// Serializes this DriversPayload to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DriversPayloadCopyWith<DriversPayload> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5805,8 +5470,6 @@ class _$DriversPayloadCopyWithImpl<$Res, $Val extends DriversPayload>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5840,8 +5503,6 @@ class __$$DriversPayloadImplCopyWithImpl<$Res>
       _$DriversPayloadImpl _value, $Res Function(_$DriversPayloadImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5880,13 +5541,11 @@ class _$DriversPayloadImpl implements _DriversPayload {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
@@ -5910,11 +5569,8 @@ abstract class _DriversPayload implements DriversPayload {
 
   @override
   bool get install;
-
-  /// Create a copy of DriversPayload
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5929,12 +5585,8 @@ mixin _$SnapSelection {
   String get channel => throw _privateConstructorUsedError;
   bool get classic => throw _privateConstructorUsedError;
 
-  /// Serializes this SnapSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SnapSelectionCopyWith<SnapSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5958,8 +5610,6 @@ class _$SnapSelectionCopyWithImpl<$Res, $Val extends SnapSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6003,8 +5653,6 @@ class __$$SnapSelectionImplCopyWithImpl<$Res>
       _$SnapSelectionImpl _value, $Res Function(_$SnapSelectionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6061,13 +5709,11 @@ class _$SnapSelectionImpl implements _SnapSelection {
             (identical(other.classic, classic) || other.classic == classic));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, name, channel, classic);
 
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
@@ -6096,11 +5742,8 @@ abstract class _SnapSelection implements SnapSelection {
   String get channel;
   @override
   bool get classic;
-
-  /// Create a copy of SnapSelection
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6115,12 +5758,8 @@ mixin _$SnapListResponse {
   List<SnapInfo> get snaps => throw _privateConstructorUsedError;
   List<SnapSelection> get selections => throw _privateConstructorUsedError;
 
-  /// Serializes this SnapListResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $SnapListResponseCopyWith<SnapListResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6147,8 +5786,6 @@ class _$SnapListResponseCopyWithImpl<$Res, $Val extends SnapListResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6195,8 +5832,6 @@ class __$$SnapListResponseImplCopyWithImpl<$Res>
       $Res Function(_$SnapListResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6270,7 +5905,7 @@ class _$SnapListResponseImpl implements _SnapListResponse {
                 .equals(other._selections, _selections));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -6278,9 +5913,7 @@ class _$SnapListResponseImpl implements _SnapListResponse {
       const DeepCollectionEquality().hash(_snaps),
       const DeepCollectionEquality().hash(_selections));
 
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
@@ -6310,11 +5943,8 @@ abstract class _SnapListResponse implements SnapListResponse {
   List<SnapInfo> get snaps;
   @override
   List<SnapSelection> get selections;
-
-  /// Create a copy of SnapListResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6328,12 +5958,8 @@ mixin _$TimeZoneInfo {
   String get timezone => throw _privateConstructorUsedError;
   bool get fromGeoip => throw _privateConstructorUsedError;
 
-  /// Serializes this TimeZoneInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $TimeZoneInfoCopyWith<TimeZoneInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6357,8 +5983,6 @@ class _$TimeZoneInfoCopyWithImpl<$Res, $Val extends TimeZoneInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6397,8 +6021,6 @@ class __$$TimeZoneInfoImplCopyWithImpl<$Res>
       _$TimeZoneInfoImpl _value, $Res Function(_$TimeZoneInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6447,13 +6069,11 @@ class _$TimeZoneInfoImpl implements _TimeZoneInfo {
                 other.fromGeoip == fromGeoip));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, timezone, fromGeoip);
 
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
@@ -6479,11 +6099,8 @@ abstract class _TimeZoneInfo implements TimeZoneInfo {
   String get timezone;
   @override
   bool get fromGeoip;
-
-  /// Create a copy of TimeZoneInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6496,12 +6113,8 @@ UbuntuProInfo _$UbuntuProInfoFromJson(Map<String, dynamic> json) {
 mixin _$UbuntuProInfo {
   String get token => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProInfoCopyWith<UbuntuProInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6525,8 +6138,6 @@ class _$UbuntuProInfoCopyWithImpl<$Res, $Val extends UbuntuProInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6560,8 +6171,6 @@ class __$$UbuntuProInfoImplCopyWithImpl<$Res>
       _$UbuntuProInfoImpl _value, $Res Function(_$UbuntuProInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6600,13 +6209,11 @@ class _$UbuntuProInfoImpl implements _UbuntuProInfo {
             (identical(other.token, token) || other.token == token));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, token);
 
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
@@ -6629,11 +6236,8 @@ abstract class _UbuntuProInfo implements UbuntuProInfo {
 
   @override
   String get token;
-
-  /// Create a copy of UbuntuProInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6647,12 +6251,8 @@ mixin _$UbuntuProResponse {
   String get token => throw _privateConstructorUsedError;
   bool get hasNetwork => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProResponseCopyWith<UbuntuProResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6676,8 +6276,6 @@ class _$UbuntuProResponseCopyWithImpl<$Res, $Val extends UbuntuProResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6716,8 +6314,6 @@ class __$$UbuntuProResponseImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6766,13 +6362,11 @@ class _$UbuntuProResponseImpl implements _UbuntuProResponse {
                 other.hasNetwork == hasNetwork));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, token, hasNetwork);
 
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
@@ -6799,11 +6393,8 @@ abstract class _UbuntuProResponse implements UbuntuProResponse {
   String get token;
   @override
   bool get hasNetwork;
-
-  /// Create a copy of UbuntuProResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6818,12 +6409,8 @@ mixin _$UbuntuProGeneralInfo {
   int get universePackages => throw _privateConstructorUsedError;
   int get mainPackages => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProGeneralInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProGeneralInfoCopyWith<UbuntuProGeneralInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6848,8 +6435,6 @@ class _$UbuntuProGeneralInfoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6893,8 +6478,6 @@ class __$$UbuntuProGeneralInfoImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProGeneralInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6955,14 +6538,12 @@ class _$UbuntuProGeneralInfoImpl implements _UbuntuProGeneralInfo {
                 other.mainPackages == mainPackages));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, eolEsmYear, universePackages, mainPackages);
 
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
@@ -6993,11 +6574,8 @@ abstract class _UbuntuProGeneralInfo implements UbuntuProGeneralInfo {
   int get universePackages;
   @override
   int get mainPackages;
-
-  /// Create a copy of UbuntuProGeneralInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7011,12 +6589,8 @@ mixin _$UPCSInitiateResponse {
   String get userCode => throw _privateConstructorUsedError;
   int get validitySeconds => throw _privateConstructorUsedError;
 
-  /// Serializes this UPCSInitiateResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UPCSInitiateResponseCopyWith<UPCSInitiateResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7041,8 +6615,6 @@ class _$UPCSInitiateResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7081,8 +6653,6 @@ class __$$UPCSInitiateResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSInitiateResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7132,13 +6702,11 @@ class _$UPCSInitiateResponseImpl implements _UPCSInitiateResponse {
                 other.validitySeconds == validitySeconds));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, userCode, validitySeconds);
 
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
@@ -7166,11 +6734,8 @@ abstract class _UPCSInitiateResponse implements UPCSInitiateResponse {
   String get userCode;
   @override
   int get validitySeconds;
-
-  /// Create a copy of UPCSInitiateResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7184,12 +6749,8 @@ mixin _$UPCSWaitResponse {
   UPCSWaitStatus get status => throw _privateConstructorUsedError;
   String? get contractToken => throw _privateConstructorUsedError;
 
-  /// Serializes this UPCSWaitResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UPCSWaitResponseCopyWith<UPCSWaitResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7213,8 +6774,6 @@ class _$UPCSWaitResponseCopyWithImpl<$Res, $Val extends UPCSWaitResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7253,8 +6812,6 @@ class __$$UPCSWaitResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSWaitResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7303,13 +6860,11 @@ class _$UPCSWaitResponseImpl implements _UPCSWaitResponse {
                 other.contractToken == contractToken));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status, contractToken);
 
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
@@ -7336,11 +6891,8 @@ abstract class _UPCSWaitResponse implements UPCSWaitResponse {
   UPCSWaitStatus get status;
   @override
   String? get contractToken;
-
-  /// Create a copy of UPCSWaitResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7355,12 +6907,8 @@ mixin _$UbuntuProService {
   String get description => throw _privateConstructorUsedError;
   bool get autoEnabled => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProService to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProServiceCopyWith<UbuntuProService> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7384,8 +6932,6 @@ class _$UbuntuProServiceCopyWithImpl<$Res, $Val extends UbuntuProService>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7429,8 +6975,6 @@ class __$$UbuntuProServiceImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProServiceImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7490,13 +7034,11 @@ class _$UbuntuProServiceImpl implements _UbuntuProService {
                 other.autoEnabled == autoEnabled));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, name, description, autoEnabled);
 
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
@@ -7526,11 +7068,8 @@ abstract class _UbuntuProService implements UbuntuProService {
   String get description;
   @override
   bool get autoEnabled;
-
-  /// Create a copy of UbuntuProService
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7547,12 +7086,8 @@ mixin _$UbuntuProSubscription {
   String get contractToken => throw _privateConstructorUsedError;
   List<UbuntuProService> get services => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProSubscription to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProSubscriptionCopyWith<UbuntuProSubscription> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7581,8 +7116,6 @@ class _$UbuntuProSubscriptionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7637,8 +7170,6 @@ class __$$UbuntuProSubscriptionImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProSubscriptionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7714,14 +7245,12 @@ class _$UbuntuProSubscriptionImpl implements _UbuntuProSubscription {
             const DeepCollectionEquality().equals(other._services, _services));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, contractName, accountName,
       contractToken, const DeepCollectionEquality().hash(_services));
 
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
@@ -7755,11 +7284,8 @@ abstract class _UbuntuProSubscription implements UbuntuProSubscription {
   String get contractToken;
   @override
   List<UbuntuProService> get services;
-
-  /// Create a copy of UbuntuProSubscription
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7774,12 +7300,8 @@ mixin _$UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status => throw _privateConstructorUsedError;
   UbuntuProSubscription? get subscription => throw _privateConstructorUsedError;
 
-  /// Serializes this UbuntuProCheckTokenAnswer to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $UbuntuProCheckTokenAnswerCopyWith<UbuntuProCheckTokenAnswer> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7807,8 +7329,6 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7827,8 +7347,6 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
     ) as $Val);
   }
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UbuntuProSubscriptionCopyWith<$Res>? get subscription {
@@ -7868,8 +7386,6 @@ class __$$UbuntuProCheckTokenAnswerImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProCheckTokenAnswerImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7918,13 +7434,11 @@ class _$UbuntuProCheckTokenAnswerImpl implements _UbuntuProCheckTokenAnswer {
                 other.subscription == subscription));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status, subscription);
 
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
@@ -7952,11 +7466,8 @@ abstract class _UbuntuProCheckTokenAnswer implements UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status;
   @override
   UbuntuProSubscription? get subscription;
-
-  /// Create a copy of UbuntuProCheckTokenAnswer
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7971,12 +7482,8 @@ mixin _$TaskProgress {
   int get done => throw _privateConstructorUsedError;
   int get total => throw _privateConstructorUsedError;
 
-  /// Serializes this TaskProgress to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $TaskProgressCopyWith<TaskProgress> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8000,8 +7507,6 @@ class _$TaskProgressCopyWithImpl<$Res, $Val extends TaskProgress>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8045,8 +7550,6 @@ class __$$TaskProgressImplCopyWithImpl<$Res>
       _$TaskProgressImpl _value, $Res Function(_$TaskProgressImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8104,13 +7607,11 @@ class _$TaskProgressImpl implements _TaskProgress {
             (identical(other.total, total) || other.total == total));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, label, done, total);
 
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
@@ -8139,11 +7640,8 @@ abstract class _TaskProgress implements TaskProgress {
   int get done;
   @override
   int get total;
-
-  /// Create a copy of TaskProgress
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8160,12 +7658,8 @@ mixin _$Task {
   TaskStatus get status => throw _privateConstructorUsedError;
   TaskProgress get progress => throw _privateConstructorUsedError;
 
-  /// Serializes this Task to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $TaskCopyWith<Task> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -8194,8 +7688,6 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8229,8 +7721,6 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
     ) as $Val);
   }
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TaskProgressCopyWith<$Res> get progress {
@@ -8265,8 +7755,6 @@ class __$$TaskImplCopyWithImpl<$Res>
   __$$TaskImplCopyWithImpl(_$TaskImpl _value, $Res Function(_$TaskImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8343,14 +7831,12 @@ class _$TaskImpl implements _Task {
                 other.progress == progress));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, kind, summary, status, progress);
 
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
@@ -8384,11 +7870,8 @@ abstract class _Task implements Task {
   TaskStatus get status;
   @override
   TaskProgress get progress;
-
-  /// Create a copy of Task
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8408,12 +7891,8 @@ mixin _$Change {
   String? get err => throw _privateConstructorUsedError;
   dynamic get data => throw _privateConstructorUsedError;
 
-  /// Serializes this Change to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ChangeCopyWith<Change> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -8443,8 +7922,6 @@ class _$ChangeCopyWithImpl<$Res, $Val extends Change>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8520,8 +7997,6 @@ class __$$ChangeImplCopyWithImpl<$Res>
       _$ChangeImpl _value, $Res Function(_$ChangeImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8631,7 +8106,7 @@ class _$ChangeImpl implements _Change {
             const DeepCollectionEquality().equals(other.data, data));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8644,9 +8119,7 @@ class _$ChangeImpl implements _Change {
       err,
       const DeepCollectionEquality().hash(data));
 
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
@@ -8689,11 +8162,8 @@ abstract class _Change implements Change {
   String? get err;
   @override
   dynamic get data;
-
-  /// Create a copy of Change
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8708,12 +8178,8 @@ mixin _$MirrorCheckResponse {
   MirrorCheckStatus get status => throw _privateConstructorUsedError;
   String get output => throw _privateConstructorUsedError;
 
-  /// Serializes this MirrorCheckResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MirrorCheckResponseCopyWith<MirrorCheckResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8737,8 +8203,6 @@ class _$MirrorCheckResponseCopyWithImpl<$Res, $Val extends MirrorCheckResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8782,8 +8246,6 @@ class __$$MirrorCheckResponseImplCopyWithImpl<$Res>
       $Res Function(_$MirrorCheckResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8839,13 +8301,11 @@ class _$MirrorCheckResponseImpl implements _MirrorCheckResponse {
             (identical(other.output, output) || other.output == output));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, url, status, output);
 
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
@@ -8875,11 +8335,8 @@ abstract class _MirrorCheckResponse implements MirrorCheckResponse {
   MirrorCheckStatus get status;
   @override
   String get output;
-
-  /// Create a copy of MirrorCheckResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8895,12 +8352,8 @@ mixin _$MirrorPost {
   String? get staged => throw _privateConstructorUsedError;
   bool? get useDuringInstallation => throw _privateConstructorUsedError;
 
-  /// Serializes this MirrorPost to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MirrorPostCopyWith<MirrorPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8928,8 +8381,6 @@ class _$MirrorPostCopyWithImpl<$Res, $Val extends MirrorPost>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8982,8 +8433,6 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
       _$MirrorPostImpl _value, $Res Function(_$MirrorPostImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9061,7 +8510,7 @@ class _$MirrorPostImpl implements _MirrorPost {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -9070,9 +8519,7 @@ class _$MirrorPostImpl implements _MirrorPost {
       staged,
       useDuringInstallation);
 
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
@@ -9104,11 +8551,8 @@ abstract class _MirrorPost implements MirrorPost {
   String? get staged;
   @override
   bool? get useDuringInstallation;
-
-  /// Create a copy of MirrorPost
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9125,12 +8569,8 @@ mixin _$MirrorGet {
   String? get staged => throw _privateConstructorUsedError;
   bool get useDuringInstallation => throw _privateConstructorUsedError;
 
-  /// Serializes this MirrorGet to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MirrorGetCopyWith<MirrorGet> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9158,8 +8598,6 @@ class _$MirrorGetCopyWithImpl<$Res, $Val extends MirrorGet>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9218,8 +8656,6 @@ class __$$MirrorGetImplCopyWithImpl<$Res>
       _$MirrorGetImpl _value, $Res Function(_$MirrorGetImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9305,7 +8741,7 @@ class _$MirrorGetImpl implements _MirrorGet {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -9315,9 +8751,7 @@ class _$MirrorGetImpl implements _MirrorGet {
       staged,
       useDuringInstallation);
 
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
@@ -9352,11 +8786,8 @@ abstract class _MirrorGet implements MirrorGet {
   String? get staged;
   @override
   bool get useDuringInstallation;
-
-  /// Create a copy of MirrorGet
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9371,12 +8802,8 @@ mixin _$AdConnectionInfo {
   String get domainName => throw _privateConstructorUsedError;
   String get password => throw _privateConstructorUsedError;
 
-  /// Serializes this AdConnectionInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $AdConnectionInfoCopyWith<AdConnectionInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9400,8 +8827,6 @@ class _$AdConnectionInfoCopyWithImpl<$Res, $Val extends AdConnectionInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9445,8 +8870,6 @@ class __$$AdConnectionInfoImplCopyWithImpl<$Res>
       $Res Function(_$AdConnectionInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9508,13 +8931,11 @@ class _$AdConnectionInfoImpl implements _AdConnectionInfo {
                 other.password == password));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, adminName, domainName, password);
 
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
@@ -9544,11 +8965,8 @@ abstract class _AdConnectionInfo implements AdConnectionInfo {
   String get domainName;
   @override
   String get password;
-
-  /// Create a copy of AdConnectionInfo
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9565,12 +8983,8 @@ mixin _$OsProber {
   String? get subpath => throw _privateConstructorUsedError;
   String? get version => throw _privateConstructorUsedError;
 
-  /// Serializes this OsProber to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $OsProberCopyWith<OsProber> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9598,8 +9012,6 @@ class _$OsProberCopyWithImpl<$Res, $Val extends OsProber>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9658,8 +9070,6 @@ class __$$OsProberImplCopyWithImpl<$Res>
       _$OsProberImpl _value, $Res Function(_$OsProberImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9735,14 +9145,12 @@ class _$OsProberImpl implements _OsProber {
             (identical(other.version, version) || other.version == version));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, long, label, type, subpath, version);
 
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
@@ -9777,11 +9185,8 @@ abstract class _OsProber implements OsProber {
   String? get subpath;
   @override
   String? get version;
-
-  /// Create a copy of OsProber
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9889,13 +9294,8 @@ mixin _$PartitionOrGap {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
-
-  /// Serializes this PartitionOrGap to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $PartitionOrGapCopyWith<PartitionOrGap> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9919,8 +9319,6 @@ class _$PartitionOrGapCopyWithImpl<$Res, $Val extends PartitionOrGap>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9976,8 +9374,6 @@ class __$$PartitionImplCopyWithImpl<$Res>
       _$PartitionImpl _value, $Res Function(_$PartitionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10061,8 +9457,6 @@ class __$$PartitionImplCopyWithImpl<$Res>
     ));
   }
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $OsProberCopyWith<$Res>? get os {
@@ -10176,7 +9570,7 @@ class _$PartitionImpl implements Partition {
             (identical(other.isInUse, isInUse) || other.isInUse == isInUse));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -10196,9 +9590,7 @@ class _$PartitionImpl implements Partition {
       path,
       isInUse);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
@@ -10391,11 +9783,8 @@ abstract class Partition implements PartitionOrGap {
   bool? get resize;
   String? get path;
   bool get isInUse;
-
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10417,8 +9806,6 @@ class __$$GapImplCopyWithImpl<$Res>
   __$$GapImplCopyWithImpl(_$GapImpl _value, $Res Function(_$GapImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10481,13 +9868,11 @@ class _$GapImpl implements Gap {
             (identical(other.usable, usable) || other.usable == usable));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, offset, size, usable);
 
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
@@ -10624,11 +10009,8 @@ abstract class Gap implements PartitionOrGap {
   @override
   int get size;
   GapUsable get usable;
-
-  /// Create a copy of PartitionOrGap
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10642,12 +10024,8 @@ mixin _$ZFS {
   String get volume => throw _privateConstructorUsedError;
   Map<String, dynamic>? get properties => throw _privateConstructorUsedError;
 
-  /// Serializes this ZFS to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ZFSCopyWith<ZFS> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10668,8 +10046,6 @@ class _$ZFSCopyWithImpl<$Res, $Val extends ZFS> implements $ZFSCopyWith<$Res> {
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10704,8 +10080,6 @@ class __$$ZFSImplCopyWithImpl<$Res> extends _$ZFSCopyWithImpl<$Res, _$ZFSImpl>
   __$$ZFSImplCopyWithImpl(_$ZFSImpl _value, $Res Function(_$ZFSImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10762,14 +10136,12 @@ class _$ZFSImpl implements _ZFS {
                 .equals(other._properties, _properties));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, volume, const DeepCollectionEquality().hash(_properties));
 
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
@@ -10794,11 +10166,8 @@ abstract class _ZFS implements ZFS {
   String get volume;
   @override
   Map<String, dynamic>? get properties;
-
-  /// Create a copy of ZFS
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10817,12 +10186,8 @@ mixin _$ZPool {
   Map<String, dynamic>? get fsProperties => throw _privateConstructorUsedError;
   bool? get defaultFeatures => throw _privateConstructorUsedError;
 
-  /// Serializes this ZPool to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ZPoolCopyWith<ZPool> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10852,8 +10217,6 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10892,8 +10255,6 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
     ) as $Val);
   }
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ZFSCopyWith<$Res>? get zfses {
@@ -10934,8 +10295,6 @@ class __$$ZPoolImplCopyWithImpl<$Res>
       _$ZPoolImpl _value, $Res Function(_$ZPoolImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11043,7 +10402,7 @@ class _$ZPoolImpl implements _ZPool {
                 other.defaultFeatures == defaultFeatures));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11054,9 +10413,7 @@ class _$ZPoolImpl implements _ZPool {
       const DeepCollectionEquality().hash(_fsProperties),
       defaultFeatures);
 
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
@@ -11093,11 +10450,8 @@ abstract class _ZPool implements ZPool {
   Map<String, dynamic>? get fsProperties;
   @override
   bool? get defaultFeatures;
-
-  /// Create a copy of ZPool
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11124,12 +10478,8 @@ mixin _$Disk {
   String? get vendor => throw _privateConstructorUsedError;
   bool get hasInUsePartition => throw _privateConstructorUsedError;
 
-  /// Serializes this Disk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $DiskCopyWith<Disk> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -11166,8 +10516,6 @@ class _$DiskCopyWithImpl<$Res, $Val extends Disk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11284,8 +10632,6 @@ class __$$DiskImplCopyWithImpl<$Res>
   __$$DiskImplCopyWithImpl(_$DiskImpl _value, $Res Function(_$DiskImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11473,7 +10819,7 @@ class _$DiskImpl implements _Disk {
                 other.hasInUsePartition == hasInUsePartition));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11493,9 +10839,7 @@ class _$DiskImpl implements _Disk {
       vendor,
       hasInUsePartition);
 
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
@@ -11559,11 +10903,8 @@ abstract class _Disk implements Disk {
   String? get vendor;
   @override
   bool get hasInUsePartition;
-
-  /// Create a copy of Disk
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11580,12 +10921,8 @@ mixin _$GuidedDisallowedCapability {
       throw _privateConstructorUsedError;
   String? get message => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedDisallowedCapability to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedDisallowedCapabilityCopyWith<GuidedDisallowedCapability>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -11614,8 +10951,6 @@ class _$GuidedDisallowedCapabilityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11665,8 +11000,6 @@ class __$$GuidedDisallowedCapabilityImplCopyWithImpl<$Res>
       $Res Function(_$GuidedDisallowedCapabilityImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11724,13 +11057,11 @@ class _$GuidedDisallowedCapabilityImpl implements _GuidedDisallowedCapability {
             (identical(other.message, message) || other.message == message));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, capability, reason, message);
 
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
@@ -11761,11 +11092,8 @@ abstract class _GuidedDisallowedCapability
   GuidedDisallowedCapabilityReason get reason;
   @override
   String? get message;
-
-  /// Create a copy of GuidedDisallowedCapability
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -11784,12 +11112,8 @@ mixin _$StorageResponse {
   Map<String, dynamic>? get dasd => throw _privateConstructorUsedError;
   int get storageVersion => throw _privateConstructorUsedError;
 
-  /// Serializes this StorageResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $StorageResponseCopyWith<StorageResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11822,8 +11146,6 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11867,8 +11189,6 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
     ) as $Val);
   }
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -11911,8 +11231,6 @@ class __$$StorageResponseImplCopyWithImpl<$Res>
       _$StorageResponseImpl _value, $Res Function(_$StorageResponseImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12038,7 +11356,7 @@ class _$StorageResponseImpl implements _StorageResponse {
                 other.storageVersion == storageVersion));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12050,9 +11368,7 @@ class _$StorageResponseImpl implements _StorageResponse {
       const DeepCollectionEquality().hash(_dasd),
       storageVersion);
 
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
@@ -12094,11 +11410,8 @@ abstract class _StorageResponse implements StorageResponse {
   Map<String, dynamic>? get dasd;
   @override
   int get storageVersion;
-
-  /// Create a copy of StorageResponse
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12116,12 +11429,8 @@ mixin _$StorageResponseV2 {
   bool? get needBoot => throw _privateConstructorUsedError;
   int? get installMinimumSize => throw _privateConstructorUsedError;
 
-  /// Serializes this StorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $StorageResponseV2CopyWith<StorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12153,8 +11462,6 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12193,8 +11500,6 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
     ) as $Val);
   }
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -12236,8 +11541,6 @@ class __$$StorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$StorageResponseV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12334,7 +11637,7 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
                 other.installMinimumSize == installMinimumSize));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12345,9 +11648,7 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
       needBoot,
       installMinimumSize);
 
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
@@ -12386,11 +11687,8 @@ abstract class _StorageResponseV2 implements StorageResponseV2 {
   bool? get needBoot;
   @override
   int? get installMinimumSize;
-
-  /// Create a copy of StorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12406,12 +11704,8 @@ mixin _$GuidedResizeValues {
   int get recommended => throw _privateConstructorUsedError;
   int get maximum => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedResizeValues to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedResizeValuesCopyWith<GuidedResizeValues> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12435,8 +11729,6 @@ class _$GuidedResizeValuesCopyWithImpl<$Res, $Val extends GuidedResizeValues>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12485,8 +11777,6 @@ class __$$GuidedResizeValuesImplCopyWithImpl<$Res>
       $Res Function(_$GuidedResizeValuesImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12555,14 +11845,12 @@ class _$GuidedResizeValuesImpl implements _GuidedResizeValues {
             (identical(other.maximum, maximum) || other.maximum == maximum));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, installMax, minimum, recommended, maximum);
 
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
@@ -12595,11 +11883,8 @@ abstract class _GuidedResizeValues implements GuidedResizeValues {
   int get recommended;
   @override
   int get maximum;
-
-  /// Create a copy of GuidedResizeValues
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12748,13 +12033,8 @@ mixin _$GuidedStorageTarget {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
-
-  /// Serializes this GuidedStorageTarget to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedStorageTargetCopyWith<GuidedStorageTarget> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12780,8 +12060,6 @@ class _$GuidedStorageTargetCopyWithImpl<$Res, $Val extends GuidedStorageTarget>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12826,8 +12104,6 @@ class __$$GuidedStorageTargetReformatImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetReformatImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12907,7 +12183,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12915,9 +12191,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
@@ -13091,11 +12365,8 @@ abstract class GuidedStorageTargetReformat implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13130,8 +12401,6 @@ class __$$GuidedStorageTargetResizeImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetResizeImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13257,7 +12526,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13270,9 +12539,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
@@ -13459,11 +12726,8 @@ abstract class GuidedStorageTargetResize implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13494,8 +12758,6 @@ class __$$GuidedStorageTargetEraseInstallImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetEraseInstallImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13586,7 +12848,7 @@ class _$GuidedStorageTargetEraseInstallImpl
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13595,9 +12857,7 @@ class _$GuidedStorageTargetEraseInstallImpl
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetEraseInstallImplCopyWith<
@@ -13774,11 +13034,8 @@ abstract class GuidedStorageTargetEraseInstall implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetEraseInstallImplCopyWith<
           _$GuidedStorageTargetEraseInstallImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -13810,8 +13067,6 @@ class __$$GuidedStorageTargetUseGapImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetUseGapImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13899,7 +13154,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13908,9 +13163,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
@@ -14086,11 +13339,8 @@ abstract class GuidedStorageTargetUseGap implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -14119,8 +13369,6 @@ class __$$GuidedStorageTargetManualImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetManualImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14189,16 +13437,14 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
@@ -14370,11 +13616,8 @@ abstract class GuidedStorageTargetManual implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
-
-  /// Create a copy of GuidedStorageTarget
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -14388,12 +13631,8 @@ mixin _$RecoveryKey {
   String? get liveLocation => throw _privateConstructorUsedError;
   String? get backupLocation => throw _privateConstructorUsedError;
 
-  /// Serializes this RecoveryKey to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $RecoveryKeyCopyWith<RecoveryKey> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14417,8 +13656,6 @@ class _$RecoveryKeyCopyWithImpl<$Res, $Val extends RecoveryKey>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14457,8 +13694,6 @@ class __$$RecoveryKeyImplCopyWithImpl<$Res>
       _$RecoveryKeyImpl _value, $Res Function(_$RecoveryKeyImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14507,13 +13742,11 @@ class _$RecoveryKeyImpl implements _RecoveryKey {
                 other.backupLocation == backupLocation));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, liveLocation, backupLocation);
 
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
@@ -14539,11 +13772,8 @@ abstract class _RecoveryKey implements RecoveryKey {
   String? get liveLocation;
   @override
   String? get backupLocation;
-
-  /// Create a copy of RecoveryKey
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14562,12 +13792,8 @@ mixin _$GuidedChoiceV2 {
   bool get resetPartition => throw _privateConstructorUsedError;
   int? get resetPartitionSize => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedChoiceV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedChoiceV2CopyWith<GuidedChoiceV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14601,8 +13827,6 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14646,8 +13870,6 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     ) as $Val);
   }
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedStorageTargetCopyWith<$Res> get target {
@@ -14656,8 +13878,6 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     });
   }
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RecoveryKeyCopyWith<$Res>? get recoveryKey {
@@ -14702,8 +13922,6 @@ class __$$GuidedChoiceV2ImplCopyWithImpl<$Res>
       _$GuidedChoiceV2Impl _value, $Res Function(_$GuidedChoiceV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14804,14 +14022,12 @@ class _$GuidedChoiceV2Impl implements _GuidedChoiceV2 {
                 other.resetPartitionSize == resetPartitionSize));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, target, capability, password,
       recoveryKey, sizingPolicy, resetPartition, resetPartitionSize);
 
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
@@ -14853,11 +14069,8 @@ abstract class _GuidedChoiceV2 implements GuidedChoiceV2 {
   bool get resetPartition;
   @override
   int? get resetPartitionSize;
-
-  /// Create a copy of GuidedChoiceV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14874,12 +14087,8 @@ mixin _$GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured => throw _privateConstructorUsedError;
   List<GuidedStorageTarget> get targets => throw _privateConstructorUsedError;
 
-  /// Serializes this GuidedStorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $GuidedStorageResponseV2CopyWith<GuidedStorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14911,8 +14120,6 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14941,8 +14148,6 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     ) as $Val);
   }
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -14955,8 +14160,6 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     });
   }
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedChoiceV2CopyWith<$Res>? get configured {
@@ -15001,8 +14204,6 @@ class __$$GuidedStorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageResponseV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15078,14 +14279,12 @@ class _$GuidedStorageResponseV2Impl implements _GuidedStorageResponseV2 {
             const DeepCollectionEquality().equals(other._targets, _targets));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, status, errorReport, configured,
       const DeepCollectionEquality().hash(_targets));
 
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
@@ -15118,11 +14317,8 @@ abstract class _GuidedStorageResponseV2 implements GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured;
   @override
   List<GuidedStorageTarget> get targets;
-
-  /// Create a copy of GuidedStorageResponseV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -15137,12 +14333,8 @@ mixin _$AddPartitionV2 {
   Partition get partition => throw _privateConstructorUsedError;
   Gap get gap => throw _privateConstructorUsedError;
 
-  /// Serializes this AddPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $AddPartitionV2CopyWith<AddPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15166,8 +14358,6 @@ class _$AddPartitionV2CopyWithImpl<$Res, $Val extends AddPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15211,8 +14401,6 @@ class __$$AddPartitionV2ImplCopyWithImpl<$Res>
       _$AddPartitionV2Impl _value, $Res Function(_$AddPartitionV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15268,7 +14456,7 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
             const DeepCollectionEquality().equals(other.gap, gap));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -15276,9 +14464,7 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
       const DeepCollectionEquality().hash(partition),
       const DeepCollectionEquality().hash(gap));
 
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
@@ -15308,11 +14494,8 @@ abstract class _AddPartitionV2 implements AddPartitionV2 {
   Partition get partition;
   @override
   Gap get gap;
-
-  /// Create a copy of AddPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15326,12 +14509,8 @@ mixin _$ModifyPartitionV2 {
   String get diskId => throw _privateConstructorUsedError;
   Partition get partition => throw _privateConstructorUsedError;
 
-  /// Serializes this ModifyPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ModifyPartitionV2CopyWith<ModifyPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15355,8 +14534,6 @@ class _$ModifyPartitionV2CopyWithImpl<$Res, $Val extends ModifyPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15395,8 +14572,6 @@ class __$$ModifyPartitionV2ImplCopyWithImpl<$Res>
       $Res Function(_$ModifyPartitionV2Impl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15444,14 +14619,12 @@ class _$ModifyPartitionV2Impl implements _ModifyPartitionV2 {
             const DeepCollectionEquality().equals(other.partition, partition));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, diskId, const DeepCollectionEquality().hash(partition));
 
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
@@ -15478,11 +14651,8 @@ abstract class _ModifyPartitionV2 implements ModifyPartitionV2 {
   String get diskId;
   @override
   Partition get partition;
-
-  /// Create a copy of ModifyPartitionV2
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15496,12 +14666,8 @@ mixin _$ReformatDisk {
   String get diskId => throw _privateConstructorUsedError;
   String? get ptable => throw _privateConstructorUsedError;
 
-  /// Serializes this ReformatDisk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ReformatDiskCopyWith<ReformatDisk> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -15525,8 +14691,6 @@ class _$ReformatDiskCopyWithImpl<$Res, $Val extends ReformatDisk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15565,8 +14729,6 @@ class __$$ReformatDiskImplCopyWithImpl<$Res>
       _$ReformatDiskImpl _value, $Res Function(_$ReformatDiskImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -15613,13 +14775,11 @@ class _$ReformatDiskImpl implements _ReformatDisk {
             (identical(other.ptable, ptable) || other.ptable == ptable));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, diskId, ptable);
 
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
@@ -15645,11 +14805,8 @@ abstract class _ReformatDisk implements ReformatDisk {
   String get diskId;
   @override
   String? get ptable;
-
-  /// Create a copy of ReformatDisk
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -26,8 +26,12 @@ mixin _$ErrorReportRef {
   bool get seen => throw _privateConstructorUsedError;
   String? get oopsId => throw _privateConstructorUsedError;
 
+  /// Serializes this ErrorReportRef to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ErrorReportRefCopyWith<ErrorReportRef> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -56,6 +60,8 @@ class _$ErrorReportRefCopyWithImpl<$Res, $Val extends ErrorReportRef>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -114,6 +120,8 @@ class __$$ErrorReportRefImplCopyWithImpl<$Res>
       _$ErrorReportRefImpl _value, $Res Function(_$ErrorReportRefImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -189,11 +197,13 @@ class _$ErrorReportRefImpl implements _ErrorReportRef {
             (identical(other.oopsId, oopsId) || other.oopsId == oopsId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, state, base, kind, seen, oopsId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
@@ -229,8 +239,11 @@ abstract class _ErrorReportRef implements ErrorReportRef {
   bool get seen;
   @override
   String? get oopsId;
+
+  /// Create a copy of ErrorReportRef
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ErrorReportRefImplCopyWith<_$ErrorReportRefImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -245,8 +258,12 @@ mixin _$NonReportableError {
   String get message => throw _privateConstructorUsedError;
   String? get details => throw _privateConstructorUsedError;
 
+  /// Serializes this NonReportableError to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NonReportableErrorCopyWith<NonReportableError> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -270,6 +287,8 @@ class _$NonReportableErrorCopyWithImpl<$Res, $Val extends NonReportableError>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -313,6 +332,8 @@ class __$$NonReportableErrorImplCopyWithImpl<$Res>
       $Res Function(_$NonReportableErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -368,11 +389,13 @@ class _$NonReportableErrorImpl implements _NonReportableError {
             (identical(other.details, details) || other.details == details));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, cause, message, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
@@ -402,8 +425,11 @@ abstract class _NonReportableError implements NonReportableError {
   String get message;
   @override
   String? get details;
+
+  /// Create a copy of NonReportableError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NonReportableErrorImplCopyWith<_$NonReportableErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -425,8 +451,12 @@ mixin _$ApplicationStatus {
   String get logSyslogId => throw _privateConstructorUsedError;
   String get eventSyslogId => throw _privateConstructorUsedError;
 
+  /// Serializes this ApplicationStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ApplicationStatusCopyWith<ApplicationStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -462,6 +492,8 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -515,6 +547,8 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     ) as $Val);
   }
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get error {
@@ -527,6 +561,8 @@ class _$ApplicationStatusCopyWithImpl<$Res, $Val extends ApplicationStatus>
     });
   }
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $NonReportableErrorCopyWith<$Res>? get nonreportableError {
@@ -574,6 +610,8 @@ class __$$ApplicationStatusImplCopyWithImpl<$Res>
       $Res Function(_$ApplicationStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -692,7 +730,7 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
                 other.eventSyslogId == eventSyslogId));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -706,7 +744,9 @@ class _$ApplicationStatusImpl implements _ApplicationStatus {
       logSyslogId,
       eventSyslogId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
@@ -754,8 +794,11 @@ abstract class _ApplicationStatus implements ApplicationStatus {
   String get logSyslogId;
   @override
   String get eventSyslogId;
+
+  /// Create a copy of ApplicationStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ApplicationStatusImplCopyWith<_$ApplicationStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -769,8 +812,12 @@ mixin _$KeyFingerprint {
   String get keytype => throw _privateConstructorUsedError;
   String get fingerprint => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyFingerprint to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyFingerprintCopyWith<KeyFingerprint> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -794,6 +841,8 @@ class _$KeyFingerprintCopyWithImpl<$Res, $Val extends KeyFingerprint>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -832,6 +881,8 @@ class __$$KeyFingerprintImplCopyWithImpl<$Res>
       _$KeyFingerprintImpl _value, $Res Function(_$KeyFingerprintImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -880,11 +931,13 @@ class _$KeyFingerprintImpl implements _KeyFingerprint {
                 other.fingerprint == fingerprint));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, keytype, fingerprint);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
@@ -911,8 +964,11 @@ abstract class _KeyFingerprint implements KeyFingerprint {
   String get keytype;
   @override
   String get fingerprint;
+
+  /// Create a copy of KeyFingerprint
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyFingerprintImplCopyWith<_$KeyFingerprintImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -932,8 +988,12 @@ mixin _$LiveSessionSSHInfo {
   List<KeyFingerprint> get hostKeyFingerprints =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this LiveSessionSSHInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $LiveSessionSSHInfoCopyWith<LiveSessionSSHInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -963,6 +1023,8 @@ class _$LiveSessionSSHInfoCopyWithImpl<$Res, $Val extends LiveSessionSSHInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1027,6 +1089,8 @@ class __$$LiveSessionSSHInfoImplCopyWithImpl<$Res>
       $Res Function(_$LiveSessionSSHInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1138,7 +1202,7 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
                 .equals(other._hostKeyFingerprints, _hostKeyFingerprints));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -1149,7 +1213,9 @@ class _$LiveSessionSSHInfoImpl implements _LiveSessionSSHInfo {
       const DeepCollectionEquality().hash(_ips),
       const DeepCollectionEquality().hash(_hostKeyFingerprints));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
@@ -1189,8 +1255,11 @@ abstract class _LiveSessionSSHInfo implements LiveSessionSSHInfo {
   List<String> get ips;
   @override
   List<KeyFingerprint> get hostKeyFingerprints;
+
+  /// Create a copy of LiveSessionSSHInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiveSessionSSHInfoImplCopyWith<_$LiveSessionSSHInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1205,8 +1274,12 @@ mixin _$RefreshStatus {
   String get currentSnapVersion => throw _privateConstructorUsedError;
   String get newSnapVersion => throw _privateConstructorUsedError;
 
+  /// Serializes this RefreshStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RefreshStatusCopyWith<RefreshStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1233,6 +1306,8 @@ class _$RefreshStatusCopyWithImpl<$Res, $Val extends RefreshStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1279,6 +1354,8 @@ class __$$RefreshStatusImplCopyWithImpl<$Res>
       _$RefreshStatusImpl _value, $Res Function(_$RefreshStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1341,12 +1418,14 @@ class _$RefreshStatusImpl implements _RefreshStatus {
                 other.newSnapVersion == newSnapVersion));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, availability, currentSnapVersion, newSnapVersion);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
@@ -1375,8 +1454,11 @@ abstract class _RefreshStatus implements RefreshStatus {
   String get currentSnapVersion;
   @override
   String get newSnapVersion;
+
+  /// Create a copy of RefreshStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RefreshStatusImplCopyWith<_$RefreshStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1446,6 +1528,8 @@ mixin _$AnyStep {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this AnyStep to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
@@ -1464,6 +1548,9 @@ class _$AnyStepCopyWithImpl<$Res, $Val extends AnyStep>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1483,6 +1570,8 @@ class __$$StepPressKeyImplCopyWithImpl<$Res>
       _$StepPressKeyImpl _value, $Res Function(_$StepPressKeyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1550,14 +1639,16 @@ class _$StepPressKeyImpl implements StepPressKey {
             const DeepCollectionEquality().equals(other._keycodes, _keycodes));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_symbols),
       const DeepCollectionEquality().hash(_keycodes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
@@ -1653,7 +1744,10 @@ abstract class StepPressKey implements AnyStep {
 
   List<String> get symbols;
   Map<int, String> get keycodes;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StepPressKeyImplCopyWith<_$StepPressKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1675,6 +1769,8 @@ class __$$StepKeyPresentImplCopyWithImpl<$Res>
       _$StepKeyPresentImpl _value, $Res Function(_$StepKeyPresentImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1737,11 +1833,13 @@ class _$StepKeyPresentImpl implements StepKeyPresent {
             (identical(other.no, no) || other.no == no));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, symbol, yes, no);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
@@ -1840,7 +1938,10 @@ abstract class StepKeyPresent implements AnyStep {
   String get symbol;
   String get yes;
   String get no;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StepKeyPresentImplCopyWith<_$StepKeyPresentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1862,6 +1963,8 @@ class __$$StepResultImplCopyWithImpl<$Res>
       _$StepResultImpl _value, $Res Function(_$StepResultImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1913,11 +2016,13 @@ class _$StepResultImpl implements StepResult {
             (identical(other.variant, variant) || other.variant == variant));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
@@ -2013,7 +2118,10 @@ abstract class StepResult implements AnyStep {
 
   String get layout;
   String get variant;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AnyStep
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StepResultImplCopyWith<_$StepResultImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2028,8 +2136,12 @@ mixin _$KeyboardSetting {
   String get variant => throw _privateConstructorUsedError;
   String? get toggle => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardSettingCopyWith<KeyboardSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2053,6 +2165,8 @@ class _$KeyboardSettingCopyWithImpl<$Res, $Val extends KeyboardSetting>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2096,6 +2210,8 @@ class __$$KeyboardSettingImplCopyWithImpl<$Res>
       _$KeyboardSettingImpl _value, $Res Function(_$KeyboardSettingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2152,11 +2268,13 @@ class _$KeyboardSettingImpl implements _KeyboardSetting {
             (identical(other.toggle, toggle) || other.toggle == toggle));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, layout, variant, toggle);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
@@ -2186,8 +2304,11 @@ abstract class _KeyboardSetting implements KeyboardSetting {
   String get variant;
   @override
   String? get toggle;
+
+  /// Create a copy of KeyboardSetting
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardSettingImplCopyWith<_$KeyboardSettingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2201,8 +2322,12 @@ mixin _$KeyboardVariant {
   String get code => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardVariant to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardVariantCopyWith<KeyboardVariant> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2226,6 +2351,8 @@ class _$KeyboardVariantCopyWithImpl<$Res, $Val extends KeyboardVariant>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2264,6 +2391,8 @@ class __$$KeyboardVariantImplCopyWithImpl<$Res>
       _$KeyboardVariantImpl _value, $Res Function(_$KeyboardVariantImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2310,11 +2439,13 @@ class _$KeyboardVariantImpl implements _KeyboardVariant {
             (identical(other.name, name) || other.name == name));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, code, name);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
@@ -2341,8 +2472,11 @@ abstract class _KeyboardVariant implements KeyboardVariant {
   String get code;
   @override
   String get name;
+
+  /// Create a copy of KeyboardVariant
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardVariantImplCopyWith<_$KeyboardVariantImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2357,8 +2491,12 @@ mixin _$KeyboardLayout {
   String get name => throw _privateConstructorUsedError;
   List<KeyboardVariant> get variants => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardLayout to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardLayoutCopyWith<KeyboardLayout> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2382,6 +2520,8 @@ class _$KeyboardLayoutCopyWithImpl<$Res, $Val extends KeyboardLayout>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2425,6 +2565,8 @@ class __$$KeyboardLayoutImplCopyWithImpl<$Res>
       _$KeyboardLayoutImpl _value, $Res Function(_$KeyboardLayoutImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2488,12 +2630,14 @@ class _$KeyboardLayoutImpl implements _KeyboardLayout {
             const DeepCollectionEquality().equals(other._variants, _variants));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, code, name, const DeepCollectionEquality().hash(_variants));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
@@ -2523,8 +2667,11 @@ abstract class _KeyboardLayout implements KeyboardLayout {
   String get name;
   @override
   List<KeyboardVariant> get variants;
+
+  /// Create a copy of KeyboardLayout
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardLayoutImplCopyWith<_$KeyboardLayoutImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2538,8 +2685,12 @@ mixin _$KeyboardSetup {
   KeyboardSetting get setting => throw _privateConstructorUsedError;
   List<KeyboardLayout> get layouts => throw _privateConstructorUsedError;
 
+  /// Serializes this KeyboardSetup to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $KeyboardSetupCopyWith<KeyboardSetup> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2565,6 +2716,8 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2583,6 +2736,8 @@ class _$KeyboardSetupCopyWithImpl<$Res, $Val extends KeyboardSetup>
     ) as $Val);
   }
 
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $KeyboardSettingCopyWith<$Res> get setting {
@@ -2614,6 +2769,8 @@ class __$$KeyboardSetupImplCopyWithImpl<$Res>
       _$KeyboardSetupImpl _value, $Res Function(_$KeyboardSetupImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2667,12 +2824,14 @@ class _$KeyboardSetupImpl implements _KeyboardSetup {
             const DeepCollectionEquality().equals(other._layouts, _layouts));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, setting, const DeepCollectionEquality().hash(_layouts));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
@@ -2698,8 +2857,11 @@ abstract class _KeyboardSetup implements KeyboardSetup {
   KeyboardSetting get setting;
   @override
   List<KeyboardLayout> get layouts;
+
+  /// Create a copy of KeyboardSetup
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$KeyboardSetupImplCopyWith<_$KeyboardSetupImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2718,8 +2880,12 @@ mixin _$SourceSelection {
   @JsonKey(name: 'default')
   bool get isDefault => throw _privateConstructorUsedError;
 
+  /// Serializes this SourceSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SourceSelectionCopyWith<SourceSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2749,6 +2915,8 @@ class _$SourceSelectionCopyWithImpl<$Res, $Val extends SourceSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2813,6 +2981,8 @@ class __$$SourceSelectionImplCopyWithImpl<$Res>
       _$SourceSelectionImpl _value, $Res Function(_$SourceSelectionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2900,12 +3070,14 @@ class _$SourceSelectionImpl implements _SourceSelection {
                 other.isDefault == isDefault));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, name, description, id, size, variant, isDefault);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
@@ -2946,8 +3118,11 @@ abstract class _SourceSelection implements SourceSelection {
   @override
   @JsonKey(name: 'default')
   bool get isDefault;
+
+  /// Create a copy of SourceSelection
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SourceSelectionImplCopyWith<_$SourceSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2963,8 +3138,12 @@ mixin _$SourceSelectionAndSetting {
   String get currentId => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
+  /// Serializes this SourceSelectionAndSetting to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SourceSelectionAndSettingCopyWith<SourceSelectionAndSetting> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -2990,6 +3169,8 @@ class _$SourceSelectionAndSettingCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3037,6 +3218,8 @@ class __$$SourceSelectionAndSettingImplCopyWithImpl<$Res>
       $Res Function(_$SourceSelectionAndSettingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3103,12 +3286,14 @@ class _$SourceSelectionAndSettingImpl implements _SourceSelectionAndSetting {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_sources), currentId, searchDrivers);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
@@ -3138,8 +3323,11 @@ abstract class _SourceSelectionAndSetting implements SourceSelectionAndSetting {
   String get currentId;
   @override
   bool get searchDrivers;
+
+  /// Create a copy of SourceSelectionAndSetting
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SourceSelectionAndSettingImplCopyWith<_$SourceSelectionAndSettingImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -3159,8 +3347,12 @@ mixin _$ZdevInfo {
   bool get failed => throw _privateConstructorUsedError;
   String get names => throw _privateConstructorUsedError;
 
+  /// Serializes this ZdevInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ZdevInfoCopyWith<ZdevInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3191,6 +3383,8 @@ class _$ZdevInfoCopyWithImpl<$Res, $Val extends ZdevInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3267,6 +3461,8 @@ class __$$ZdevInfoImplCopyWithImpl<$Res>
       _$ZdevInfoImpl _value, $Res Function(_$ZdevInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3369,12 +3565,14 @@ class _$ZdevInfoImpl implements _ZdevInfo {
             (identical(other.names, names) || other.names == names));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, type, on, exists, pers, auto, failed, names);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
@@ -3418,8 +3616,11 @@ abstract class _ZdevInfo implements ZdevInfo {
   bool get failed;
   @override
   String get names;
+
+  /// Create a copy of ZdevInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ZdevInfoImplCopyWith<_$ZdevInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3434,8 +3635,12 @@ mixin _$NetworkStatus {
   PackageInstallState get wlanSupportInstallState =>
       throw _privateConstructorUsedError;
 
+  /// Serializes this NetworkStatus to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $NetworkStatusCopyWith<NetworkStatus> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3460,6 +3665,8 @@ class _$NetworkStatusCopyWithImpl<$Res, $Val extends NetworkStatus>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3499,6 +3706,8 @@ class __$$NetworkStatusImplCopyWithImpl<$Res>
       _$NetworkStatusImpl _value, $Res Function(_$NetworkStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3556,12 +3765,14 @@ class _$NetworkStatusImpl implements _NetworkStatus {
                 other.wlanSupportInstallState == wlanSupportInstallState));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType,
       const DeepCollectionEquality().hash(_devices), wlanSupportInstallState);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
@@ -3588,8 +3799,11 @@ abstract class _NetworkStatus implements NetworkStatus {
   List<NetDevInfo> get devices;
   @override
   PackageInstallState get wlanSupportInstallState;
+
+  /// Create a copy of NetworkStatus
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$NetworkStatusImplCopyWith<_$NetworkStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3605,8 +3819,12 @@ mixin _$IdentityData {
   String get cryptedPassword => throw _privateConstructorUsedError;
   String get hostname => throw _privateConstructorUsedError;
 
+  /// Serializes this IdentityData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $IdentityDataCopyWith<IdentityData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3634,6 +3852,8 @@ class _$IdentityDataCopyWithImpl<$Res, $Val extends IdentityData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3686,6 +3906,8 @@ class __$$IdentityDataImplCopyWithImpl<$Res>
       _$IdentityDataImpl _value, $Res Function(_$IdentityDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3760,12 +3982,14 @@ class _$IdentityDataImpl implements _IdentityData {
                 other.hostname == hostname));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, realname, username, cryptedPassword, hostname);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
@@ -3797,8 +4021,11 @@ abstract class _IdentityData implements IdentityData {
   String get cryptedPassword;
   @override
   String get hostname;
+
+  /// Create a copy of IdentityData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$IdentityDataImplCopyWith<_$IdentityDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3813,8 +4040,12 @@ mixin _$SSHData {
   bool get allowPw => throw _privateConstructorUsedError;
   List<String> get authorizedKeys => throw _privateConstructorUsedError;
 
+  /// Serializes this SSHData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SSHDataCopyWith<SSHData> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -3836,6 +4067,8 @@ class _$SSHDataCopyWithImpl<$Res, $Val extends SSHData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3878,6 +4111,8 @@ class __$$SSHDataImplCopyWithImpl<$Res>
       _$SSHDataImpl _value, $Res Function(_$SSHDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -3944,12 +4179,14 @@ class _$SSHDataImpl implements _SSHData {
                 .equals(other._authorizedKeys, _authorizedKeys));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, installServer, allowPw,
       const DeepCollectionEquality().hash(_authorizedKeys));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
@@ -3977,8 +4214,11 @@ abstract class _SSHData implements SSHData {
   bool get allowPw;
   @override
   List<String> get authorizedKeys;
+
+  /// Create a copy of SSHData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SSHDataImplCopyWith<_$SSHDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -3994,8 +4234,12 @@ mixin _$SSHIdentity {
   String get keyComment => throw _privateConstructorUsedError;
   String get keyFingerprint => throw _privateConstructorUsedError;
 
+  /// Serializes this SSHIdentity to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SSHIdentityCopyWith<SSHIdentity> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4020,6 +4264,8 @@ class _$SSHIdentityCopyWithImpl<$Res, $Val extends SSHIdentity>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4069,6 +4315,8 @@ class __$$SSHIdentityImplCopyWithImpl<$Res>
       _$SSHIdentityImpl _value, $Res Function(_$SSHIdentityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4137,12 +4385,14 @@ class _$SSHIdentityImpl implements _SSHIdentity {
                 other.keyFingerprint == keyFingerprint));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, keyType, key, keyComment, keyFingerprint);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
@@ -4174,8 +4424,11 @@ abstract class _SSHIdentity implements SSHIdentity {
   String get keyComment;
   @override
   String get keyFingerprint;
+
+  /// Create a copy of SSHIdentity
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SSHIdentityImplCopyWith<_$SSHIdentityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4190,8 +4443,12 @@ mixin _$SSHFetchIdResponse {
   List<SSHIdentity>? get identities => throw _privateConstructorUsedError;
   String? get error => throw _privateConstructorUsedError;
 
+  /// Serializes this SSHFetchIdResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SSHFetchIdResponseCopyWith<SSHFetchIdResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4216,6 +4473,8 @@ class _$SSHFetchIdResponseCopyWithImpl<$Res, $Val extends SSHFetchIdResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4260,6 +4519,8 @@ class __$$SSHFetchIdResponseImplCopyWithImpl<$Res>
       $Res Function(_$SSHFetchIdResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4327,12 +4588,14 @@ class _$SSHFetchIdResponseImpl implements _SSHFetchIdResponse {
             (identical(other.error, error) || other.error == error));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status,
       const DeepCollectionEquality().hash(_identities), error);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
@@ -4362,8 +4625,11 @@ abstract class _SSHFetchIdResponse implements SSHFetchIdResponse {
   List<SSHIdentity>? get identities;
   @override
   String? get error;
+
+  /// Create a copy of SSHFetchIdResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SSHFetchIdResponseImplCopyWith<_$SSHFetchIdResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4381,8 +4647,12 @@ mixin _$ChannelSnapInfo {
   int get size => throw _privateConstructorUsedError;
   DateTime get releasedAt => throw _privateConstructorUsedError;
 
+  /// Serializes this ChannelSnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ChannelSnapInfoCopyWith<ChannelSnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4412,6 +4682,8 @@ class _$ChannelSnapInfoCopyWithImpl<$Res, $Val extends ChannelSnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4476,6 +4748,8 @@ class __$$ChannelSnapInfoImplCopyWithImpl<$Res>
       _$ChannelSnapInfoImpl _value, $Res Function(_$ChannelSnapInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4564,12 +4838,14 @@ class _$ChannelSnapInfoImpl implements _ChannelSnapInfo {
                 other.releasedAt == releasedAt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, channelName, revision,
       confinement, version, size, releasedAt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
@@ -4608,8 +4884,11 @@ abstract class _ChannelSnapInfo implements ChannelSnapInfo {
   int get size;
   @override
   DateTime get releasedAt;
+
+  /// Create a copy of ChannelSnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ChannelSnapInfoImplCopyWith<_$ChannelSnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4630,8 +4909,12 @@ mixin _$SnapInfo {
   String get license => throw _privateConstructorUsedError;
   List<ChannelSnapInfo> get channels => throw _privateConstructorUsedError;
 
+  /// Serializes this SnapInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SnapInfoCopyWith<SnapInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4663,6 +4946,8 @@ class _$SnapInfoCopyWithImpl<$Res, $Val extends SnapInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4745,6 +5030,8 @@ class __$$SnapInfoImplCopyWithImpl<$Res>
       _$SnapInfoImpl _value, $Res Function(_$SnapInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -4874,7 +5161,7 @@ class _$SnapInfoImpl implements _SnapInfo {
             const DeepCollectionEquality().equals(other._channels, _channels));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -4888,7 +5175,9 @@ class _$SnapInfoImpl implements _SnapInfo {
       license,
       const DeepCollectionEquality().hash(_channels));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
@@ -4935,8 +5224,11 @@ abstract class _SnapInfo implements SnapInfo {
   String get license;
   @override
   List<ChannelSnapInfo> get channels;
+
+  /// Create a copy of SnapInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SnapInfoImplCopyWith<_$SnapInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4952,8 +5244,12 @@ mixin _$DriversResponse {
   bool get localOnly => throw _privateConstructorUsedError;
   bool get searchDrivers => throw _privateConstructorUsedError;
 
+  /// Serializes this DriversResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DriversResponseCopyWith<DriversResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -4981,6 +5277,8 @@ class _$DriversResponseCopyWithImpl<$Res, $Val extends DriversResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5033,6 +5331,8 @@ class __$$DriversResponseImplCopyWithImpl<$Res>
       _$DriversResponseImpl _value, $Res Function(_$DriversResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5110,12 +5410,14 @@ class _$DriversResponseImpl implements _DriversResponse {
                 other.searchDrivers == searchDrivers));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, install,
       const DeepCollectionEquality().hash(_drivers), localOnly, searchDrivers);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
@@ -5148,8 +5450,11 @@ abstract class _DriversResponse implements DriversResponse {
   bool get localOnly;
   @override
   bool get searchDrivers;
+
+  /// Create a copy of DriversResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DriversResponseImplCopyWith<_$DriversResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5162,8 +5467,12 @@ OEMResponse _$OEMResponseFromJson(Map<String, dynamic> json) {
 mixin _$OEMResponse {
   List<String>? get metapackages => throw _privateConstructorUsedError;
 
+  /// Serializes this OEMResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OEMResponseCopyWith<OEMResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5187,6 +5496,8 @@ class _$OEMResponseCopyWithImpl<$Res, $Val extends OEMResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5220,6 +5531,8 @@ class __$$OEMResponseImplCopyWithImpl<$Res>
       _$OEMResponseImpl _value, $Res Function(_$OEMResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5267,12 +5580,14 @@ class _$OEMResponseImpl implements _OEMResponse {
                 .equals(other._metapackages, _metapackages));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_metapackages));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
@@ -5295,8 +5610,11 @@ abstract class _OEMResponse implements OEMResponse {
 
   @override
   List<String>? get metapackages;
+
+  /// Create a copy of OEMResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OEMResponseImplCopyWith<_$OEMResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5309,8 +5627,12 @@ CodecsData _$CodecsDataFromJson(Map<String, dynamic> json) {
 mixin _$CodecsData {
   bool get install => throw _privateConstructorUsedError;
 
+  /// Serializes this CodecsData to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $CodecsDataCopyWith<CodecsData> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5334,6 +5656,8 @@ class _$CodecsDataCopyWithImpl<$Res, $Val extends CodecsData>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5367,6 +5691,8 @@ class __$$CodecsDataImplCopyWithImpl<$Res>
       _$CodecsDataImpl _value, $Res Function(_$CodecsDataImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5405,11 +5731,13 @@ class _$CodecsDataImpl implements _CodecsData {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
@@ -5431,8 +5759,11 @@ abstract class _CodecsData implements CodecsData {
 
   @override
   bool get install;
+
+  /// Create a copy of CodecsData
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$CodecsDataImplCopyWith<_$CodecsDataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5445,8 +5776,12 @@ DriversPayload _$DriversPayloadFromJson(Map<String, dynamic> json) {
 mixin _$DriversPayload {
   bool get install => throw _privateConstructorUsedError;
 
+  /// Serializes this DriversPayload to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DriversPayloadCopyWith<DriversPayload> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5470,6 +5805,8 @@ class _$DriversPayloadCopyWithImpl<$Res, $Val extends DriversPayload>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5503,6 +5840,8 @@ class __$$DriversPayloadImplCopyWithImpl<$Res>
       _$DriversPayloadImpl _value, $Res Function(_$DriversPayloadImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5541,11 +5880,13 @@ class _$DriversPayloadImpl implements _DriversPayload {
             (identical(other.install, install) || other.install == install));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, install);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
@@ -5569,8 +5910,11 @@ abstract class _DriversPayload implements DriversPayload {
 
   @override
   bool get install;
+
+  /// Create a copy of DriversPayload
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DriversPayloadImplCopyWith<_$DriversPayloadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5585,8 +5929,12 @@ mixin _$SnapSelection {
   String get channel => throw _privateConstructorUsedError;
   bool get classic => throw _privateConstructorUsedError;
 
+  /// Serializes this SnapSelection to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SnapSelectionCopyWith<SnapSelection> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5610,6 +5958,8 @@ class _$SnapSelectionCopyWithImpl<$Res, $Val extends SnapSelection>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5653,6 +6003,8 @@ class __$$SnapSelectionImplCopyWithImpl<$Res>
       _$SnapSelectionImpl _value, $Res Function(_$SnapSelectionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5709,11 +6061,13 @@ class _$SnapSelectionImpl implements _SnapSelection {
             (identical(other.classic, classic) || other.classic == classic));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, channel, classic);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
@@ -5742,8 +6096,11 @@ abstract class _SnapSelection implements SnapSelection {
   String get channel;
   @override
   bool get classic;
+
+  /// Create a copy of SnapSelection
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SnapSelectionImplCopyWith<_$SnapSelectionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5758,8 +6115,12 @@ mixin _$SnapListResponse {
   List<SnapInfo> get snaps => throw _privateConstructorUsedError;
   List<SnapSelection> get selections => throw _privateConstructorUsedError;
 
+  /// Serializes this SnapListResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $SnapListResponseCopyWith<SnapListResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5786,6 +6147,8 @@ class _$SnapListResponseCopyWithImpl<$Res, $Val extends SnapListResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5832,6 +6195,8 @@ class __$$SnapListResponseImplCopyWithImpl<$Res>
       $Res Function(_$SnapListResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -5905,7 +6270,7 @@ class _$SnapListResponseImpl implements _SnapListResponse {
                 .equals(other._selections, _selections));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -5913,7 +6278,9 @@ class _$SnapListResponseImpl implements _SnapListResponse {
       const DeepCollectionEquality().hash(_snaps),
       const DeepCollectionEquality().hash(_selections));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
@@ -5943,8 +6310,11 @@ abstract class _SnapListResponse implements SnapListResponse {
   List<SnapInfo> get snaps;
   @override
   List<SnapSelection> get selections;
+
+  /// Create a copy of SnapListResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SnapListResponseImplCopyWith<_$SnapListResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5958,8 +6328,12 @@ mixin _$TimeZoneInfo {
   String get timezone => throw _privateConstructorUsedError;
   bool get fromGeoip => throw _privateConstructorUsedError;
 
+  /// Serializes this TimeZoneInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TimeZoneInfoCopyWith<TimeZoneInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -5983,6 +6357,8 @@ class _$TimeZoneInfoCopyWithImpl<$Res, $Val extends TimeZoneInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6021,6 +6397,8 @@ class __$$TimeZoneInfoImplCopyWithImpl<$Res>
       _$TimeZoneInfoImpl _value, $Res Function(_$TimeZoneInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6069,11 +6447,13 @@ class _$TimeZoneInfoImpl implements _TimeZoneInfo {
                 other.fromGeoip == fromGeoip));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, timezone, fromGeoip);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
@@ -6099,8 +6479,11 @@ abstract class _TimeZoneInfo implements TimeZoneInfo {
   String get timezone;
   @override
   bool get fromGeoip;
+
+  /// Create a copy of TimeZoneInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TimeZoneInfoImplCopyWith<_$TimeZoneInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6113,8 +6496,12 @@ UbuntuProInfo _$UbuntuProInfoFromJson(Map<String, dynamic> json) {
 mixin _$UbuntuProInfo {
   String get token => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProInfoCopyWith<UbuntuProInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6138,6 +6525,8 @@ class _$UbuntuProInfoCopyWithImpl<$Res, $Val extends UbuntuProInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6171,6 +6560,8 @@ class __$$UbuntuProInfoImplCopyWithImpl<$Res>
       _$UbuntuProInfoImpl _value, $Res Function(_$UbuntuProInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6209,11 +6600,13 @@ class _$UbuntuProInfoImpl implements _UbuntuProInfo {
             (identical(other.token, token) || other.token == token));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, token);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
@@ -6236,8 +6629,11 @@ abstract class _UbuntuProInfo implements UbuntuProInfo {
 
   @override
   String get token;
+
+  /// Create a copy of UbuntuProInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProInfoImplCopyWith<_$UbuntuProInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6251,8 +6647,12 @@ mixin _$UbuntuProResponse {
   String get token => throw _privateConstructorUsedError;
   bool get hasNetwork => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProResponseCopyWith<UbuntuProResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6276,6 +6676,8 @@ class _$UbuntuProResponseCopyWithImpl<$Res, $Val extends UbuntuProResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6314,6 +6716,8 @@ class __$$UbuntuProResponseImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6362,11 +6766,13 @@ class _$UbuntuProResponseImpl implements _UbuntuProResponse {
                 other.hasNetwork == hasNetwork));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, token, hasNetwork);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
@@ -6393,8 +6799,11 @@ abstract class _UbuntuProResponse implements UbuntuProResponse {
   String get token;
   @override
   bool get hasNetwork;
+
+  /// Create a copy of UbuntuProResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProResponseImplCopyWith<_$UbuntuProResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6409,8 +6818,12 @@ mixin _$UbuntuProGeneralInfo {
   int get universePackages => throw _privateConstructorUsedError;
   int get mainPackages => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProGeneralInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProGeneralInfoCopyWith<UbuntuProGeneralInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6435,6 +6848,8 @@ class _$UbuntuProGeneralInfoCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6478,6 +6893,8 @@ class __$$UbuntuProGeneralInfoImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProGeneralInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6538,12 +6955,14 @@ class _$UbuntuProGeneralInfoImpl implements _UbuntuProGeneralInfo {
                 other.mainPackages == mainPackages));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, eolEsmYear, universePackages, mainPackages);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
@@ -6574,8 +6993,11 @@ abstract class _UbuntuProGeneralInfo implements UbuntuProGeneralInfo {
   int get universePackages;
   @override
   int get mainPackages;
+
+  /// Create a copy of UbuntuProGeneralInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProGeneralInfoImplCopyWith<_$UbuntuProGeneralInfoImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -6589,8 +7011,12 @@ mixin _$UPCSInitiateResponse {
   String get userCode => throw _privateConstructorUsedError;
   int get validitySeconds => throw _privateConstructorUsedError;
 
+  /// Serializes this UPCSInitiateResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UPCSInitiateResponseCopyWith<UPCSInitiateResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6615,6 +7041,8 @@ class _$UPCSInitiateResponseCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6653,6 +7081,8 @@ class __$$UPCSInitiateResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSInitiateResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6702,11 +7132,13 @@ class _$UPCSInitiateResponseImpl implements _UPCSInitiateResponse {
                 other.validitySeconds == validitySeconds));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, userCode, validitySeconds);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
@@ -6734,8 +7166,11 @@ abstract class _UPCSInitiateResponse implements UPCSInitiateResponse {
   String get userCode;
   @override
   int get validitySeconds;
+
+  /// Create a copy of UPCSInitiateResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UPCSInitiateResponseImplCopyWith<_$UPCSInitiateResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -6749,8 +7184,12 @@ mixin _$UPCSWaitResponse {
   UPCSWaitStatus get status => throw _privateConstructorUsedError;
   String? get contractToken => throw _privateConstructorUsedError;
 
+  /// Serializes this UPCSWaitResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UPCSWaitResponseCopyWith<UPCSWaitResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6774,6 +7213,8 @@ class _$UPCSWaitResponseCopyWithImpl<$Res, $Val extends UPCSWaitResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6812,6 +7253,8 @@ class __$$UPCSWaitResponseImplCopyWithImpl<$Res>
       $Res Function(_$UPCSWaitResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6860,11 +7303,13 @@ class _$UPCSWaitResponseImpl implements _UPCSWaitResponse {
                 other.contractToken == contractToken));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, contractToken);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
@@ -6891,8 +7336,11 @@ abstract class _UPCSWaitResponse implements UPCSWaitResponse {
   UPCSWaitStatus get status;
   @override
   String? get contractToken;
+
+  /// Create a copy of UPCSWaitResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UPCSWaitResponseImplCopyWith<_$UPCSWaitResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6907,8 +7355,12 @@ mixin _$UbuntuProService {
   String get description => throw _privateConstructorUsedError;
   bool get autoEnabled => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProService to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProServiceCopyWith<UbuntuProService> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -6932,6 +7384,8 @@ class _$UbuntuProServiceCopyWithImpl<$Res, $Val extends UbuntuProService>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -6975,6 +7429,8 @@ class __$$UbuntuProServiceImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProServiceImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7034,11 +7490,13 @@ class _$UbuntuProServiceImpl implements _UbuntuProService {
                 other.autoEnabled == autoEnabled));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, name, description, autoEnabled);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
@@ -7068,8 +7526,11 @@ abstract class _UbuntuProService implements UbuntuProService {
   String get description;
   @override
   bool get autoEnabled;
+
+  /// Create a copy of UbuntuProService
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProServiceImplCopyWith<_$UbuntuProServiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7086,8 +7547,12 @@ mixin _$UbuntuProSubscription {
   String get contractToken => throw _privateConstructorUsedError;
   List<UbuntuProService> get services => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProSubscription to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProSubscriptionCopyWith<UbuntuProSubscription> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7116,6 +7581,8 @@ class _$UbuntuProSubscriptionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7170,6 +7637,8 @@ class __$$UbuntuProSubscriptionImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProSubscriptionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7245,12 +7714,14 @@ class _$UbuntuProSubscriptionImpl implements _UbuntuProSubscription {
             const DeepCollectionEquality().equals(other._services, _services));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, contractName, accountName,
       contractToken, const DeepCollectionEquality().hash(_services));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
@@ -7284,8 +7755,11 @@ abstract class _UbuntuProSubscription implements UbuntuProSubscription {
   String get contractToken;
   @override
   List<UbuntuProService> get services;
+
+  /// Create a copy of UbuntuProSubscription
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProSubscriptionImplCopyWith<_$UbuntuProSubscriptionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7300,8 +7774,12 @@ mixin _$UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status => throw _privateConstructorUsedError;
   UbuntuProSubscription? get subscription => throw _privateConstructorUsedError;
 
+  /// Serializes this UbuntuProCheckTokenAnswer to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $UbuntuProCheckTokenAnswerCopyWith<UbuntuProCheckTokenAnswer> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7329,6 +7807,8 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7347,6 +7827,8 @@ class _$UbuntuProCheckTokenAnswerCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $UbuntuProSubscriptionCopyWith<$Res>? get subscription {
@@ -7386,6 +7868,8 @@ class __$$UbuntuProCheckTokenAnswerImplCopyWithImpl<$Res>
       $Res Function(_$UbuntuProCheckTokenAnswerImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7434,11 +7918,13 @@ class _$UbuntuProCheckTokenAnswerImpl implements _UbuntuProCheckTokenAnswer {
                 other.subscription == subscription));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, subscription);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
@@ -7466,8 +7952,11 @@ abstract class _UbuntuProCheckTokenAnswer implements UbuntuProCheckTokenAnswer {
   UbuntuProCheckTokenStatus get status;
   @override
   UbuntuProSubscription? get subscription;
+
+  /// Create a copy of UbuntuProCheckTokenAnswer
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$UbuntuProCheckTokenAnswerImplCopyWith<_$UbuntuProCheckTokenAnswerImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -7482,8 +7971,12 @@ mixin _$TaskProgress {
   int get done => throw _privateConstructorUsedError;
   int get total => throw _privateConstructorUsedError;
 
+  /// Serializes this TaskProgress to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TaskProgressCopyWith<TaskProgress> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7507,6 +8000,8 @@ class _$TaskProgressCopyWithImpl<$Res, $Val extends TaskProgress>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7550,6 +8045,8 @@ class __$$TaskProgressImplCopyWithImpl<$Res>
       _$TaskProgressImpl _value, $Res Function(_$TaskProgressImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7607,11 +8104,13 @@ class _$TaskProgressImpl implements _TaskProgress {
             (identical(other.total, total) || other.total == total));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, label, done, total);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
@@ -7640,8 +8139,11 @@ abstract class _TaskProgress implements TaskProgress {
   int get done;
   @override
   int get total;
+
+  /// Create a copy of TaskProgress
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TaskProgressImplCopyWith<_$TaskProgressImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7658,8 +8160,12 @@ mixin _$Task {
   TaskStatus get status => throw _privateConstructorUsedError;
   TaskProgress get progress => throw _privateConstructorUsedError;
 
+  /// Serializes this Task to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $TaskCopyWith<Task> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -7688,6 +8194,8 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7721,6 +8229,8 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
     ) as $Val);
   }
 
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $TaskProgressCopyWith<$Res> get progress {
@@ -7755,6 +8265,8 @@ class __$$TaskImplCopyWithImpl<$Res>
   __$$TaskImplCopyWithImpl(_$TaskImpl _value, $Res Function(_$TaskImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7831,12 +8343,14 @@ class _$TaskImpl implements _Task {
                 other.progress == progress));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, id, kind, summary, status, progress);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
@@ -7870,8 +8384,11 @@ abstract class _Task implements Task {
   TaskStatus get status;
   @override
   TaskProgress get progress;
+
+  /// Create a copy of Task
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TaskImplCopyWith<_$TaskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -7891,8 +8408,12 @@ mixin _$Change {
   String? get err => throw _privateConstructorUsedError;
   dynamic get data => throw _privateConstructorUsedError;
 
+  /// Serializes this Change to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ChangeCopyWith<Change> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -7922,6 +8443,8 @@ class _$ChangeCopyWithImpl<$Res, $Val extends Change>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -7997,6 +8520,8 @@ class __$$ChangeImplCopyWithImpl<$Res>
       _$ChangeImpl _value, $Res Function(_$ChangeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8106,7 +8631,7 @@ class _$ChangeImpl implements _Change {
             const DeepCollectionEquality().equals(other.data, data));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8119,7 +8644,9 @@ class _$ChangeImpl implements _Change {
       err,
       const DeepCollectionEquality().hash(data));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
@@ -8162,8 +8689,11 @@ abstract class _Change implements Change {
   String? get err;
   @override
   dynamic get data;
+
+  /// Create a copy of Change
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ChangeImplCopyWith<_$ChangeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8178,8 +8708,12 @@ mixin _$MirrorCheckResponse {
   MirrorCheckStatus get status => throw _privateConstructorUsedError;
   String get output => throw _privateConstructorUsedError;
 
+  /// Serializes this MirrorCheckResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MirrorCheckResponseCopyWith<MirrorCheckResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8203,6 +8737,8 @@ class _$MirrorCheckResponseCopyWithImpl<$Res, $Val extends MirrorCheckResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8246,6 +8782,8 @@ class __$$MirrorCheckResponseImplCopyWithImpl<$Res>
       $Res Function(_$MirrorCheckResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8301,11 +8839,13 @@ class _$MirrorCheckResponseImpl implements _MirrorCheckResponse {
             (identical(other.output, output) || other.output == output));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, url, status, output);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
@@ -8335,8 +8875,11 @@ abstract class _MirrorCheckResponse implements MirrorCheckResponse {
   MirrorCheckStatus get status;
   @override
   String get output;
+
+  /// Create a copy of MirrorCheckResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MirrorCheckResponseImplCopyWith<_$MirrorCheckResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8352,8 +8895,12 @@ mixin _$MirrorPost {
   String? get staged => throw _privateConstructorUsedError;
   bool? get useDuringInstallation => throw _privateConstructorUsedError;
 
+  /// Serializes this MirrorPost to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MirrorPostCopyWith<MirrorPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8381,6 +8928,8 @@ class _$MirrorPostCopyWithImpl<$Res, $Val extends MirrorPost>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8433,6 +8982,8 @@ class __$$MirrorPostImplCopyWithImpl<$Res>
       _$MirrorPostImpl _value, $Res Function(_$MirrorPostImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8510,7 +9061,7 @@ class _$MirrorPostImpl implements _MirrorPost {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8519,7 +9070,9 @@ class _$MirrorPostImpl implements _MirrorPost {
       staged,
       useDuringInstallation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
@@ -8551,8 +9104,11 @@ abstract class _MirrorPost implements MirrorPost {
   String? get staged;
   @override
   bool? get useDuringInstallation;
+
+  /// Create a copy of MirrorPost
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MirrorPostImplCopyWith<_$MirrorPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8569,8 +9125,12 @@ mixin _$MirrorGet {
   String? get staged => throw _privateConstructorUsedError;
   bool get useDuringInstallation => throw _privateConstructorUsedError;
 
+  /// Serializes this MirrorGet to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $MirrorGetCopyWith<MirrorGet> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8598,6 +9158,8 @@ class _$MirrorGetCopyWithImpl<$Res, $Val extends MirrorGet>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8656,6 +9218,8 @@ class __$$MirrorGetImplCopyWithImpl<$Res>
       _$MirrorGetImpl _value, $Res Function(_$MirrorGetImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8741,7 +9305,7 @@ class _$MirrorGetImpl implements _MirrorGet {
                 other.useDuringInstallation == useDuringInstallation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -8751,7 +9315,9 @@ class _$MirrorGetImpl implements _MirrorGet {
       staged,
       useDuringInstallation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
@@ -8786,8 +9352,11 @@ abstract class _MirrorGet implements MirrorGet {
   String? get staged;
   @override
   bool get useDuringInstallation;
+
+  /// Create a copy of MirrorGet
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MirrorGetImplCopyWith<_$MirrorGetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8802,8 +9371,12 @@ mixin _$AdConnectionInfo {
   String get domainName => throw _privateConstructorUsedError;
   String get password => throw _privateConstructorUsedError;
 
+  /// Serializes this AdConnectionInfo to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AdConnectionInfoCopyWith<AdConnectionInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8827,6 +9400,8 @@ class _$AdConnectionInfoCopyWithImpl<$Res, $Val extends AdConnectionInfo>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8870,6 +9445,8 @@ class __$$AdConnectionInfoImplCopyWithImpl<$Res>
       $Res Function(_$AdConnectionInfoImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -8931,11 +9508,13 @@ class _$AdConnectionInfoImpl implements _AdConnectionInfo {
                 other.password == password));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, adminName, domainName, password);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
@@ -8965,8 +9544,11 @@ abstract class _AdConnectionInfo implements AdConnectionInfo {
   String get domainName;
   @override
   String get password;
+
+  /// Create a copy of AdConnectionInfo
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AdConnectionInfoImplCopyWith<_$AdConnectionInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -8983,8 +9565,12 @@ mixin _$OsProber {
   String? get subpath => throw _privateConstructorUsedError;
   String? get version => throw _privateConstructorUsedError;
 
+  /// Serializes this OsProber to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $OsProberCopyWith<OsProber> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9012,6 +9598,8 @@ class _$OsProberCopyWithImpl<$Res, $Val extends OsProber>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9070,6 +9658,8 @@ class __$$OsProberImplCopyWithImpl<$Res>
       _$OsProberImpl _value, $Res Function(_$OsProberImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9145,12 +9735,14 @@ class _$OsProberImpl implements _OsProber {
             (identical(other.version, version) || other.version == version));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, long, label, type, subpath, version);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
@@ -9185,8 +9777,11 @@ abstract class _OsProber implements OsProber {
   String? get subpath;
   @override
   String? get version;
+
+  /// Create a copy of OsProber
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$OsProberImplCopyWith<_$OsProberImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9294,8 +9889,13 @@ mixin _$PartitionOrGap {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this PartitionOrGap to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PartitionOrGapCopyWith<PartitionOrGap> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9319,6 +9919,8 @@ class _$PartitionOrGapCopyWithImpl<$Res, $Val extends PartitionOrGap>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9374,6 +9976,8 @@ class __$$PartitionImplCopyWithImpl<$Res>
       _$PartitionImpl _value, $Res Function(_$PartitionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9457,6 +10061,8 @@ class __$$PartitionImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $OsProberCopyWith<$Res>? get os {
@@ -9570,7 +10176,7 @@ class _$PartitionImpl implements Partition {
             (identical(other.isInUse, isInUse) || other.isInUse == isInUse));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -9590,7 +10196,9 @@ class _$PartitionImpl implements Partition {
       path,
       isInUse);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
@@ -9783,8 +10391,11 @@ abstract class Partition implements PartitionOrGap {
   bool? get resize;
   String? get path;
   bool get isInUse;
+
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PartitionImplCopyWith<_$PartitionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -9806,6 +10417,8 @@ class __$$GapImplCopyWithImpl<$Res>
   __$$GapImplCopyWithImpl(_$GapImpl _value, $Res Function(_$GapImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -9868,11 +10481,13 @@ class _$GapImpl implements Gap {
             (identical(other.usable, usable) || other.usable == usable));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, offset, size, usable);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
@@ -10009,8 +10624,11 @@ abstract class Gap implements PartitionOrGap {
   @override
   int get size;
   GapUsable get usable;
+
+  /// Create a copy of PartitionOrGap
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GapImplCopyWith<_$GapImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10024,8 +10642,12 @@ mixin _$ZFS {
   String get volume => throw _privateConstructorUsedError;
   Map<String, dynamic>? get properties => throw _privateConstructorUsedError;
 
+  /// Serializes this ZFS to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ZFSCopyWith<ZFS> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10046,6 +10668,8 @@ class _$ZFSCopyWithImpl<$Res, $Val extends ZFS> implements $ZFSCopyWith<$Res> {
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10080,6 +10704,8 @@ class __$$ZFSImplCopyWithImpl<$Res> extends _$ZFSCopyWithImpl<$Res, _$ZFSImpl>
   __$$ZFSImplCopyWithImpl(_$ZFSImpl _value, $Res Function(_$ZFSImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10136,12 +10762,14 @@ class _$ZFSImpl implements _ZFS {
                 .equals(other._properties, _properties));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, volume, const DeepCollectionEquality().hash(_properties));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
@@ -10166,8 +10794,11 @@ abstract class _ZFS implements ZFS {
   String get volume;
   @override
   Map<String, dynamic>? get properties;
+
+  /// Create a copy of ZFS
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ZFSImplCopyWith<_$ZFSImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10186,8 +10817,12 @@ mixin _$ZPool {
   Map<String, dynamic>? get fsProperties => throw _privateConstructorUsedError;
   bool? get defaultFeatures => throw _privateConstructorUsedError;
 
+  /// Serializes this ZPool to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ZPoolCopyWith<ZPool> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10217,6 +10852,8 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10255,6 +10892,8 @@ class _$ZPoolCopyWithImpl<$Res, $Val extends ZPool>
     ) as $Val);
   }
 
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ZFSCopyWith<$Res>? get zfses {
@@ -10295,6 +10934,8 @@ class __$$ZPoolImplCopyWithImpl<$Res>
       _$ZPoolImpl _value, $Res Function(_$ZPoolImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10402,7 +11043,7 @@ class _$ZPoolImpl implements _ZPool {
                 other.defaultFeatures == defaultFeatures));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -10413,7 +11054,9 @@ class _$ZPoolImpl implements _ZPool {
       const DeepCollectionEquality().hash(_fsProperties),
       defaultFeatures);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
@@ -10450,8 +11093,11 @@ abstract class _ZPool implements ZPool {
   Map<String, dynamic>? get fsProperties;
   @override
   bool? get defaultFeatures;
+
+  /// Create a copy of ZPool
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ZPoolImplCopyWith<_$ZPoolImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10478,8 +11124,12 @@ mixin _$Disk {
   String? get vendor => throw _privateConstructorUsedError;
   bool get hasInUsePartition => throw _privateConstructorUsedError;
 
+  /// Serializes this Disk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $DiskCopyWith<Disk> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -10516,6 +11166,8 @@ class _$DiskCopyWithImpl<$Res, $Val extends Disk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10632,6 +11284,8 @@ class __$$DiskImplCopyWithImpl<$Res>
   __$$DiskImplCopyWithImpl(_$DiskImpl _value, $Res Function(_$DiskImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -10819,7 +11473,7 @@ class _$DiskImpl implements _Disk {
                 other.hasInUsePartition == hasInUsePartition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -10839,7 +11493,9 @@ class _$DiskImpl implements _Disk {
       vendor,
       hasInUsePartition);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
@@ -10903,8 +11559,11 @@ abstract class _Disk implements Disk {
   String? get vendor;
   @override
   bool get hasInUsePartition;
+
+  /// Create a copy of Disk
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$DiskImplCopyWith<_$DiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -10921,8 +11580,12 @@ mixin _$GuidedDisallowedCapability {
       throw _privateConstructorUsedError;
   String? get message => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedDisallowedCapability to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedDisallowedCapabilityCopyWith<GuidedDisallowedCapability>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -10951,6 +11614,8 @@ class _$GuidedDisallowedCapabilityCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11000,6 +11665,8 @@ class __$$GuidedDisallowedCapabilityImplCopyWithImpl<$Res>
       $Res Function(_$GuidedDisallowedCapabilityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11057,11 +11724,13 @@ class _$GuidedDisallowedCapabilityImpl implements _GuidedDisallowedCapability {
             (identical(other.message, message) || other.message == message));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, capability, reason, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
@@ -11092,8 +11761,11 @@ abstract class _GuidedDisallowedCapability
   GuidedDisallowedCapabilityReason get reason;
   @override
   String? get message;
+
+  /// Create a copy of GuidedDisallowedCapability
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedDisallowedCapabilityImplCopyWith<_$GuidedDisallowedCapabilityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -11112,8 +11784,12 @@ mixin _$StorageResponse {
   Map<String, dynamic>? get dasd => throw _privateConstructorUsedError;
   int get storageVersion => throw _privateConstructorUsedError;
 
+  /// Serializes this StorageResponse to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $StorageResponseCopyWith<StorageResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11146,6 +11822,8 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11189,6 +11867,8 @@ class _$StorageResponseCopyWithImpl<$Res, $Val extends StorageResponse>
     ) as $Val);
   }
 
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -11231,6 +11911,8 @@ class __$$StorageResponseImplCopyWithImpl<$Res>
       _$StorageResponseImpl _value, $Res Function(_$StorageResponseImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11356,7 +12038,7 @@ class _$StorageResponseImpl implements _StorageResponse {
                 other.storageVersion == storageVersion));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11368,7 +12050,9 @@ class _$StorageResponseImpl implements _StorageResponse {
       const DeepCollectionEquality().hash(_dasd),
       storageVersion);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
@@ -11410,8 +12094,11 @@ abstract class _StorageResponse implements StorageResponse {
   Map<String, dynamic>? get dasd;
   @override
   int get storageVersion;
+
+  /// Create a copy of StorageResponse
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StorageResponseImplCopyWith<_$StorageResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11429,8 +12116,12 @@ mixin _$StorageResponseV2 {
   bool? get needBoot => throw _privateConstructorUsedError;
   int? get installMinimumSize => throw _privateConstructorUsedError;
 
+  /// Serializes this StorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $StorageResponseV2CopyWith<StorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11462,6 +12153,8 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11500,6 +12193,8 @@ class _$StorageResponseV2CopyWithImpl<$Res, $Val extends StorageResponseV2>
     ) as $Val);
   }
 
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -11541,6 +12236,8 @@ class __$$StorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$StorageResponseV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11637,7 +12334,7 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
                 other.installMinimumSize == installMinimumSize));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -11648,7 +12345,9 @@ class _$StorageResponseV2Impl implements _StorageResponseV2 {
       needBoot,
       installMinimumSize);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
@@ -11687,8 +12386,11 @@ abstract class _StorageResponseV2 implements StorageResponseV2 {
   bool? get needBoot;
   @override
   int? get installMinimumSize;
+
+  /// Create a copy of StorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$StorageResponseV2ImplCopyWith<_$StorageResponseV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11704,8 +12406,12 @@ mixin _$GuidedResizeValues {
   int get recommended => throw _privateConstructorUsedError;
   int get maximum => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedResizeValues to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedResizeValuesCopyWith<GuidedResizeValues> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -11729,6 +12435,8 @@ class _$GuidedResizeValuesCopyWithImpl<$Res, $Val extends GuidedResizeValues>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11777,6 +12485,8 @@ class __$$GuidedResizeValuesImplCopyWithImpl<$Res>
       $Res Function(_$GuidedResizeValuesImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -11845,12 +12555,14 @@ class _$GuidedResizeValuesImpl implements _GuidedResizeValues {
             (identical(other.maximum, maximum) || other.maximum == maximum));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, installMax, minimum, recommended, maximum);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
@@ -11883,8 +12595,11 @@ abstract class _GuidedResizeValues implements GuidedResizeValues {
   int get recommended;
   @override
   int get maximum;
+
+  /// Create a copy of GuidedResizeValues
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedResizeValuesImplCopyWith<_$GuidedResizeValuesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12033,8 +12748,13 @@ mixin _$GuidedStorageTarget {
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this GuidedStorageTarget to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedStorageTargetCopyWith<GuidedStorageTarget> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -12060,6 +12780,8 @@ class _$GuidedStorageTargetCopyWithImpl<$Res, $Val extends GuidedStorageTarget>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12104,6 +12826,8 @@ class __$$GuidedStorageTargetReformatImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetReformatImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12183,7 +12907,7 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12191,7 +12915,9 @@ class _$GuidedStorageTargetReformatImpl implements GuidedStorageTargetReformat {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
@@ -12365,8 +13091,11 @@ abstract class GuidedStorageTargetReformat implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetReformatImplCopyWith<_$GuidedStorageTargetReformatImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -12401,6 +13130,8 @@ class __$$GuidedStorageTargetResizeImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetResizeImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12526,7 +13257,7 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12539,7 +13270,9 @@ class _$GuidedStorageTargetResizeImpl implements GuidedStorageTargetResize {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
@@ -12726,8 +13459,11 @@ abstract class GuidedStorageTargetResize implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetResizeImplCopyWith<_$GuidedStorageTargetResizeImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -12758,6 +13494,8 @@ class __$$GuidedStorageTargetEraseInstallImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetEraseInstallImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -12848,7 +13586,7 @@ class _$GuidedStorageTargetEraseInstallImpl
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -12857,7 +13595,9 @@ class _$GuidedStorageTargetEraseInstallImpl
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetEraseInstallImplCopyWith<
@@ -13034,8 +13774,11 @@ abstract class GuidedStorageTargetEraseInstall implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetEraseInstallImplCopyWith<
           _$GuidedStorageTargetEraseInstallImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -13067,6 +13810,8 @@ class __$$GuidedStorageTargetUseGapImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetUseGapImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13154,7 +13899,7 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -13163,7 +13908,9 @@ class _$GuidedStorageTargetUseGapImpl implements GuidedStorageTargetUseGap {
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
@@ -13339,8 +14086,11 @@ abstract class GuidedStorageTargetUseGap implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetUseGapImplCopyWith<_$GuidedStorageTargetUseGapImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13369,6 +14119,8 @@ class __$$GuidedStorageTargetManualImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageTargetManualImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13437,14 +14189,16 @@ class _$GuidedStorageTargetManualImpl implements GuidedStorageTargetManual {
                 .equals(other._disallowed, _disallowed));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(_allowed),
       const DeepCollectionEquality().hash(_disallowed));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
@@ -13616,8 +14370,11 @@ abstract class GuidedStorageTargetManual implements GuidedStorageTarget {
   List<GuidedCapability> get allowed;
   @override
   List<GuidedDisallowedCapability> get disallowed;
+
+  /// Create a copy of GuidedStorageTarget
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageTargetManualImplCopyWith<_$GuidedStorageTargetManualImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -13631,8 +14388,12 @@ mixin _$RecoveryKey {
   String? get liveLocation => throw _privateConstructorUsedError;
   String? get backupLocation => throw _privateConstructorUsedError;
 
+  /// Serializes this RecoveryKey to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RecoveryKeyCopyWith<RecoveryKey> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13656,6 +14417,8 @@ class _$RecoveryKeyCopyWithImpl<$Res, $Val extends RecoveryKey>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13694,6 +14457,8 @@ class __$$RecoveryKeyImplCopyWithImpl<$Res>
       _$RecoveryKeyImpl _value, $Res Function(_$RecoveryKeyImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13742,11 +14507,13 @@ class _$RecoveryKeyImpl implements _RecoveryKey {
                 other.backupLocation == backupLocation));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, liveLocation, backupLocation);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
@@ -13772,8 +14539,11 @@ abstract class _RecoveryKey implements RecoveryKey {
   String? get liveLocation;
   @override
   String? get backupLocation;
+
+  /// Create a copy of RecoveryKey
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RecoveryKeyImplCopyWith<_$RecoveryKeyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13792,8 +14562,12 @@ mixin _$GuidedChoiceV2 {
   bool get resetPartition => throw _privateConstructorUsedError;
   int? get resetPartitionSize => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedChoiceV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedChoiceV2CopyWith<GuidedChoiceV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -13827,6 +14601,8 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -13870,6 +14646,8 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     ) as $Val);
   }
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedStorageTargetCopyWith<$Res> get target {
@@ -13878,6 +14656,8 @@ class _$GuidedChoiceV2CopyWithImpl<$Res, $Val extends GuidedChoiceV2>
     });
   }
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RecoveryKeyCopyWith<$Res>? get recoveryKey {
@@ -13922,6 +14702,8 @@ class __$$GuidedChoiceV2ImplCopyWithImpl<$Res>
       _$GuidedChoiceV2Impl _value, $Res Function(_$GuidedChoiceV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14022,12 +14804,14 @@ class _$GuidedChoiceV2Impl implements _GuidedChoiceV2 {
                 other.resetPartitionSize == resetPartitionSize));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, target, capability, password,
       recoveryKey, sizingPolicy, resetPartition, resetPartitionSize);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
@@ -14069,8 +14853,11 @@ abstract class _GuidedChoiceV2 implements GuidedChoiceV2 {
   bool get resetPartition;
   @override
   int? get resetPartitionSize;
+
+  /// Create a copy of GuidedChoiceV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedChoiceV2ImplCopyWith<_$GuidedChoiceV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14087,8 +14874,12 @@ mixin _$GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured => throw _privateConstructorUsedError;
   List<GuidedStorageTarget> get targets => throw _privateConstructorUsedError;
 
+  /// Serializes this GuidedStorageResponseV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $GuidedStorageResponseV2CopyWith<GuidedStorageResponseV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14120,6 +14911,8 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14148,6 +14941,8 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ErrorReportRefCopyWith<$Res>? get errorReport {
@@ -14160,6 +14955,8 @@ class _$GuidedStorageResponseV2CopyWithImpl<$Res,
     });
   }
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $GuidedChoiceV2CopyWith<$Res>? get configured {
@@ -14204,6 +15001,8 @@ class __$$GuidedStorageResponseV2ImplCopyWithImpl<$Res>
       $Res Function(_$GuidedStorageResponseV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14279,12 +15078,14 @@ class _$GuidedStorageResponseV2Impl implements _GuidedStorageResponseV2 {
             const DeepCollectionEquality().equals(other._targets, _targets));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, status, errorReport, configured,
       const DeepCollectionEquality().hash(_targets));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
@@ -14317,8 +15118,11 @@ abstract class _GuidedStorageResponseV2 implements GuidedStorageResponseV2 {
   GuidedChoiceV2? get configured;
   @override
   List<GuidedStorageTarget> get targets;
+
+  /// Create a copy of GuidedStorageResponseV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$GuidedStorageResponseV2ImplCopyWith<_$GuidedStorageResponseV2Impl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -14333,8 +15137,12 @@ mixin _$AddPartitionV2 {
   Partition get partition => throw _privateConstructorUsedError;
   Gap get gap => throw _privateConstructorUsedError;
 
+  /// Serializes this AddPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $AddPartitionV2CopyWith<AddPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14358,6 +15166,8 @@ class _$AddPartitionV2CopyWithImpl<$Res, $Val extends AddPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14401,6 +15211,8 @@ class __$$AddPartitionV2ImplCopyWithImpl<$Res>
       _$AddPartitionV2Impl _value, $Res Function(_$AddPartitionV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14456,7 +15268,7 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
             const DeepCollectionEquality().equals(other.gap, gap));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType,
@@ -14464,7 +15276,9 @@ class _$AddPartitionV2Impl implements _AddPartitionV2 {
       const DeepCollectionEquality().hash(partition),
       const DeepCollectionEquality().hash(gap));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
@@ -14494,8 +15308,11 @@ abstract class _AddPartitionV2 implements AddPartitionV2 {
   Partition get partition;
   @override
   Gap get gap;
+
+  /// Create a copy of AddPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AddPartitionV2ImplCopyWith<_$AddPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14509,8 +15326,12 @@ mixin _$ModifyPartitionV2 {
   String get diskId => throw _privateConstructorUsedError;
   Partition get partition => throw _privateConstructorUsedError;
 
+  /// Serializes this ModifyPartitionV2 to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ModifyPartitionV2CopyWith<ModifyPartitionV2> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14534,6 +15355,8 @@ class _$ModifyPartitionV2CopyWithImpl<$Res, $Val extends ModifyPartitionV2>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14572,6 +15395,8 @@ class __$$ModifyPartitionV2ImplCopyWithImpl<$Res>
       $Res Function(_$ModifyPartitionV2Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14619,12 +15444,14 @@ class _$ModifyPartitionV2Impl implements _ModifyPartitionV2 {
             const DeepCollectionEquality().equals(other.partition, partition));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, diskId, const DeepCollectionEquality().hash(partition));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
@@ -14651,8 +15478,11 @@ abstract class _ModifyPartitionV2 implements ModifyPartitionV2 {
   String get diskId;
   @override
   Partition get partition;
+
+  /// Create a copy of ModifyPartitionV2
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ModifyPartitionV2ImplCopyWith<_$ModifyPartitionV2Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14666,8 +15496,12 @@ mixin _$ReformatDisk {
   String get diskId => throw _privateConstructorUsedError;
   String? get ptable => throw _privateConstructorUsedError;
 
+  /// Serializes this ReformatDisk to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ReformatDiskCopyWith<ReformatDisk> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -14691,6 +15525,8 @@ class _$ReformatDiskCopyWithImpl<$Res, $Val extends ReformatDisk>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14729,6 +15565,8 @@ class __$$ReformatDiskImplCopyWithImpl<$Res>
       _$ReformatDiskImpl _value, $Res Function(_$ReformatDiskImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -14775,11 +15613,13 @@ class _$ReformatDiskImpl implements _ReformatDisk {
             (identical(other.ptable, ptable) || other.ptable == ptable));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, diskId, ptable);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
@@ -14805,8 +15645,11 @@ abstract class _ReformatDisk implements ReformatDisk {
   String get diskId;
   @override
   String? get ptable;
+
+  /// Create a copy of ReformatDisk
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ReformatDiskImplCopyWith<_$ReformatDiskImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/assets/whitelabel.yml
+++ b/packages/ubuntu_provision/assets/whitelabel.yml
@@ -39,6 +39,8 @@ pages:
     image: "assets/images/disk.svg"
   passphrase:
     image: "assets/images/passphrase.svg"
+  recovery-key:
+    image: "assets/images/passphrase.svg"
   confirm:
     image: "assets/images/summary.svg"
   identity:

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
@@ -23,8 +23,12 @@ mixin _$PageConfigEntry {
   String? get image => throw _privateConstructorUsedError;
   bool get visible => throw _privateConstructorUsedError;
 
+  /// Serializes this PageConfigEntry to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PageConfigEntryCopyWith<PageConfigEntry> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -48,6 +52,8 @@ class _$PageConfigEntryCopyWithImpl<$Res, $Val extends PageConfigEntry>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -86,6 +92,8 @@ class __$$PageConfigEntryImplCopyWithImpl<$Res>
       _$PageConfigEntryImpl _value, $Res Function(_$PageConfigEntryImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -133,11 +141,13 @@ class _$PageConfigEntryImpl implements _PageConfigEntry {
             (identical(other.visible, visible) || other.visible == visible));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, image, visible);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
@@ -163,8 +173,11 @@ abstract class _PageConfigEntry implements PageConfigEntry {
   String? get image;
   @override
   bool get visible;
+
+  /// Create a copy of PageConfigEntry
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -178,8 +191,12 @@ mixin _$PageConfig {
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages => throw _privateConstructorUsedError;
 
+  /// Serializes this PageConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $PageConfigCopyWith<PageConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -203,6 +220,8 @@ class _$PageConfigCopyWithImpl<$Res, $Val extends PageConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -236,6 +255,8 @@ class __$$PageConfigImplCopyWithImpl<$Res>
       _$PageConfigImpl _value, $Res Function(_$PageConfigImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -284,12 +305,14 @@ class _$PageConfigImpl implements _PageConfig {
             const DeepCollectionEquality().equals(other._pages, _pages));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_pages));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
@@ -314,8 +337,11 @@ abstract class _PageConfig implements PageConfig {
   @override
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages;
+
+  /// Create a copy of PageConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/page_config_service.freezed.dart
@@ -23,12 +23,8 @@ mixin _$PageConfigEntry {
   String? get image => throw _privateConstructorUsedError;
   bool get visible => throw _privateConstructorUsedError;
 
-  /// Serializes this PageConfigEntry to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $PageConfigEntryCopyWith<PageConfigEntry> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -52,8 +48,6 @@ class _$PageConfigEntryCopyWithImpl<$Res, $Val extends PageConfigEntry>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -92,8 +86,6 @@ class __$$PageConfigEntryImplCopyWithImpl<$Res>
       _$PageConfigEntryImpl _value, $Res Function(_$PageConfigEntryImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -141,13 +133,11 @@ class _$PageConfigEntryImpl implements _PageConfigEntry {
             (identical(other.visible, visible) || other.visible == visible));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, image, visible);
 
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
@@ -173,11 +163,8 @@ abstract class _PageConfigEntry implements PageConfigEntry {
   String? get image;
   @override
   bool get visible;
-
-  /// Create a copy of PageConfigEntry
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PageConfigEntryImplCopyWith<_$PageConfigEntryImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -191,12 +178,8 @@ mixin _$PageConfig {
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages => throw _privateConstructorUsedError;
 
-  /// Serializes this PageConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $PageConfigCopyWith<PageConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -220,8 +203,6 @@ class _$PageConfigCopyWithImpl<$Res, $Val extends PageConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -255,8 +236,6 @@ class __$$PageConfigImplCopyWithImpl<$Res>
       _$PageConfigImpl _value, $Res Function(_$PageConfigImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -305,14 +284,12 @@ class _$PageConfigImpl implements _PageConfig {
             const DeepCollectionEquality().equals(other._pages, _pages));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_pages));
 
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
@@ -337,11 +314,8 @@ abstract class _PageConfig implements PageConfig {
   @override
   @PageConfigEntryConverter()
   Map<String, PageConfigEntry> get pages;
-
-  /// Create a copy of PageConfig
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PageConfigImplCopyWith<_$PageConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -24,8 +24,12 @@ mixin _$ThemeConfig {
   String? get elevatedButtonColor => throw _privateConstructorUsedError;
   String? get elevatedButtonTextColor => throw _privateConstructorUsedError;
 
+  /// Serializes this ThemeConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ThemeConfigCopyWith<ThemeConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -52,6 +56,8 @@ class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -98,6 +104,8 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
       _$ThemeConfigImpl _value, $Res Function(_$ThemeConfigImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -159,12 +167,14 @@ class _$ThemeConfigImpl implements _ThemeConfig {
                 other.elevatedButtonTextColor == elevatedButtonTextColor));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
       runtimeType, accentColor, elevatedButtonColor, elevatedButtonTextColor);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
@@ -193,8 +203,11 @@ abstract class _ThemeConfig implements ThemeConfig {
   String? get elevatedButtonColor;
   @override
   String? get elevatedButtonTextColor;
+
+  /// Create a copy of ThemeConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
+++ b/packages/ubuntu_provision/lib/src/services/theme_variant_service.freezed.dart
@@ -24,12 +24,8 @@ mixin _$ThemeConfig {
   String? get elevatedButtonColor => throw _privateConstructorUsedError;
   String? get elevatedButtonTextColor => throw _privateConstructorUsedError;
 
-  /// Serializes this ThemeConfig to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ThemeConfigCopyWith<ThemeConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -56,8 +52,6 @@ class _$ThemeConfigCopyWithImpl<$Res, $Val extends ThemeConfig>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -104,8 +98,6 @@ class __$$ThemeConfigImplCopyWithImpl<$Res>
       _$ThemeConfigImpl _value, $Res Function(_$ThemeConfigImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -167,14 +159,12 @@ class _$ThemeConfigImpl implements _ThemeConfig {
                 other.elevatedButtonTextColor == elevatedButtonTextColor));
   }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType, accentColor, elevatedButtonColor, elevatedButtonTextColor);
 
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
@@ -203,11 +193,8 @@ abstract class _ThemeConfig implements ThemeConfig {
   String? get elevatedButtonColor;
   @override
   String? get elevatedButtonTextColor;
-
-  /// Create a copy of ThemeConfig
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ThemeConfigImplCopyWith<_$ThemeConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -370,6 +370,7 @@ extension UbuntuBootstrapPageTester on WidgetTester {
   Future<void> testPassphrasePage({
     required String passphrase,
     String? screenshot,
+    bool skip = false,
   }) async {
     await pumpUntilPage(PassphrasePage);
 
@@ -377,6 +378,12 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     final l10n = UbuntuBootstrapLocalizations.of(context);
 
     expect(find.titleBar(l10n.choosePassphraseTitle), findsOneWidget);
+
+    if (skip) {
+      await tapSkip();
+      await pumpAndSettle();
+      return;
+    }
 
     await enterText(
       find.textField(l10n.choosePassphraseHint),
@@ -410,6 +417,13 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     if (screenshot != null) {
       await takeScreenshot(screenshot);
     }
+
+    final checkbox = find.text(l10n.recoveryKeyConfirmation);
+    await tap(checkbox);
+    await pumpAndSettle();
+
+    await tapNext();
+    await pumpAndSettle();
   }
 
   Future<void> testConfirmPage({


### PR DESCRIPTION
Allow the user to specify a passphrase for TPM FDE (but do not _require_ that they set one) and overhaul the recovery key information page to match the new Figma designs.

This is still a work in progress for now while we wait for the Subiquity API work to be completed. One outstanding piece of functionality that needs to be implemented is making use of the `/storage/v2/calculate_entropy` endpoint when it is available to provide feedback on the user's passphrase strength.

UDENG-5816

## Screenshots
![2025-01-23_15-34](https://github.com/user-attachments/assets/4e4bf1d5-346f-4cfa-b8b2-43ec3741db12)
![2025-01-23_15-34_1](https://github.com/user-attachments/assets/8640b126-4219-4f5a-97af-7a945472ac2d)
