### PR TITLE
fix: show mountpoint and partition format for ZFS/LVM setups

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -124,40 +124,7 @@ class ConfirmPage extends ConsumerWidget with ProvisioningPage {
                             style: Theme.of(context).textTheme.titleMedium,
                           ),
                           const SizedBox(height: kWizardSpacing / 2),
-                          Table(
-                            border: TableBorder(
-                              horizontalInside: BorderSide(
-                                color: Theme.of(context).dividerColor,
-                              ),
-                            ),
-                            children: [
-                              for (final entry in model.partitions.entries)
-                                for (final partition in entry.value) ...[
-                                  if (model.guidedTarget
-                                          is GuidedStorageTargetEraseInstall &&
-                                      !(partition.preserve ?? false))
-                                    _PartitionRow(
-                                      sysname: entry.key,
-                                      partition: partition,
-                                      original: model.getOriginalPartition(
-                                        entry.key,
-                                        partition.number ?? -1,
-                                      ),
-                                      productInfo: model.productInfo,
-                                      showOriginal: true,
-                                    ),
-                                  _PartitionRow(
-                                    sysname: entry.key,
-                                    partition: partition,
-                                    original: model.getOriginalPartition(
-                                      entry.key,
-                                      partition.number ?? -1,
-                                    ),
-                                    productInfo: model.productInfo,
-                                  ),
-                                ],
-                            ],
-                          ),
+                          _PartitionTable(),
                         ],
                       ),
               ),
@@ -165,6 +132,54 @@ class ConfirmPage extends ConsumerWidget with ProvisioningPage {
           ],
         ),
       ],
+    );
+  }
+}
+
+class _PartitionTable extends ConsumerWidget {
+  const _PartitionTable();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final model = ref.watch(confirmModelProvider);
+    final rows = <TableRow>[];
+    for (final entry in model.partitions.entries) {
+      for (final partition in entry.value) {
+        final original = model.getOriginalPartition(
+          entry.key,
+          partition.number ?? -1,
+        );
+        if (model.guidedTarget is GuidedStorageTargetEraseInstall &&
+            !(partition.preserve ?? false) &&
+            original != null) {
+          rows.add(
+            _PartitionRow(
+              sysname: entry.key,
+              partition: partition,
+              original: original,
+              productInfo: model.productInfo,
+              showOriginal: true,
+            ),
+          );
+        }
+        rows.add(
+          _PartitionRow(
+            sysname: entry.key,
+            partition: partition,
+            original: original,
+            productInfo: model.productInfo,
+          ),
+        );
+      }
+    }
+
+    return Table(
+      border: TableBorder(
+        horizontalInside: BorderSide(
+          color: Theme.of(context).dividerColor,
+        ),
+      ),
+      children: rows,
     );
   }
 }

