### PR TITLE
fix: Install libgles2 (LP: #2106101)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,6 +206,7 @@ parts:
       # Needed for the dri drivers see https://github.com/canonical/ubuntu-desktop-installer/issues/2391
       - libelf1
       - libgl1
+      - libgles2
       - libglib2.0-0
       - libglib2.0-dev
       - libgirepository-1.0-1


### PR DESCRIPTION
Include snapcraft.yaml fix from https://github.com/canonical/ubuntu-desktop-provision/pull/1031 in snap/ubuntu-desktop-bootstrap/24.04