### PR TITLE
Fix: invalid golangci-lint config

### DIFF
--- a/provd/.golangci.yaml
+++ b/provd/.golangci.yaml
@@ -47,10 +47,6 @@ issues:
     # Sometimes it is more readable it do a `if err:=a(); err != nil` tha simpy `return a()`
     - if-return
 
-nolintlint:
-  require-explanation: true
-  require-specific: true
-
 linters-settings:
   # Forbid the usage of deprecated ioutil and debug prints
   forbidigo:
@@ -60,3 +56,7 @@ linters-settings:
   # Never have naked return ever
   nakedret:
     max-func-lines: 1
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+


### PR DESCRIPTION
Fixes the CI failure coming from the go-sanity check.

See https://github.com/ubuntu/authd/commit/a127b5d418494bc1e1cd35a38127f9301247d718

```
Go: Code sanity
Failed to run: Error: Command failed: /home/runner/golangci-lint-1.57.2-linux-amd64/golangci-lint config verify
jsonschema: "" does not validate with "/additionalProperties": additionalProperties 'nolintlint' not allowed
Error: the configuration contains invalid elements
Usage:
  golangci-lint config verify [flags]

Global Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -c, --config PATH    Read config from file path PATH
  -h, --help           Help for a command
      --no-config      Don't read config file
  -v, --verbose        Verbose output

Failed executing command with error: the configuration contains invalid elements
, Error: Command failed: /home/runner/golangci-lint-1.57.2-linux-amd64/golangci-lint config verify
jsonschema: "" does not validate with "/additionalProperties": additionalProperties 'nolintlint' not allowed
Error: the configuration contains invalid elements
Usage:
  golangci-lint config verify [flags]

Global Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -c, --config PATH    Read config from file path PATH
  -h, --help           Help for a command
      --no-config      Don't read config file
  -v, --verbose        Verbose output

Failed executing command with error: the configuration contains invalid elements

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```