### PR TITLE
fix: don't block 'erase and install' if bitlocker is detected (24.04)

### DIFF
--- a/packages/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
+++ b/packages/ubuntu_bootstrap/lib/pages/storage/storage_wizard.dart
@@ -39,7 +39,7 @@ class StorageWizard extends ConsumerWidget with ProvisioningPage {
         builder: (_) => StoragePage(),
         userData: WizardRouteData(step: InstallationStep.secureBoot.pageIndex),
       ),
-      if (type != StorageType.manual)
+      if (type != StorageType.manual && type != StorageType.erase)
         StorageSteps.bitlocker.route: WizardRoute(
           builder: (_) => const BitLockerPage(),
           onLoad: (_) => const BitLockerPage().load(context, ref),

--- a/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
+++ b/packages/ubuntu_bootstrap/test/installer_wizard_test.dart
@@ -257,7 +257,9 @@ void main() {
     await tester.tapNext();
     await tester.pumpAndSettle();
     expect(find.byType(ConfirmPage), findsOneWidget);
-    verify(bitLockerModel.init()).called(1); // skipped
+    verifyNever(
+      bitLockerModel.init(),
+    ); // don't show bitlocker page when erasing the entire disk
     verify(guidedReformatModel.init()).called(1); // skipped
     verify(passphraseModel.init()).called(1); // skipped
     verify(recoveryKeyModel.init()).called(1); // skipped


### PR DESCRIPTION
#929 for `ubuntu/24.04`

UDENG-5912