### PR TITLE
chore: bump go toolchain versions

### DIFF
--- a/provd/go.mod
+++ b/provd/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/ubuntu-desktop-provision/provd
 
 go 1.22.0
 
-toolchain go1.22.11
+toolchain go1.22.12
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf

--- a/provd/tools/go.mod
+++ b/provd/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/canonical/ubuntu-desktop-provision/provd/tools
 
 go 1.21.0
 
-toolchain go1.22.5
+toolchain go1.22.12
 
 require (
 	github.com/golangci/golangci-lint v1.57.2


### PR DESCRIPTION
Fixes https://github.com/canonical/ubuntu-desktop-provision/actions/runs/13186877081/job/36810990501?pr=917#step:4:616