### PR TITLE
chore: include subiquity fix for LP:#2105480

### DIFF
--- a/apps/ubuntu_bootstrap/pubspec.lock
+++ b/apps/ubuntu_bootstrap/pubspec.lock
@@ -1237,7 +1237,7 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/timezone_map"
-      ref: HEAD
+      ref: "55c3a2ac"
       resolved-ref: "55c3a2ac2cfc26a5ff9cf00fee745e619aebc054"
       url: "https://github.com/canonical/ubuntu-flutter-plugins.git"
     source: git

--- a/apps/ubuntu_bootstrap/pubspec.yaml
+++ b/apps/ubuntu_bootstrap/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
+      ref: 55c3a2ac
   ubuntu_flavor: ^0.4.0
   ubuntu_localizations: ^0.5.0
   ubuntu_logger: ^0.1.1

--- a/apps/ubuntu_init/pubspec.lock
+++ b/apps/ubuntu_init/pubspec.lock
@@ -1174,8 +1174,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/timezone_map"
-      ref: HEAD
-      resolved-ref: "07be1076574fd803979799dcea22f079067c8e0f"
+      ref: "55c3a2ac"
+      resolved-ref: "55c3a2ac2cfc26a5ff9cf00fee745e619aebc054"
       url: "https://github.com/canonical/ubuntu-flutter-plugins.git"
     source: git
     version: "0.1.0"

--- a/apps/ubuntu_init/pubspec.yaml
+++ b/apps/ubuntu_init/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
+      ref: 55c3a2ac
   ubuntu_flavor: ^0.4.0
   ubuntu_localizations: ^0.5.0
   ubuntu_logger: ^0.1.1

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
     git:
       url: https://github.com/canonical/ubuntu-flutter-plugins.git
       path: packages/timezone_map
+      ref: 55c3a2ac
   ubuntu_flavor: ^0.4.0
   ubuntu_localizations: ^0.5.0
   ubuntu_logger: ^0.1.1


### PR DESCRIPTION
Includes https://github.com/canonical/subiquity/pull/2193 in `ubuntu/25.04`.
I had to pin `timezone_map` since we've bumped the Flutter version in `ubuntu-flutter-plugins` (it's a `git` dependency, since it isn't published on pub.dev).