### PR TITLE
chore: removing provd deb package build and upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,48 +260,6 @@ jobs:
           path: /tmp/coverage.out
           key: ${{ github.sha }}-go-test-coverage
 
-  build-and-upload:
-    if: github.event_name == 'push'
-    needs: go-tests
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        platform: [x86_64, arm64]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: matrix.platform == 'arm64'
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        if: matrix.platform == 'arm64'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Debian package in Ubuntu Docker container
-        run: |
-          if [ "${{ matrix.platform }}" == "x86_64" ]; then
-            docker run --rm -v $(pwd):/workspace -w /workspace/provd ubuntu:noble bash -c "
-              apt-get update &&
-              apt-get install -y gsettings-desktop-schemas libgtk-3-dev debhelper dh-golang golang-go &&
-              dpkg-buildpackage -us -uc -b &&
-              mv ../provd_*.deb ../provd-${{ matrix.platform }}.deb
-            "
-          else
-            docker run --rm --platform linux/arm64 -v $(pwd):/workspace -w /workspace/provd ubuntu:noble bash -c "
-              apt-get update &&
-              apt-get install -y gsettings-desktop-schemas libgtk-3-dev libglib2.0-dev debhelper dh-golang golang-go &&
-              dpkg-buildpackage -us -uc -b &&
-              mv ../provd_*.deb ../provd-${{ matrix.platform }}.deb
-            "
-          fi
-      - name: Upload Debian package
-        uses: actions/upload-artifact@v4
-        with:
-          name: provd-deb-package-${{ matrix.platform }}
-          path: provd-${{ matrix.platform }}.deb
-
   tics-coverage:
     name: Convert and upload coverage reports for TiCS
     if: github.event_name == 'push'


### PR DESCRIPTION
This was originally added to make it easier for a contractor to pull a pre-built debian package of provd. Now that provd is in launchpad and no-one on the team uses ARM64 for dev work, these CI steps are redundant.