### PR TITLE
fix: Install libgles2 (LP: #2106101)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -213,6 +213,7 @@ parts:
       # Needed for the dri drivers see https://github.com/canonical/ubuntu-desktop-installer/issues/2391
       - libelf1t64
       - libgl1
+      - libgles2
       - libglib2.0-0t64
       - libglib2.0-dev
       - libgirepository-1.0-1


### PR DESCRIPTION
Include `snapcraft.yaml` fix from #1031 in `snap/ubuntu-desktop-bootstrap/main`