### PR TITLE
chore: bump go toolchain (24.04)

### DIFF
--- a/provd/go.mod
+++ b/provd/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/ubuntu-desktop-provision/provd
 
 go 1.22.0
 
-toolchain go1.22.5
+toolchain go1.22.11
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf


### PR DESCRIPTION
#920 for `ubuntu/24.04`