### PR TITLE
chore: release snap with subiquity fixes for 24.04.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref 75af98756bc546a18642d54782fa30a6621fbd03
+    source-commit: &commit-ref 53dc4ec57d6b3459e806e1dc412dfe14cc7d4af9
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
@@ -68,7 +68,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 7fbc96a413ed4a85370edbdb4e7bfa456c350346
+    source-commit: 28dc844eadca33c183dfb1c455b11a38acf4f01d
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"


### PR DESCRIPTION
Includes changes from #936