### PR TITLE
chore(deps): stage python3-packaging for provision

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -136,6 +136,7 @@ parts:
       - python3-minimal
       - python3-more-itertools
       - python3-oauthlib
+      - python3-packaging
       - python3-passlib
       - python3-pkg-resources
       - python3-pyroute2


### PR DESCRIPTION
We have added a dependency on python3-packaging for curtin, reflect that here.

Matching PR: https://github.com/canonical/subiquity/pull/2171