--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -220,7 +220,11 @@ class _PartitionProperties extends StatelessWidget {
 
   String? properties(BuildContext context) {
     final l10n = UbuntuBootstrapLocalizations.of(context);
-    if (showOriginal && !(partition.preserve ?? false)) {
+    final mount = partition.mount ?? partition.effectiveMount;
+    final format = partition.format ?? partition.effectiveFormat;
+    final preserve = partition.preserve ?? false;
+
+    if (showOriginal && !preserve) {
       return l10n.confirmTableErased;
     }
     if (partition.resize ?? false) {
@@ -228,28 +232,26 @@ class _PartitionProperties extends StatelessWidget {
         context.formatByteSize(original?.size ?? 0).bold(),
         context.formatByteSize(partition.size ?? 0).bold(),
       );
-    } else if (!(partition.preserve ?? false) &&
-        (partition.mount?.isNotEmpty ?? false) &&
-        partition.format != null) {
+    } else if (!preserve && (mount?.isNotEmpty ?? false) && format != null) {
       return l10n.confirmTableCreatedFormattedMounted(
-        partition.format!.bold(),
-        partition.mount!.bold(),
+        format.bold(),
+        mount!.bold(),
       );
-    } else if (partition.wipe != null &&
-        (partition.mount?.isNotEmpty ?? false) &&
-        partition.format != null) {
+    } else if (!preserve && (mount?.isNotEmpty ?? false) && format != null) {
       return l10n.confirmTableFormattedMounted(
-        partition.format!.bold(),
-        partition.mount!.bold(),
+        format.bold(),
+        mount!.bold(),
       );
-    } else if (partition.wipe != null && partition.format != null) {
+    } else if (!preserve && format != null) {
       return l10n.confirmTableFormatted(
-        partition.format!.bold(),
+        format.bold(),
       );
-    } else if (partition.mount?.isNotEmpty ?? false) {
-      return l10n.confirmTableMounted(partition.mount!.bold());
+    } else if (mount?.isNotEmpty ?? false) {
+      return l10n.confirmTableMounted(mount!.bold());
+    } else if (preserve) {
+      return l10n.confirmTableUnchanged;
     }
-    return l10n.confirmTableUnchanged;
+    return null;
   }
 
   @override
@@ -281,10 +283,11 @@ class _PartitionLabel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final String? name;
+    final mount = partition.mount ?? partition.effectiveMount;
 
     if (showOriginal) {
-      name = original?.os?.long ?? original?.name ?? original?.format ?? '';
-    } else if (!(partition.preserve ?? false) && partition.mount == '/') {
+      name = original?.os?.long ?? original?.name ?? '';
+    } else if (!(partition.preserve ?? false) && mount == '/') {
       name = productInfo.toString();
     } else {
       name = partition.os?.long ?? partition.name ?? '';

--- a/packages/subiquity_client/lib/src/types.dart
+++ b/packages/subiquity_client/lib/src/types.dart
@@ -798,6 +798,9 @@ class PartitionOrGap with _$PartitionOrGap {
     String? path,
     String? name,
     @Default(false) bool isInUse,
+    String? effectiveMount,
+    String? effectiveFormat,
+    bool? effectivelyEncrypted,
   }) = Partition;
 
   @FreezedUnionValue('Gap')

--- a/packages/subiquity_client/lib/src/types.freezed.dart
+++ b/packages/subiquity_client/lib/src/types.freezed.dart
@@ -9821,7 +9821,10 @@ mixin _$PartitionOrGap {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)
         partition,
     required TResult Function(int offset, int size, GapUsable usable) gap,
   }) =>
@@ -9844,7 +9847,10 @@ mixin _$PartitionOrGap {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)?
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)?
         partition,
     TResult? Function(int offset, int size, GapUsable usable)? gap,
   }) =>
@@ -9867,7 +9873,10 @@ mixin _$PartitionOrGap {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)?
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)?
         partition,
     TResult Function(int offset, int size, GapUsable usable)? gap,
     required TResult orElse(),
@@ -9967,7 +9976,10 @@ abstract class _$$PartitionImplCopyWith<$Res>
       bool? resize,
       String? path,
       String? name,
-      bool isInUse});
+      bool isInUse,
+      String? effectiveMount,
+      String? effectiveFormat,
+      bool? effectivelyEncrypted});
 
   $OsProberCopyWith<$Res>? get os;
 }
@@ -10001,6 +10013,9 @@ class __$$PartitionImplCopyWithImpl<$Res>
     Object? path = freezed,
     Object? name = freezed,
     Object? isInUse = null,
