### PR TITLE
fix: Resolve 1870620 - Mascot progress image contrast

### DIFF
--- a/packages/ubuntu_provision/lib/src/widgets/mascot_avatar.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/mascot_avatar.dart
@@ -26,13 +26,25 @@ class MascotAvatar extends StatelessWidget {
           ),
           child: image,
         ),
-        if (progress != null && progress! > 0 && progress! < 1)
+        if (progress != null && progress! > 0 && progress! < 1) ...[
+          Container(
+            constraints: BoxConstraints.tight(
+              Size(size.width - 17, size.height - 17),
+            ),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.black.withOpacity(0.25),
+            ),
+          ),
           Positioned(
             child: Text(
               '${(progress! * 100).ceil()}%',
-              style: Theme.of(context).textTheme.titleLarge,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: Colors.white,
+                  ),
             ),
           ),
+        ],
         Positioned.fill(
           top: 3.75,
           left: 3.75,


### PR DESCRIPTION
Adds a dim to the image when a download percentage is present. Also forces the download text to be white, since the image will always been dark anyway. New contrast ratio is around 5.

<details>
<summary>Screenshots</summary>

Without download percentage (before download starts, unchanged):
![image](https://github.com/user-attachments/assets/fb596c52-b812-43aa-8c87-dbc9336ef736)

With download percentage (after download starts):
![image](https://github.com/user-attachments/assets/7c6e6893-902c-42ff-8f65-da40ffdf35ac)
</details>

---

UDENG-5924