### PR TITLE
fix: clear passphrase when not using a corresponding capability

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/passphrase/passphrase_model.dart
@@ -63,6 +63,7 @@ class PassphraseModel extends SafeChangeNotifier {
         return true;
 
       default:
+        await clearPassphrase();
         return false;
     }
   }
@@ -75,6 +76,13 @@ class PassphraseModel extends SafeChangeNotifier {
   /// Saves the passphrase to the service and clears the local values.
   Future<void> savePassphrase() async {
     _service.passphrase = passphrase;
+    _passphrase.value = '';
+    _confirmedPassphrase.value = '';
+  }
+
+  /// Clears the passphrase in the service and the local values,
+  Future<void> clearPassphrase() async {
+    _service.passphrase = null;
     _passphrase.value = '';
     _confirmedPassphrase.value = '';
   }

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/passphrase_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/passphrase_model_test.dart
@@ -65,5 +65,10 @@ void main() {
     verify(service.passphrase).called(1);
     expect(model.passphrase, 'bar456');
     expect(model.confirmedPassphrase, 'bar456');
+
+    await model.clearPassphrase();
+    verify(service.passphrase = null).called(1);
+    expect(model.passphrase, '');
+    expect(model.confirmedPassphrase, '');
   });
 }

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
@@ -143,6 +143,16 @@ class MockPassphraseModel extends _i1.Mock implements _i2.PassphraseModel {
       ) as _i4.Future<void>);
 
   @override
+  _i4.Future<void> clearPassphrase() => (super.noSuchMethod(
+        Invocation.method(
+          #clearPassphrase,
+          [],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
   void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,


### PR DESCRIPTION
Fix #1000
UDENG-6529