### PR TITLE
fix: Wizard theme constrast adjustments

### DIFF
--- a/packages/ubuntu_wizard/lib/src/wizard_app.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_app.dart
@@ -39,8 +39,10 @@ class WizardApp extends StatelessWidget {
           theme: (theme ?? flavor?.theme ?? yaru.theme)?.customize(),
           darkTheme:
               (darkTheme ?? flavor?.darkTheme ?? yaru.darkTheme)?.customize(),
-          highContrastTheme: yaruHighContrastLight.customize(),
-          highContrastDarkTheme: yaruHighContrastDark.customize(),
+          highContrastTheme:
+              yaruHighContrastLight.customize(highContrast: true),
+          highContrastDarkTheme:
+              yaruHighContrastDark.customize(highContrast: true),
           debugShowCheckedModeBanner: false,
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,

--- a/packages/ubuntu_wizard/lib/src/wizard_theme.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_theme.dart
@@ -20,11 +20,9 @@ extension WizardFlavorX on UbuntuFlavor {
 }
 
 extension WizardThemeDataX on ThemeData {
-  ThemeData customize() {
-    final errorColor = YaruColors.from(brightness).error;
+  ThemeData _customizeCursor() {
     final mouseCursor = WidgetStateProperty.all(SystemMouseCursors.basic);
     return copyWith(
-      colorScheme: colorScheme.copyWith(error: errorColor),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: elevatedButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
       ),
@@ -35,6 +33,39 @@ extension WizardThemeDataX on ThemeData {
           floatingActionButtonTheme.copyWith(mouseCursor: mouseCursor),
       iconButtonTheme: IconButtonThemeData(
         style: iconButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+      ),
+      listTileTheme: listTileTheme.copyWith(mouseCursor: mouseCursor),
+      menuButtonTheme: MenuButtonThemeData(
+        style: MenuItemButton.styleFrom(
+          enabledMouseCursor: SystemMouseCursors.basic,
+          disabledMouseCursor: SystemMouseCursors.basic,
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: outlinedButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+      ),
+      popupMenuTheme: popupMenuTheme.copyWith(mouseCursor: mouseCursor),
+      sliderTheme: sliderTheme.copyWith(
+        mouseCursor: mouseCursor,
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: textButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
+      ),
+      extensions: [
+        YaruCheckboxThemeData(mouseCursor: mouseCursor),
+        YaruPageIndicatorThemeData(mouseCursor: mouseCursor),
+        YaruRadioThemeData(mouseCursor: mouseCursor),
+        YaruSwitchThemeData(mouseCursor: mouseCursor),
+        YaruToggleButtonThemeData(mouseCursor: mouseCursor),
+      ],
+    );
+  }
+
+  ThemeData _customizeColors() {
+    final errorColor = YaruColors.from(brightness).error;
+    return copyWith(
+      colorScheme: colorScheme.copyWith(
+        error: errorColor,
       ),
       inputDecorationTheme: inputDecorationTheme.copyWith(
         floatingLabelStyle: WidgetStateTextStyle.resolveWith((states) {
@@ -54,46 +85,43 @@ extension WizardThemeDataX on ThemeData {
         }),
         focusedBorder: OutlineInputBorder(
           borderSide: BorderSide(color: colorScheme.onSurface),
-          borderRadius: BorderRadius.circular(kYaruButtonRadius),
         ),
         errorBorder: OutlineInputBorder(
           borderSide: BorderSide(color: errorColor),
-          borderRadius: BorderRadius.circular(kYaruButtonRadius),
         ),
       ),
-      listTileTheme: listTileTheme.copyWith(mouseCursor: mouseCursor),
-      menuButtonTheme: MenuButtonThemeData(
-        style: MenuItemButton.styleFrom(
-          enabledMouseCursor: SystemMouseCursors.basic,
-          disabledMouseCursor: SystemMouseCursors.basic,
-        ),
-      ),
-      outlinedButtonTheme: OutlinedButtonThemeData(
-        style: outlinedButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
-      ),
-      popupMenuTheme: popupMenuTheme.copyWith(mouseCursor: mouseCursor),
       sliderTheme: sliderTheme.copyWith(
-        mouseCursor: mouseCursor,
         valueIndicatorColor: colorScheme.inverseSurface,
         valueIndicatorStrokeColor: colorScheme.onInverseSurface,
         valueIndicatorTextStyle:
             textTheme.bodyMedium!.copyWith(color: colorScheme.onInverseSurface),
-        valueIndicatorShape: const RectangularSliderValueIndicatorShape(),
-      ),
-      textButtonTheme: TextButtonThemeData(
-        style: textButtonTheme.style!.copyWith(mouseCursor: mouseCursor),
       ),
       extensions: [
         ...extensions.values,
-        YaruCheckboxThemeData(mouseCursor: mouseCursor),
-        YaruPageIndicatorThemeData(mouseCursor: mouseCursor),
-        YaruRadioThemeData(mouseCursor: mouseCursor),
-        YaruSwitchThemeData(mouseCursor: mouseCursor),
         YaruTitleBarThemeData(
           backgroundColor: WidgetStatePropertyAll(colorScheme.surface),
         ),
-        YaruToggleButtonThemeData(mouseCursor: mouseCursor),
       ],
     );
+  }
+
+  ThemeData _customizeShapes() {
+    return copyWith(
+      inputDecorationTheme: inputDecorationTheme.copyWith(
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(kYaruButtonRadius),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(kYaruButtonRadius),
+        ),
+      ),
+      sliderTheme: sliderTheme.copyWith(
+        valueIndicatorShape: const RectangularSliderValueIndicatorShape(),
+      ),
+    );
+  }
+
+  ThemeData customize() {
+    return _customizeCursor()._customizeColors()._customizeShapes();
   }
 }

--- a/packages/ubuntu_wizard/lib/src/wizard_theme.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_theme.dart
@@ -61,7 +61,7 @@ extension WizardThemeDataX on ThemeData {
     );
   }
 
-  ThemeData _customizeColors() {
+  ThemeData _customizeColors(bool highContrast) {
     final errorColor = YaruColors.from(brightness).error;
     return copyWith(
       colorScheme: colorScheme.copyWith(
@@ -98,6 +98,11 @@ extension WizardThemeDataX on ThemeData {
         valueIndicatorTextStyle:
             textTheme.bodyMedium!.copyWith(color: colorScheme.onInverseSurface),
       ),
+      listTileTheme: highContrast
+          ? listTileTheme.copyWith(
+              textColor: colorScheme.onSurface,
+            )
+          : null,
       extensions: [
         ...extensions.values,
         YaruTitleBarThemeData(
@@ -123,7 +128,7 @@ extension WizardThemeDataX on ThemeData {
     );
   }
 
-  ThemeData customize() {
-    return _customizeCursor()._customizeColors()._customizeShapes();
+  ThemeData customize({bool highContrast = false}) {
+    return _customizeCursor()._customizeColors(highContrast)._customizeShapes();
   }
 }

--- a/packages/ubuntu_wizard/lib/src/wizard_theme.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_theme.dart
@@ -89,6 +89,8 @@ extension WizardThemeDataX on ThemeData {
         errorBorder: OutlineInputBorder(
           borderSide: BorderSide(color: errorColor),
         ),
+        fillColor: colorScheme.surface,
+        hoverColor: colorScheme.surface,
       ),
       sliderTheme: sliderTheme.copyWith(
         valueIndicatorColor: colorScheme.inverseSurface,


### PR DESCRIPTION
This does a couple small things:

- Separates theme customizations into separate cursor, color, and shape functions
- Makes regular TextFields look like ValidatedTextFields (removed their background color)
- In high contrast mode, make subtitle text the same color as title text in list tiles

These are just the changes that could've been made in the theme itself (which isn't a lot), some of the other contrast changes will need some customization at a widget level.

<details>
<summary>Screenshots</summary>

**Removes background color on normal TextFields**
![image](https://github.com/user-attachments/assets/19fa9342-b7ff-4254-a46f-6270fde8889b)

**High contrast mode list tiles**
![image](https://github.com/user-attachments/assets/fcfafe92-ea4a-4193-aad6-e8f9c65c3315)


</details>

---

UDENG-6291