### PR TITLE
chore: bump go toolchain

### DIFF
--- a/provd/go.mod
+++ b/provd/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/ubuntu-desktop-provision/provd
 
 go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.22.11
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf


### PR DESCRIPTION
Needed to fix two vulnerabilities:

```
Vulnerability #1: GO-2025-3420
    Sensitive headers incorrectly sent after cross-domain redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3420
  Standard library
    Found in: net/http@go1.22.5
    Fixed in: net/http@go1.22.11
    Example traces found:
      #1: internal/services/telemetry/telemetry.go:38:31: telemetry.sysmetricsImpl.SendDecline calls sysmetrics.SendDecline, which eventually calls http.Client.Do

Vulnerability #2: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.22.5
    Fixed in: crypto/x509@go1.22.11
    Example traces found:
      #1: internal/testutils/systembus.go:35:10: testutils.StartLocalSystemBus calls sync.Once.Do, which eventually calls x509.CertPool.AppendCertsFromPEM
      #2: cmd/provd/daemon/daemon_test.go:224:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify
      #3: cmd/provd/daemon/daemon_test.go:224:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.VerifyHostname
      #4: cmd/provd/daemon/daemon_test.go:449:25: daemon_test.TestMain calls fmt.Sprintf, which eventually calls x509.HostnameError.Error
      #5: internal/testutils/systembus.go:35:10: testutils.StartLocalSystemBus calls sync.Once.Do, which eventually calls x509.ParseCertificate
```