### PR TITLE
Change message when Intel RST is detected

### DIFF
--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -121,15 +121,10 @@
     }
   },
   "rstTitle": "RST detected",
-  "rstHeader": "Turn off RST to continue",
-  "rstDescription": "This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing {DISTRO} - otherwise, please boot into your system's BIOS setup and disable RST there before installing {DISTRO}.",
-  "@rstDescription": {
-    "placeholders": {
-      "DISTRO": {
-        "type": "String"
-      }
-    }
-  },
+  "rstHeader": "You must disable RST to continue installation",
+  "rstDisable": "Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:",
+  "rstDisableWindows": "Windows, if you are using a dual boot setup with Windows",
+  "rstDisableBios": "The BIOS settings",
   "rstInstructions": "For instructions, scan the QR code on another device or visit: <a href=\"https://{url}\">{url}</a>",
   "@rstInstructions": {
     "placeholders": {
@@ -583,6 +578,8 @@
       }
     }
   },
+  "restartComputer": "Restart computer",
+  "restartComputerTitle": "Restart computer?",
   "restartIntoWindows": "Restart into Windows",
   "restartIntoWindowsTitle": "Restart into Windows?",
   "restartIntoWindowsDescription": "Are you sure you want to restart your computer? You will need to restart the {DISTRO} installation later to finish installing {DISTRO}.",

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -122,7 +122,7 @@
   },
   "rstTitle": "RST detected",
   "rstHeader": "Turn off RST to continue",
