### PR TITLE
fix: Lighten "Warning" text in battery toasts

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/source/on_battery_snackbar.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/source/on_battery_snackbar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ubuntu_bootstrap/l10n/ubuntu_bootstrap_localizations.dart';
+import 'package:yaru/yaru.dart';
 
 class OnBatterySnackBar extends SnackBar {
   OnBatterySnackBar({super.key})
@@ -13,7 +14,6 @@ class OnBatterySnackBar extends SnackBar {
           showCloseIcon: true,
           content: Builder(
             builder: (context) {
-              final theme = Theme.of(context);
               final lang = UbuntuBootstrapLocalizations.of(context);
 
               return Text.rich(
@@ -21,7 +21,9 @@ class OnBatterySnackBar extends SnackBar {
                   children: [
                     TextSpan(
                       text: lang.warningLabel,
-                      style: TextStyle(color: theme.colorScheme.error),
+                      style: TextStyle(
+                        color: YaruColors.from(Brightness.dark).error,
+                      ),
                     ),
                     const TextSpan(text: ' '),
                     TextSpan(text: lang.batteryWarning),


### PR DESCRIPTION
Quick change to lighten the "Warning" text that appears when on battery power to have a better contrast ratio. The snack bar is always the same color so using the Yaru dark theme error color instead seems fitting.

<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/2487fe3f-92f3-42f5-bc95-06bd309d33b8)

</details>

---

UDENG-6292