### PR TITLE
fix: don't block 'erase and install' if bitlocker is detected

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/bitlocker/bitlocker_page.dart
@@ -15,7 +15,8 @@ class BitLockerPage extends ConsumerWidget with ProvisioningPage {
 
   @override
   Future<bool> load(BuildContext context, WidgetRef ref) {
-    if (ref.read(storageModelProvider).type == StorageType.manual) {
+    final type = ref.read(storageModelProvider).type;
+    if (type == StorageType.manual || type == StorageType.erase) {
       return Future.value(false);
     }
 

--- a/apps/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/apps/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -255,7 +255,9 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
     expect(find.byType(ConfirmPage), findsOneWidget);
-    verify(bitLockerModel.init()).called(1); // skipped
+    verifyNever(
+      bitLockerModel.init(),
+    ); // don't show bitlocker page when erasing the entire disk
     verify(guidedReformatModel.init()).called(1); // skipped
     verify(passphraseModel.init()).called(1); // skipped
     verify(recoveryKeyModel.init()).called(1); // skipped


### PR DESCRIPTION
Currently, we show the "Bitlocker" page and stop the user from continuing the installation even when selecting the "Erase disk and install" guided target. Since subiquity is capable of erasing the entire disk and installing Ubuntu in this case, we shouldn't display the page at all and let the user continue instead.

[lp:2045750](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2045750)

UDENG-5912