### PR TITLE
fix: reset storage before setting a guided target

### DIFF
--- a/apps/ubuntu_bootstrap/lib/services/storage_service.dart
+++ b/apps/ubuntu_bootstrap/lib/services/storage_service.dart
@@ -87,6 +87,7 @@ class StorageService {
 
   /// Sets the selected target for guided partitioning.
   Future<void> setGuidedStorage() async {
+    await _client.resetStorageV2();
     await _client.setGuidedStorageV2(
       GuidedChoiceV2(
         target: guidedTarget!,

--- a/apps/ubuntu_bootstrap/test/services/storage_service_test.dart
+++ b/apps/ubuntu_bootstrap/test/services/storage_service_test.dart
@@ -34,6 +34,8 @@ void main() {
         state: ApplicationState.RUNNING,
       ),
     );
+    when(client.resetStorageV2())
+        .thenAnswer((_) async => fakeStorageResponse());
   });
 
   test('get guided storage', () async {
@@ -62,6 +64,7 @@ void main() {
     final service = StorageService(client);
     service.guidedTarget = target;
     await service.setGuidedStorage();
+    verify(client.resetStorageV2()).called(1);
     verify(client.setGuidedStorageV2(choice)).called(1);
     verify(client.setStorageV2()).called(1);
   });
@@ -85,6 +88,7 @@ void main() {
 
     service.guidedTarget = target;
     await service.setGuidedStorage();
+    verify(client.resetStorageV2()).called(1);
     verify(client.setGuidedStorageV2(choice)).called(1);
     verify(client.setStorageV2()).called(1);
   });


### PR DESCRIPTION
I've explored a few different options for fixing this, but ultimately decided that resetting the storage before setting the guided target (which is currently being done when the confirmation page is loaded) is the simplest solution.
My preferred solution would be posting to `/storage/v2/guided` once the user finishes the storage configuration, but since all pages in the storage wizard potentially affect the request we need to send, we'd have to do the request either on the last page in the wizard (currently the 'passphrase' page) or on the first page that follows just after the storage wizard (currently the 'identity' page). Both seem like arbitrary choices and we'd have to move the logic around again in case these pages are moved to a different place.
If we find some time to refactor the `wizard_router`, we could also add an `onDone` callback to the `Wizard`.

Fix [lp:2097271](https://bugs.launchpad.net/subiquity/+bug/2097271)
UDENG-6411