### PR TITLE
chore: bump dependencies for bootstrap and curtin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref 53dc4ec57d6b3459e806e1dc412dfe14cc7d4af9
+    source-commit: &commit-ref 5c03687df61ebf448ad1cdeab7c0f6ca73c0434c
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
@@ -68,7 +68,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 28dc844eadca33c183dfb1c455b11a38acf4f01d
+    source-commit: e67611532bb84e39980ca60ab37fc08f304a15a5
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"


### PR DESCRIPTION
Includes changes from #958