### PR TITLE
fix: Correct journal log's hover color

### DIFF
--- a/packages/ubuntu_provision/lib/src/widgets/journal_view.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/journal_view.dart
@@ -23,6 +23,7 @@ class JournalView extends StatelessWidget {
         enabledBorder: InputBorder.none,
         focusedBorder: InputBorder.none,
         fillColor: Colors.transparent,
+        hoverColor: Colors.transparent,
       ),
       background: BoxDecoration(color: Theme.of(context).shadowColor),
     );


### PR DESCRIPTION
Previous changes resulted in the hover color of the journal log during install to be white. This changes the hover color to transparent.

Fixes #1006

---

UDENG-6566