### PR TITLE
deps: track subiquity's plucky branch for 25.04

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
 	url = https://github.com/canonical/subiquity.git
-	branch = main
+	branch = ubuntu/plucky


### PR DESCRIPTION
This PR targets the newly created `ubuntu/25.04` branch and updates the `.gitmodules` file to track https://github.com/canonical/subiquity/tree/ubuntu/plucky.

UDENG-6467