-  "rstDescription": "This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing {DISTRO}.",
+  "rstDescription": "This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing {DISTRO} - otherwise, please boot into your system's BIOS setup and disable RST there before installing {DISTRO}.",
   "@rstDescription": {
     "placeholders": {
       "DISTRO": {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -506,14 +506,26 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @rstHeader.
   ///
   /// In en, this message translates to:
-  /// **'Turn off RST to continue'**
+  /// **'You must disable RST to continue installation'**
   String get rstHeader;
 
-  /// No description provided for @rstDescription.
+  /// No description provided for @rstDisable.
   ///
   /// In en, this message translates to:
-  /// **'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing {DISTRO} - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing {DISTRO}.'**
-  String rstDescription(String DISTRO);
+  /// **'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:'**
+  String get rstDisable;
+
+  /// No description provided for @rstDisableWindows.
+  ///
+  /// In en, this message translates to:
+  /// **'Windows, if you are using a dual boot setup with Windows'**
+  String get rstDisableWindows;
+
+  /// No description provided for @rstDisableBios.
+  ///
+  /// In en, this message translates to:
+  /// **'The BIOS settings'**
+  String get rstDisableBios;
 
   /// No description provided for @rstInstructions.
   ///
@@ -1534,6 +1546,18 @@ abstract class UbuntuBootstrapLocalizations {
   /// In en, this message translates to:
   /// **'For instructions, scan the QR code on another device or visit: <a href=\"https://{url}\">{url}</a>'**
   String bitlockerInstructions(String url);
+
+  /// No description provided for @restartComputer.
+  ///
+  /// In en, this message translates to:
+  /// **'Restart computer'**
+  String get restartComputer;
+
+  /// No description provided for @restartComputerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Restart computer?'**
+  String get restartComputerTitle;
 
   /// No description provided for @restartIntoWindows.
   ///

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -512,7 +512,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @rstDescription.
   ///
   /// In en, this message translates to:
-  /// **'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing {DISTRO}.'**
+  /// **'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing {DISTRO} - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing {DISTRO}.'**
   String rstDescription(String DISTRO);
 
   /// No description provided for @rstInstructions.

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'قم بإيقاف RST للمتابعة';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'يستخدم هذا الكمبيوتر Intel RST (تقنية التخزين السريع). تحتاج إلى إيقاف تشغيل RST في Windows قبل تثبيت Ubuntu.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Выключыць RST для працягу';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Гэты камп\'ютар выкарыстоўвае Intel RST (Rapid Storage Technology). Вам неабходна выключыць яго ў Windows перад усталяваннем $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Для атрымання даведкі адсканіруйце QR-код на іншай прыладзе або наведайце: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Перазапусціць у Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'Desactiva la RST.';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Aquest ordinador utilitza Intel RST (Tecnologia d\'emmagatzematge ràpid). Heu de desactivar RST a Windows abans d\'instal·lar Ubuntu.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Aby bylo možné pokračovat, vypněte RST';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Na tomto počítači je zapnutá technologie Intel RST (Rapit Storage Technology). Aby bylo možné $DISTRO nainstalovat, je třeba ve Windows funkci RST vypnout.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Ohledně pokynů naskenujte QR kód na jiném zařízení (třeba telefonu) nebo jděte na: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restartovat do Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'Diffoddwch RST';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Slå RST fra for at fortsætte';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Denne computer bruger Intel RST (Rapid Storage Technology). Før installation af $DISTRO skal du slå RST fra i Windows.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Få vejledning ved at skanne QR-koden på en anden enhed, eller besøg: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Genstart i Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Schalten Sie RST aus, um fortzufahren';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Dieser Computer verwendet Intel RST (Rapid Storage Technology). Vor der Installation von $DISTRO muss RST in Windows ausgeschaltet werden.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Für Anweisungen scannen Sie den QR-Code mit einem anderen Gerät oder besuchen Sie: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Neustart in Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'Απενεργοποίηση του RST';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Malŝaltu RST por daŭrigi';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Ĉi tiu komputilo uzas Intel RST (Rapid-Konservejan Teknikon). Vi devas malŝalti RST en Windows antaŭ ol instali $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Por instrukcioj, skanu la QR-kodon per alia aparato, aŭ vizitu la jenon: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restartigi al Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Desactive RST para continuar';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Este equipo utiliza la tecnología Intel RST (Rapid Storage Technology). Es necesario desactivar RST en Windows antes de instalar $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Para obtener instrucciones, escanee el código QR en otro dispositivo o visite: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Reiniciar en Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'Itzali RST';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Ordenagailu honek Intel RST (Rapid Storage Technology) erabiltzen du. RST itzali behar duzu Windowsen Ubuntu instalatu baino lehenago.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'برای ادامه RST را خاموش کنید';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'این رایانه از RST (فناوری ذخیره‌سازی سریع) اینتل استفاده می‌کند. باید پیش از نصب $DISTRO در ویندوز خاموشش کنید.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'برای دستورالعمل‌ها، رمز پاس را روی افزاره‌ای دیگر پوییده یا ببینید: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'آغاز دوباره به ویندوز';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Poista RST käytöstä jatkaaksesi';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Tämä tietokone käyttää Intel RST:tä (Rapid Storage Technology). Sinun tulee sammuttaa RST Windowsissa, ennen kuin asennat ${DISTRO}n.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Lue ohjeet skannaamalla QR-koodi tai käy jollain toisella laitteella: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Uudelleenkäynnistä Windowsiin';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Désactivez RST pour continuer';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Cet ordinateur utilise la technologie RST (Rapid Storage Technology) d’Intel. Il est nécessaire de désactiver RST dans Windows avant d’installer $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Pour obtenir des instructions, scannez le code QR sur un autre appareil ou visitez le site : <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Redémarrer sous Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Cas as RST chun leanúint ar aghaidh';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Úsáideann an ríomhaire seo Intel RST (Teicneolaíocht Stórála Mear). Ní mór duit RST a mhúchadh in Windows sula suiteálann tú $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Le treoracha a fháil, scanadh an cód QR ar ghléas eile nó tabhair cuairt ar: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Atosaigh isteach Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'יש לכבות את ה־RST כדי להמשיך';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'המחשב הזה משתמש ב־RST‏ (Rapid Storage Technology) מבית אינטל. יש לכבות את RST דרך Windows בטרם התקנת $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'לקבלת הנחיות, יש לסרוק את קוד ה־QR הזה במכשיר אחר או לבקר באתר: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'להפעיל מחדש אל Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Az RST kikapcsolása a folytatáshoz';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Ez a számítógép Intel RST (Rapid Storage Technology – gyors tárolótechnológia) technológiát használ. Ki kell kapcsolnia az RST-t a Windowsban a(z) $DISTRO telepítése előtt.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Az utasításokért olvassa le a QR-kódot egy másik eszközön vagy látogassa meg ezt az oldalt: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Újraindítás és Windows használata';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Nonaktifkan RST untuk melanjutkan';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Komputer ini menggunakan Intel RST (Rapid Storage Technology). Anda harus mematikan RST di Windows sebelum memasang $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Untuk petunjuk, pindai kode QR pada perangkat lain atau kunjungi: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Mulai Ulang Ke Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'Slökkva á RST';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'Disattiva RST';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Questo computer usa Intel RST (Rapid Storage Technology). Devi disattivare RST da Windows prima di poter installare Ubuntu.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get rstHeader => '続行するにはRSTをオフにしてください';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'このコンピューターは Intel RST (Rapid Storage Technology) を使用しています。$DISTRO をインストールする前に Windows で RST を無効にする必要があります。';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return '手順は、別のデバイスでQRコードをスキャンするか、<a href=\"https://$url\">$url</a>をご確認ください';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => '再起動して Windows を使用';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST ჩართულია';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get rstHeader => '계속하려면 RST를 끄십시오';
 
   @override
-  String rstDescription(String DISTRO) {
-    return '이 컴퓨터는 Intel RST (Rapid Storage Technology)를 사용합니다. $DISTRO를 설치하기 전에 Windows 에서 RST를 비활성화해야 합니다.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return '절차를 확인하려면, 다른 장치에서 QR코드를 스캔하거나 링크를 방문 하십시오: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Windows로 다시 시작';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Norėdami tęsti, išjunkite RST';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Šis kompiuteris naudoja Intel RST (Rapid Storage Technology). Prieš įdiegdami Ubuntu, turite „Windows“ sistemoje išjungti RST.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Norėdami skaityti instrukcijas, nuskenuokite kitu įrenginiu QR kodą arba apsilankykite adresu: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Paleisti iš naujo į „Windows“';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST ഓഫ് ചെയ്യുക';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'ഈ കമ്പ്യൂട്ടർ ഇന്റൽ ആർഎസ്ടി (റാപ്പിഡ് സ്റ്റോറേജ് ടെക്നോളജി) ഉപയോഗിക്കുന്നു. ഉബുണ്ടു ഇൻസ്റ്റാൾ ചെയ്യുന്നതിന് മുമ്പ് നിങ്ങൾ വിൻഡോസിൽ ആർഎസ്ടി ഓഫ് ചെയ്യേണ്ടതുണ്ട്.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'നിർദ്ദേശങ്ങൾക്കായി, ഒരു ഫോണിലോ മറ്റ് ഉപകരണത്തിലോ ഈ പേജ് തുറക്കുക: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'വിന്ഡോസിലേക്ക് പുനരാരംഭിക്കുക';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Skru av RST for å fortsette';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Denne datamaskinen bruker Intel RST (Rapid Storage Technology). Du må slå av RST i Windows før du installerer Ubuntu.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Instruks er tilgjengelig hvis du åpner denne siden på en telefon eller en annen enhet: <a href=\"https://$url\"></a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Omstart til Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST बन्द गर्नुहोस्';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST uitschakelen';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Deze computer maakt gebruik van Intel RST (Rapid Storage Technology). Om Ubuntu te installeren, is het noodzakelijk om dit uit te schakelen.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Desactivatz lo RST per contunhar';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Aqueste ordenador utiliza la tecnologia RST (Rapid Storage Technology) d’Intel. Cal desactivar RST jos Windows abans d’installar Ubuntu.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Per las consignas, numerizatz aqueste còdi QR d’un autre aparelh estant o consultatz : <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Reaviar jos Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Wyłącz funkcję RST, aby kontynuować';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Ten komputer wykorzystuje funkcję Intel RST (Rapid Storage Technology). Musisz wyłączyć RST w systemie Windows przed instalacją $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Aby uzyskać instrukcje, zeskanuj kod QR na innym urządzeniu lub odwiedź: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Uruchom ponownie do Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Desligue a RST para continuar';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Este computador usa Intel RST (Rapid Storage Technology). Precisa de desligar a RST no Windows antes de instalar o $DISTRO..';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -745,6 +749,12 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
+
+  @override
   String get restartIntoWindows => 'Reiniciar no Windows';
 
   @override
@@ -1197,11 +1207,6 @@ class UbuntuBootstrapLocalizationsPtBr extends UbuntuBootstrapLocalizationsPt {
 
   @override
   String get rstHeader => 'Desligue o RST para continuar';
-
-  @override
-  String rstDescription(String DISTRO) {
-    return 'Este computador usa Intel RST (Rapid Storage Technology). Você precisa desligar a RST no Windows antes de instalar o $DISTRO.';
-  }
 
   @override
   String rstInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Для продолжения отключите RST';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Данный компьютер использует Intel RST (Rapid Storage Technology). Перед тем, как продолжить установку $DISTRO, необходимо отключить RST в Windows.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Чтобы получить инструкции, отсканируйте QR-код на другом устройстве или посетите: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Перезагрузить в Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'ඉදිරියට යාමට RST අක්‍රිය කරන්න';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'මෙම පරිගණකය ඉන්ටෙල් RST (ශ්‍රීඝ්‍ර ආචයන තාක්‍ෂණය) භාවිතා කරයි. උබුන්ටු ස්ථාපනයට පෙර වින්ඩෝස් හි RST අක්‍රිය කළ යුතුය.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'උපදෙස් සඳහා, දුරකථනයක හෝ වෙනත් උපාංගයක මෙම පිටුව අරින්න: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'වින්ඩෝස් වෙත යළි අරඹන්න';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Ak chcete pokračovať, vypnite RST';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Tento počítač používa technológiu Intel RST (Rapid Storage Technology). Pred inštaláciou $DISTRO musíte vo Windowse vypnúť RST.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Ohľadne pokynov naskenujte QR kód na inom zariadení alebo choďte na: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Reštartovať do Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Искључите RST да бисте наставили';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Овај рачунар користи Intel RST (Rapid Storage Technology). Потребно је да искључите RST у Windows-у пре инсталације $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'За упутства, скенирајте QR код на другом уређају или посетите: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Поново покрени у Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Slå av RST för att fortsätta';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Den här datorn använder Intel RST (Rapid Storage Technology). Du måste stänga av RST i Windows innan du installerar Ubuntu.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'För instruktioner, scanna QR-koden på en annan enhet eller besök: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Starta om till Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RSTயை முடக்கு';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'ปิด RST เพื่อดำเนินการต่อ';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'คอมพิวเตอร์เครื่องนี้ใช้ Intel RST (Rapid Storage Technology) คุณต้องปิด RST ใน Windows ก่อนที่จะติดตั้ง $DISTRO';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Devam etmek için RST\'yi kapatın';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Bu bilgisayar Intel RST (Rapid Storage Technology) kullanmaktadır. Ubuntu\'yu kurmadan önce Windows\'tan RST\'yi kapatmalısınız.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Talimatlar için QR kodunu başka bir cihazda tarayın ya da <a href=\"https://$url\">$url</a> sayfasını ziyaret edin';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Windows\'a yeniden başlat';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get rstHeader => 'Вимкніть RST для продовженя';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'Цей комп’ютер використовує технологію Intel RST (Rapid Storage Technology). Перед встановленням $DISTRO вам потрібно вимкнути RST у Windows.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'Для отримання інструкцій відкрийте цю сторінку на телефоні або іншому пристрої: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Перезапустити у Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -165,7 +165,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
 
   @override
   String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). You need to turn off RST in Windows before installing $DISTRO.';
+    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
   }
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -161,12 +161,16 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get rstTitle => 'RST detected';
 
   @override
-  String get rstHeader => 'Turn off RST to continue';
+  String get rstHeader => 'You must disable RST to continue installation';
 
   @override
-  String rstDescription(String DISTRO) {
-    return 'This computer uses Intel RST (Rapid Storage Technology). On dual boot systems, you can turn off RST in Windows before installing $DISTRO - otherwise, please boot into your system\'s BIOS setup and disable RST there before installing $DISTRO.';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -743,6 +747,12 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String bitlockerInstructions(String url) {
     return 'For instructions, scan the QR code on another device or visit: <a href=\"https://$url\">$url</a>';
   }
+
+  @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
 
   @override
   String get restartIntoWindows => 'Restart into Windows';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -164,9 +164,13 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get rstHeader => '关闭 RST 以继续';
 
   @override
-  String rstDescription(String DISTRO) {
-    return '此计算机使用了英特尔 RST（快速存储技术）。在安装 $DISTRO 之前，您需要在 Windows 中关闭 RST。';
-  }
+  String get rstDisable => 'Your computer uses Intel RST (Rapid Storage Technology). You can disable RST either in:';
+
+  @override
+  String get rstDisableWindows => 'Windows, if you are using a dual boot setup with Windows';
+
+  @override
+  String get rstDisableBios => 'The BIOS settings';
 
   @override
   String rstInstructions(String url) {
@@ -745,6 +749,12 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   }
 
   @override
+  String get restartComputer => 'Restart computer';
+
+  @override
+  String get restartComputerTitle => 'Restart computer?';
+
+  @override
   String get restartIntoWindows => '重启进入 Windows';
 
   @override
@@ -1212,11 +1222,6 @@ class UbuntuBootstrapLocalizationsZhTw extends UbuntuBootstrapLocalizationsZh {
 
   @override
   String get rstHeader => '關閉 RST 以繼續安裝';
-
-  @override
-  String rstDescription(String DISTRO) {
-    return '本電腦正在使用 Intel 快速儲存技術 (Rapid Storage Technology)，在安裝 $DISTRO 之前您需要先在 Windows 下關閉該功能。';
-  }
 
   @override
   String rstInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/pages/rst/rst_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/rst/rst_page.dart
@@ -33,7 +33,10 @@ class RstPage extends ConsumerWidget with ProvisioningPage {
         leading: BackWizardButton(),
       ),
       children: [
-        Text(lang.rstDescription(flavor.displayName)),
+        Html(
+          data:
+              '${lang.rstDisable}<ul><li>${lang.rstDisableWindows}</li><li>${lang.rstDisableBios}</li></ul>',
+        ),
         const SizedBox(height: kWizardSpacing),
         Html(
           data: lang.rstInstructions('help.ubuntu.com/rst'),
@@ -49,7 +52,7 @@ class RstPage extends ConsumerWidget with ProvisioningPage {
             final window = YaruWindow.of(context);
             final confirmed = await showConfirmationDialog(
               context,
-              title: lang.restartIntoWindowsTitle,
+              title: lang.restartComputerTitle,
               message: lang.restartIntoWindowsDescription(flavor.displayName),
               okLabel: UbuntuLocalizations.of(context).restartLabel,
               okElevated: true,
@@ -59,7 +62,7 @@ class RstPage extends ConsumerWidget with ProvisioningPage {
             }
           },
           child: Text(
-            lang.restartIntoWindows,
+            lang.restartComputer,
           ),
         ),
       ],

--- a/apps/ubuntu_bootstrap/test/rst/rst_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/rst/rst_page_test.dart
@@ -21,7 +21,7 @@ void main() {
     final context = tester.element(find.byType(RstPage));
     final l10n = UbuntuBootstrapLocalizations.of(context);
 
-    final restartButton = find.button(l10n.restartIntoWindows);
+    final restartButton = find.button(l10n.restartComputer);
     expect(restartButton, findsOneWidget);
 
     final windowClosed = YaruTestWindow.waitForClosed();

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -89,7 +89,7 @@ extension UbuntuBootstrapPageTester on WidgetTester {
       await takeScreenshot(screenshot);
     }
 
-    await tapButton(l10n.restartIntoWindows);
+    await tapButton(l10n.restartComputer);
     await pumpAndSettle();
     expect(find.byType(AlertDialog), findsOneWidget);
 


### PR DESCRIPTION
The current advice message is to disable Intel RST from Windows - which only holds true and is useful if the user is using a dual boot system with windows.

I've updated this to mention that if you're not on a dual boot system, you need to disable RST in the BIOS - not super detailed but saves the user going to the web page, and gives them a better jumping off point.

I don't have a working flutter installation, so dloose offered to apply this change to the other translations.