+    Object? effectiveMount = freezed,
+    Object? effectiveFormat = freezed,
+    Object? effectivelyEncrypted = freezed,
   }) {
     return _then(_$PartitionImpl(
       size: freezed == size
@@ -10067,6 +10082,18 @@ class __$$PartitionImplCopyWithImpl<$Res>
           ? _value.isInUse
           : isInUse // ignore: cast_nullable_to_non_nullable
               as bool,
+      effectiveMount: freezed == effectiveMount
+          ? _value.effectiveMount
+          : effectiveMount // ignore: cast_nullable_to_non_nullable
+              as String?,
+      effectiveFormat: freezed == effectiveFormat
+          ? _value.effectiveFormat
+          : effectiveFormat // ignore: cast_nullable_to_non_nullable
+              as String?,
+      effectivelyEncrypted: freezed == effectivelyEncrypted
+          ? _value.effectivelyEncrypted
+          : effectivelyEncrypted // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 
@@ -10105,6 +10132,9 @@ class _$PartitionImpl implements Partition {
       this.path,
       this.name,
       this.isInUse = false,
+      this.effectiveMount,
+      this.effectiveFormat,
+      this.effectivelyEncrypted,
       final String? $type})
       : _annotations = annotations,
         $type = $type ?? 'Partition';
@@ -10153,13 +10183,19 @@ class _$PartitionImpl implements Partition {
   @override
   @JsonKey()
   final bool isInUse;
+  @override
+  final String? effectiveMount;
+  @override
+  final String? effectiveFormat;
+  @override
+  final bool? effectivelyEncrypted;
 
   @JsonKey(name: '\$type')
   final String $type;
 
   @override
   String toString() {
-    return 'PartitionOrGap.partition(size: $size, number: $number, preserve: $preserve, wipe: $wipe, annotations: $annotations, mount: $mount, format: $format, grubDevice: $grubDevice, boot: $boot, os: $os, offset: $offset, estimatedMinSize: $estimatedMinSize, resize: $resize, path: $path, name: $name, isInUse: $isInUse)';
+    return 'PartitionOrGap.partition(size: $size, number: $number, preserve: $preserve, wipe: $wipe, annotations: $annotations, mount: $mount, format: $format, grubDevice: $grubDevice, boot: $boot, os: $os, offset: $offset, estimatedMinSize: $estimatedMinSize, resize: $resize, path: $path, name: $name, isInUse: $isInUse, effectiveMount: $effectiveMount, effectiveFormat: $effectiveFormat, effectivelyEncrypted: $effectivelyEncrypted)';
   }
 
   @override
@@ -10186,29 +10222,39 @@ class _$PartitionImpl implements Partition {
             (identical(other.resize, resize) || other.resize == resize) &&
             (identical(other.path, path) || other.path == path) &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.isInUse, isInUse) || other.isInUse == isInUse));
+            (identical(other.isInUse, isInUse) || other.isInUse == isInUse) &&
+            (identical(other.effectiveMount, effectiveMount) ||
+                other.effectiveMount == effectiveMount) &&
+            (identical(other.effectiveFormat, effectiveFormat) ||
+                other.effectiveFormat == effectiveFormat) &&
+            (identical(other.effectivelyEncrypted, effectivelyEncrypted) ||
+                other.effectivelyEncrypted == effectivelyEncrypted));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      size,
-      number,
-      preserve,
-      wipe,
-      const DeepCollectionEquality().hash(_annotations),
-      mount,
-      format,
-      grubDevice,
-      boot,
-      os,
-      offset,
-      estimatedMinSize,
-      resize,
-      path,
-      name,
-      isInUse);
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        size,
+        number,
+        preserve,
+        wipe,
+        const DeepCollectionEquality().hash(_annotations),
+        mount,
+        format,
+        grubDevice,
+        boot,
+        os,
+        offset,
+        estimatedMinSize,
+        resize,
+        path,
+        name,
+        isInUse,
+        effectiveMount,
+        effectiveFormat,
+        effectivelyEncrypted
+      ]);
 
   /// Create a copy of PartitionOrGap
   /// with the given fields replaced by the non-null parameter values.
@@ -10237,7 +10283,10 @@ class _$PartitionImpl implements Partition {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)
         partition,
     required TResult Function(int offset, int size, GapUsable usable) gap,
   }) {
@@ -10257,7 +10306,10 @@ class _$PartitionImpl implements Partition {
         resize,
         path,
         name,
-        isInUse);
+        isInUse,
+        effectiveMount,
+        effectiveFormat,
+        effectivelyEncrypted);
   }
 
   @override
@@ -10279,7 +10331,10 @@ class _$PartitionImpl implements Partition {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)?
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)?
         partition,
     TResult? Function(int offset, int size, GapUsable usable)? gap,
   }) {
@@ -10299,7 +10354,10 @@ class _$PartitionImpl implements Partition {
         resize,
         path,
         name,
-        isInUse);
+        isInUse,
+        effectiveMount,
+        effectiveFormat,
+        effectivelyEncrypted);
   }
 
   @override
@@ -10321,7 +10379,10 @@ class _$PartitionImpl implements Partition {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)?
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)?
         partition,
     TResult Function(int offset, int size, GapUsable usable)? gap,
     required TResult orElse(),
@@ -10343,7 +10404,10 @@ class _$PartitionImpl implements Partition {
           resize,
           path,
           name,
-          isInUse);
+          isInUse,
+          effectiveMount,
+          effectiveFormat,
+          effectivelyEncrypted);
     }
     return orElse();
   }
