### PR TITLE
fix: disable delete partition button while waiting for reply

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_widgets.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/manual/manual_storage_widgets.dart
@@ -233,7 +233,7 @@ class PartitionButtonRow extends ConsumerWidget {
                     side: BorderSide.none,
                     shape: const RoundedRectangleBorder(),
                   ),
-                  onPressed: model.canRemovePartition
+                  onPressed: model.canRemovePartition && !model.waitingForReply
                       ? () => model.deletePartition(
                             model.selectedDisk!,
                             model.selectedPartition!,

--- a/apps/ubuntu_bootstrap/test/storage/manual/manual_storage_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/manual/manual_storage_page_test.dart
@@ -200,6 +200,26 @@ void main() {
     verify(model.deletePartition(disk, partition)).called(1);
   });
 
+  testWidgets('waiting for reply', (tester) async {
+    final disk = testDisks.first;
+    final partition = disk.partitions.whereType<Partition>().first;
+    final model = buildManualStorageModel(
+      disks: testDisks,
+      selectedDisk: disk,
+      selectedPartition: partition,
+      canRemovePartition: true,
+      waitingForReply: true,
+    );
+    await tester.pumpApp((_) => buildPage(model));
+
+    final removeButton = find.iconButton(Icons.remove);
+    expect(removeButton, findsOneWidget);
+    expect(removeButton, isDisabled);
+
+    await tester.tap(removeButton);
+    verifyNever(model.deletePartition(disk, partition));
+  });
+
   testWidgets('can reset', (tester) async {
     final disk = testDisks.first;
     final model = buildManualStorageModel(

--- a/apps/ubuntu_bootstrap/test/storage/manual/test_manual_storage.dart
+++ b/apps/ubuntu_bootstrap/test/storage/manual/test_manual_storage.dart
@@ -23,6 +23,7 @@ ManualStorageModel buildManualStorageModel({
   bool? canEditPartition,
   bool? canReformatDisk,
   int? bootDiskIndex,
+  bool? waitingForReply,
 }) {
   final model = MockManualStorageModel();
   when(model.isValid).thenReturn(isValid ?? false);
@@ -48,5 +49,6 @@ ManualStorageModel buildManualStorageModel({
   when(model.canReformatDisk).thenReturn(canReformatDisk ?? false);
 
   when(model.bootDiskIndex).thenReturn(bootDiskIndex);
+  when(model.waitingForReply).thenReturn(waitingForReply ?? false);
   return model;
 }

--- a/apps/ubuntu_bootstrap/test/storage/manual/test_manual_storage.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/manual/test_manual_storage.mocks.dart
@@ -115,6 +115,12 @@ class MockManualStorageModel extends _i1.Mock
       ) as bool);
 
   @override
+  bool get waitingForReply => (super.noSuchMethod(
+        Invocation.getter(#waitingForReply),
+        returnValue: false,
+      ) as bool);
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,


### PR DESCRIPTION
Fixes a bug on the manual storage page where pressing the `-` button (to delete a partition) multiple times in quick succession, can lead to an error in subiquity. To prevent sending the same request twice before subiquity responds, this PR adds some logic to disable the button while we wait for the server reply. We should consider introducing a proper UI loading state in the future, though.

Example with artificial delay in subiquity:
```diff
diff --git i/subiquity/server/controllers/filesystem.py w/subiquity/server/controllers/filesystem.py
index a12b6fe8..1b065b97 100644
--- i/subiquity/server/controllers/filesystem.py
+++ w/subiquity/server/controllers/filesystem.py
@@ -1482,6 +1482,7 @@ class FilesystemController(SubiquityController, FilesystemManipulator):
         self, data: ModifyPartitionV2
     ) -> StorageResponseV2:
         log.debug(data)
+        await asyncio.sleep(2)
         self.locked_probe_data = True
         disk = self.model._one(id=data.disk_id)
         if disk.ptable == "unsupported":

```

Before:

[Screencast From 2025-03-20 14-09-16.webm](https://github.com/user-attachments/assets/15bd9874-6e51-4bf8-99e3-d0319886635b)

After

[Screencast From 2025-03-20 14-07-03.webm](https://github.com/user-attachments/assets/468a7790-29fa-4b7d-84d9-18c45ea7e2c0)


[lp:2103662](https://bugs.launchpad.net/subiquity/+bug/2103662)
UDENG-6491