### PR TITLE
fix(confirm_page): list partitions as 'formatted' when `wipe`d

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -238,6 +238,7 @@ class _PartitionProperties extends StatelessWidget {
     final mount = partition.mount ?? partition.effectiveMount;
     final format = partition.format ?? partition.effectiveFormat;
     final preserve = partition.preserve ?? false;
+    final wipe = partition.wipe != null;
 
     if (showOriginal && !preserve) {
       return l10n.confirmTableErased;
@@ -252,12 +253,12 @@ class _PartitionProperties extends StatelessWidget {
         format.bold(),
         mount!.bold(),
       );
-    } else if (!preserve && (mount?.isNotEmpty ?? false) && format != null) {
+    } else if (wipe && (mount?.isNotEmpty ?? false) && format != null) {
       return l10n.confirmTableFormattedMounted(
         format.bold(),
         mount!.bold(),
       );
-    } else if (!preserve && format != null) {
+    } else if (wipe && format != null) {
       return l10n.confirmTableFormatted(
         format.bold(),
       );


### PR DESCRIPTION
In #1020 I've mistakenly replaced `partition.wipe != null` with `!partition.preserved` during a refactor. This PR reverts the logic to its previous state.

Fix [lp:2107208](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2107208)
UDENG-6769