### PR TITLE
feat: add 'experimental-features' cli argument

### DIFF
--- a/apps/ubuntu_bootstrap/lib/app.dart
+++ b/apps/ubuntu_bootstrap/lib/app.dart
@@ -73,6 +73,12 @@ Future<void> runInstallerApp(
       // This can't be handled by the whitelabel config since if a user clicks
       // try, the next time it opens the installer the page shouldn't show.
       parser.addFlag('try-or-install', aliases: ['welcome']);
+      parser.addOption(
+        'experimental-features',
+        valueHelp: 'featureA,featureB',
+        defaultsTo: '',
+        help: 'Comma-separated list of experimental features to enable',
+      );
     },
   )!;
   final liveRun = options['dry-run'] != true;
@@ -119,6 +125,8 @@ Future<void> runInstallerApp(
     () => InstallerService(
       getService<SubiquityClient>(),
       pageConfig: getService<PageConfigService>(),
+      experimentalFeatures:
+          (options['experimental-features'] as String?)?.split(',') ?? [],
     ),
   );
   tryRegisterService(JournalService.new);

--- a/apps/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/apps/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -7,11 +7,18 @@ import 'package:ubuntu_provision/services.dart';
 final _log = Logger('installer_service');
 
 class InstallerService {
-  InstallerService(this._client, {required this.pageConfig});
+  InstallerService(
+    this._client, {
+    required this.pageConfig,
+    List<String>? experimentalFeatures,
+  }) : _experimentalFeatures = experimentalFeatures;
 
   final SubiquityClient _client;
   final PageConfigService pageConfig;
+  final List<String>? _experimentalFeatures;
   late Set<String> _pages;
+
+  List<String> get experimentalFeatures => _experimentalFeatures ?? [];
 
   Future<void> init() async {
     await _client.setVariant(Variant.DESKTOP);

--- a/apps/ubuntu_bootstrap/test/services/installer_service_test.dart
+++ b/apps/ubuntu_bootstrap/test/services/installer_service_test.dart
@@ -204,4 +204,13 @@ void main() {
 
     expect(service.hasRoute('identity'), isFalse);
   });
+
+  test('Experimental features', () async {
+    final service = InstallerService(
+      MockSubiquityClient(),
+      pageConfig: MockPageConfigService(),
+      experimentalFeatures: ['foo', 'bar'],
+    );
+    expect(service.experimentalFeatures, equals(['foo', 'bar']));
+  });
 }

--- a/apps/ubuntu_bootstrap/test/test_utils.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/test_utils.mocks.dart
@@ -233,6 +233,12 @@ class MockInstallerService extends _i1.Mock implements _i10.InstallerService {
       ) as _i3.PageConfigService);
 
   @override
+  List<String> get experimentalFeatures => (super.noSuchMethod(
+        Invocation.getter(#experimentalFeatures),
+        returnValue: <String>[],
+      ) as List<String>);
+
+  @override
   _i9.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,


### PR DESCRIPTION
Adds a `--experimental-features` command line argument that can be used to pass a comma-separated list of experimental features to be enabled. The features are exposed as a list of strings via the `InstallerService`.

@matthew-hagemann you could add something like this to the autoinstall model:
```dart
  bool get showLandscape =>
      getService<InstallerService>().experimentalFeatures.contains('landscape');
```
and then conditionally show the tile for the landscape flow.

UDENG-5754