### PR TITLE
fix(confirm): restore modified disks

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_model.dart
@@ -36,9 +36,26 @@ class ConfirmModel extends SafeChangeNotifier {
   Map<String, List<Partition>>? _partitions;
   Map<String, List<Partition>>? _originals;
 
+  /// The list of all disks
+  List<Disk> get disks => _disks ?? [];
+
   /// The list of non-preserved disks, and preserved disks with any modified
   /// partitions.
-  List<Disk> get disks => _disks ?? [];
+  List<Disk> get modifiedDisks =>
+      _disks
+          ?.where(
+            (d) =>
+                d.preserve == false ||
+                d.partitions.whereType<Partition>().any(
+                      (p) =>
+                          p.wipe != null ||
+                          p.mount != null ||
+                          (p.resize ?? false) ||
+                          p.preserve == false,
+                    ),
+          )
+          .toList() ??
+      [];
 
   /// A map of changed partitions per each disk (sysname).
   Map<String, List<Partition>> get partitions => _partitions ?? {};

--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -404,7 +404,7 @@ class _InstallationDisk extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        for (final disk in model.disks)
+        for (final disk in model.modifiedDisks)
           Html(
             data: _prettyFormatDisk(disk),
             style: {

--- a/apps/ubuntu_bootstrap/test/confirm/confirm_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/confirm/confirm_model_test.dart
@@ -46,6 +46,8 @@ void main() {
     ),
   ];
 
+  final modifiedDisks = testDisks.sublist(0, 4);
+
   test('get storage', () async {
     final installer = MockInstallerService();
     final storage = MockStorageService();
@@ -66,6 +68,7 @@ void main() {
     verifyNever(storage.setGuidedStorage());
 
     expect(model.disks, equals(testDisks));
+    expect(model.modifiedDisks, equals(modifiedDisks));
     expect(
       model.partitions,
       equals({

--- a/apps/ubuntu_bootstrap/test/confirm/test_confirm.dart
+++ b/apps/ubuntu_bootstrap/test/confirm/test_confirm.dart
@@ -21,6 +21,7 @@ export 'test_confirm.mocks.dart';
 @GenerateMocks([ConfirmModel])
 ConfirmModel buildConfirmModel({
   List<Disk>? disks,
+  List<Disk>? modifiedDisks,
   Map<String, List<Partition>>? partitions,
   Map<String, List<Partition>>? originals,
   GuidedStorageTarget? guidedTarget,
@@ -31,6 +32,7 @@ ConfirmModel buildConfirmModel({
 }) {
   final model = MockConfirmModel();
   when(model.disks).thenReturn(disks ?? <Disk>[]);
+  when(model.modifiedDisks).thenReturn(modifiedDisks ?? disks ?? <Disk>[]);
   when(model.partitions).thenReturn(partitions ?? <String, List<Partition>>{});
   when(model.getOriginalPartition(any, any)).thenAnswer(
     (i) => originals?[i.positionalArguments.first]?.firstWhereOrNull(

--- a/apps/ubuntu_bootstrap/test/confirm/test_confirm.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/confirm/test_confirm.mocks.dart
@@ -49,6 +49,12 @@ class MockConfirmModel extends _i1.Mock implements _i3.ConfirmModel {
       ) as List<_i4.Disk>);
 
   @override
+  List<_i4.Disk> get modifiedDisks => (super.noSuchMethod(
+        Invocation.getter(#modifiedDisks),
+        returnValue: <_i4.Disk>[],
+      ) as List<_i4.Disk>);
+
+  @override
   Map<String, List<_i4.Partition>> get partitions => (super.noSuchMethod(
         Invocation.getter(#partitions),
         returnValue: <String, List<_i4.Partition>>{},


### PR DESCRIPTION
In #969 we've changed the behavior of the `confirmModel` to provide a list of *all* disks instead of only those that have been modified in order to include unchanged partitions in the table on the confirmation page. However, the 'Installation disk' entry on that page still needs access to a list of modified disks - this PR (re-)adds this property.

Fix #1012
UDENG-6572