@@ -10404,7 +10468,10 @@ abstract class Partition implements PartitionOrGap {
       final bool? resize,
       final String? path,
       final String? name,
-      final bool isInUse}) = _$PartitionImpl;
+      final bool isInUse,
+      final String? effectiveMount,
+      final String? effectiveFormat,
+      final bool? effectivelyEncrypted}) = _$PartitionImpl;
 
   factory Partition.fromJson(Map<String, dynamic> json) =
       _$PartitionImpl.fromJson;
@@ -10427,6 +10494,9 @@ abstract class Partition implements PartitionOrGap {
   String? get path;
   String? get name;
   bool get isInUse;
+  String? get effectiveMount;
+  String? get effectiveFormat;
+  bool? get effectivelyEncrypted;
 
   /// Create a copy of PartitionOrGap
   /// with the given fields replaced by the non-null parameter values.
@@ -10548,7 +10618,10 @@ class _$GapImpl implements Gap {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)
         partition,
     required TResult Function(int offset, int size, GapUsable usable) gap,
   }) {
@@ -10574,7 +10647,10 @@ class _$GapImpl implements Gap {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)?
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)?
         partition,
     TResult? Function(int offset, int size, GapUsable usable)? gap,
   }) {
@@ -10600,7 +10676,10 @@ class _$GapImpl implements Gap {
             bool? resize,
             String? path,
             String? name,
-            bool isInUse)?
+            bool isInUse,
+            String? effectiveMount,
+            String? effectiveFormat,
+            bool? effectivelyEncrypted)?
         partition,
     TResult Function(int offset, int size, GapUsable usable)? gap,
     required TResult orElse(),

--- a/packages/subiquity_client/lib/src/types.g.dart
+++ b/packages/subiquity_client/lib/src/types.g.dart
@@ -919,6 +919,9 @@ _$PartitionImpl _$$PartitionImplFromJson(Map<String, dynamic> json) =>
       path: json['path'] as String?,
       name: json['name'] as String?,
       isInUse: json['is_in_use'] as bool? ?? false,
+      effectiveMount: json['effective_mount'] as String?,
+      effectiveFormat: json['effective_format'] as String?,
+      effectivelyEncrypted: json['effectively_encrypted'] as bool?,
       $type: json[r'$type'] as String?,
     );
 
@@ -940,6 +943,9 @@ Map<String, dynamic> _$$PartitionImplToJson(_$PartitionImpl instance) =>
       'path': instance.path,
       'name': instance.name,
       'is_in_use': instance.isInUse,
+      'effective_mount': instance.effectiveMount,
+      'effective_format': instance.effectiveFormat,
+      'effectively_encrypted': instance.effectivelyEncrypted,
       r'$type': instance.$type,
     };
 

--- a/packages/subiquity_client/test/types_test.dart
+++ b/packages/subiquity_client/test/types_test.dart
@@ -155,8 +155,10 @@ void main() {
       wipe: 'superblock',
       annotations: ['3', '4', '5'],
       mount: '/foo',
+      effectiveMount: '/effective_foo',
       boot: false,
       format: 'bar',
+      effectiveFormat: 'effective_bar',
       grubDevice: false,
       os: OsProber(
         long: 'Windows Boot Manager',
@@ -171,6 +173,7 @@ void main() {
       estimatedMinSize: 123,
       isInUse: true,
       name: 'GPT name',
+      effectivelyEncrypted: true,
     );
 
     expect(partition.sysname, equals('sda2'));
@@ -182,7 +185,9 @@ void main() {
       'wipe': 'superblock',
       'annotations': ['3', '4', '5'],
       'mount': '/foo',
+      'effective_mount': '/effective_foo',
       'format': 'bar',
+      'effective_format': 'effective_bar',
       'grub_device': false,
       'boot': false,
       'os': {
@@ -198,6 +203,7 @@ void main() {
       'estimated_min_size': 123,
       'is_in_use': true,
       'name': 'GPT name',
+      'effectively_encrypted': true,
       '\$type': 'Partition',
     };
     expect(partition.toJson(), equals(json));


### PR DESCRIPTION
This makes use of the `effectiveMount` and `effectiveFormat` properties recently added to subiquity's API.
I've also moved the whole partition summary table into a separate widget to clean up the code a bit.

Fix #1001
UDENG-6530