### PR TITLE
feat: display TPM recovery key after finishing the installation

### DIFF
--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -917,10 +917,11 @@
     }
   },
   "recoveryKeyTitle": "Recovery key",
+  "recoveryKeyTitleBadgeLabel": "Important",
   "recoveryKeyHeader": "Save your recovery key",
   "recoveryKeyInfoHeader": "You may lose all your data without a recovery key",
   "recoveryKeyTextFieldLabel": "Recovery key",
-  "recoveryKeyStorageAdvice": "If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.",
+  "recoveryKeyStorageAdvice": "You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.",
   "recoveryKeyConfirmation": "I saved my recovery key somewhere safe",
   "recoveryKeyLinkLabel": "Learn more",
   "recoveryKeySaveToFileLabel": "Save to file",
@@ -933,7 +934,8 @@
       }
     }
   },
-  "recoveryKeyQrDialogBody": "Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.",
+  "recoveryKeyQrDialogBody": "Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.",
+  "recoveryKeyClipboardNotifiaction": "Copied to clipboard",
   "landscapeMagicAttachInstructions": "Scan the QR code or enter the code below at <a href=\"https://{url}\">{url}</a>",
   "@landscapeMagicAttachInstructions": {
     "placeholders": {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -916,21 +916,24 @@
       }
     }
   },
-  "recoveryKeyTitle": "TPM recovery key",
-  "recoveryKeyHeader": "Get a recovery key",
+  "recoveryKeyTitle": "Recovery key",
+  "recoveryKeyHeader": "Save your recovery key",
   "recoveryKeyInfoHeader": "You may lose all your data without a recovery key",
-  "recoveryKeyInfoBody": "Get a recovery key as soon as you first log into {distro} and store it somewhere safe.",
-  "@recoveryKeyInfoBody": {
+  "recoveryKeyTextFieldLabel": "Recovery key",
+  "recoveryKeyStorageAdvice": "If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.",
+  "recoveryKeyConfirmation": "I saved my recovery key somewhere safe",
+  "recoveryKeyLinkLabel": "Learn more",
+  "recoveryKeySaveToFileLabel": "Save to file",
+  "recoveryKeyShowQrCodeLabel": "Show QR code",
+  "recoveryKeyQrDialogTitle": "{DISTRO} Desktop - Recovery key",
+  "@recoveryKeyQrDialogTitle": {
     "placeholders": {
-      "distro": {
+      "DISTRO": {
         "type": "String"
       }
     }
   },
-  "recoveryKeyCommand": "To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:",
-  "recoveryKeyStorageAdvice": "Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.",
-  "recoveryKeyConfirmation": "I understand I may lose all my data if I don't have a recovery key",
-  "recoveryKeyLinkLabel": "Learn more",
+  "recoveryKeyQrDialogBody": "Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.",
   "landscapeMagicAttachInstructions": "Scan the QR code or enter the code below at <a href=\"https://{url}\">{url}</a>",
   "@landscapeMagicAttachInstructions": {
     "placeholders": {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -2039,6 +2039,12 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'Recovery key'**
   String get recoveryKeyTitle;
 
+  /// No description provided for @recoveryKeyTitleBadgeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Important'**
+  String get recoveryKeyTitleBadgeLabel;
+
   /// No description provided for @recoveryKeyHeader.
   ///
   /// In en, this message translates to:
@@ -2060,7 +2066,7 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @recoveryKeyStorageAdvice.
   ///
   /// In en, this message translates to:
-  /// **'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.'**
+  /// **'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.'**
   String get recoveryKeyStorageAdvice;
 
   /// No description provided for @recoveryKeyConfirmation.
@@ -2096,8 +2102,14 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @recoveryKeyQrDialogBody.
   ///
   /// In en, this message translates to:
-  /// **'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.'**
+  /// **'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.'**
   String get recoveryKeyQrDialogBody;
+
+  /// No description provided for @recoveryKeyClipboardNotifiaction.
+  ///
+  /// In en, this message translates to:
+  /// **'Copied to clipboard'**
+  String get recoveryKeyClipboardNotifiaction;
 
   /// No description provided for @landscapeMagicAttachInstructions.
   ///

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -2036,13 +2036,13 @@ abstract class UbuntuBootstrapLocalizations {
   /// No description provided for @recoveryKeyTitle.
   ///
   /// In en, this message translates to:
-  /// **'TPM recovery key'**
+  /// **'Recovery key'**
   String get recoveryKeyTitle;
 
   /// No description provided for @recoveryKeyHeader.
   ///
   /// In en, this message translates to:
-  /// **'Get a recovery key'**
+  /// **'Save your recovery key'**
   String get recoveryKeyHeader;
 
   /// No description provided for @recoveryKeyInfoHeader.
@@ -2051,28 +2051,22 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'You may lose all your data without a recovery key'**
   String get recoveryKeyInfoHeader;
 
-  /// No description provided for @recoveryKeyInfoBody.
+  /// No description provided for @recoveryKeyTextFieldLabel.
   ///
   /// In en, this message translates to:
-  /// **'Get a recovery key as soon as you first log into {distro} and store it somewhere safe.'**
-  String recoveryKeyInfoBody(String distro);
-
-  /// No description provided for @recoveryKeyCommand.
-  ///
-  /// In en, this message translates to:
-  /// **'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:'**
-  String get recoveryKeyCommand;
+  /// **'Recovery key'**
+  String get recoveryKeyTextFieldLabel;
 
   /// No description provided for @recoveryKeyStorageAdvice.
   ///
   /// In en, this message translates to:
-  /// **'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.'**
+  /// **'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.'**
   String get recoveryKeyStorageAdvice;
 
   /// No description provided for @recoveryKeyConfirmation.
   ///
   /// In en, this message translates to:
-  /// **'I understand I may lose all my data if I don\'t have a recovery key'**
+  /// **'I saved my recovery key somewhere safe'**
   String get recoveryKeyConfirmation;
 
   /// No description provided for @recoveryKeyLinkLabel.
@@ -2080,6 +2074,30 @@ abstract class UbuntuBootstrapLocalizations {
   /// In en, this message translates to:
   /// **'Learn more'**
   String get recoveryKeyLinkLabel;
+
+  /// No description provided for @recoveryKeySaveToFileLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Save to file'**
+  String get recoveryKeySaveToFileLabel;
+
+  /// No description provided for @recoveryKeyShowQrCodeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Show QR code'**
+  String get recoveryKeyShowQrCodeLabel;
+
+  /// No description provided for @recoveryKeyQrDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{DISTRO} Desktop - Recovery key'**
+  String recoveryKeyQrDialogTitle(String DISTRO);
+
+  /// No description provided for @recoveryKeyQrDialogBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.'**
+  String get recoveryKeyQrDialogBody;
 
   /// No description provided for @landscapeMagicAttachInstructions.
   ///

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ аднаўлення TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ аднаўлення TPM';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'Вы можаце атрымаць доступ да ключа аднаўлення пасля ўсталявання з дапамогай наступнай каманды:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Obnovovací klíč k TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Získat obnovovací klíč';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Bez klíče pro obnovení můžete přijít o všechna data';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Jakmile se poprvé přihlásíte do $distro, získejte obnovovací klíč a uložte si jej na bezpečném místě.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Pro získání obnovovacího klíče dokončete instalaci, restartujte počítač a v terminálu spusťte tento příkaz:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Uložte si klíč pro obnovení na bezpečném místě. Použijte jej k dešifrování disku v případě určitých systémových změn. Můžete jej například potřebovat, pokud měníte součásti v počítači nebo aktualizujete firmware.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Dozvědět se více';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-genoprettelsesnøgle';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'Du kan tilgå din genoprettelsesnøgle efter installation med følgende kommando:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-genoprettelsesnøgle';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-Wiederherstellungsschlüssel';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Wiederherstellungsschlüssel erhalten';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Ohne einen Wiederherstellungsschlüssel können Sie alle Ihre Daten verlieren';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Besorgen Sie sich einen Wiederherstellungsschlüssel, sobald Sie sich zum ersten Mal bei $distro anmelden, und bewahren Sie ihn an einem sicheren Ort auf.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Um einen Wiederherstellungsschlüssel zu erhalten, schließen Sie die Installation ab, starten Sie Ihren Computer neu und führen Sie diesen Befehl im Terminal aus:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Bewahren Sie den Wiederherstellungsschlüssel an einem sicheren Ort auf. Verwenden Sie ihn zum Entschlüsseln der Festplatte im Falle bestimmter Systemänderungen. Sie benötigen ihn zum Beispiel, wenn Sie die Komponenten in Ihrem Computer ändern oder die Firmware aktualisieren.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Mehr erfahren';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Vi eble perdos ĉiom da viaj datenoj sen restaŭra ŝlosilo';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Akiru restaŭran ŝlosilon tuj post unua saluto al $distro, kaj konservu ĝin ie sekure.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Por akiri restaŭran ŝlosilon, finu la instaladon, restartigu vian komputilon, kaj rulu la jenon en la terminalo:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Konservu la restaŭran ŝlosilon ie sekure. Uzu ĝin por malĉifri la diskon por kelkaj sistemaj ŝanĝoj. Ekzemple, oni bezonos ĝin, se oni ŝanĝos la komponantojn de via komputilo aŭ ĝisdatigos la mikroprogramaron.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Lerni plu';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ŝlosilo por aparato-baza ĉifrado';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Akiri restaŭran ŝlosilon';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Puede perder todos sus datos sin una clave de recuperación';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Obtenga una clave de recuperación tan pronto como su primer acceso a $distro y almacénela en algún lugar seguro.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Puede obtener una llave de recuperación, complete la instalación, reinicie su equipo, y ejecute este comando dentro del terminal:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Almacene la clave de recuperación donde sea seguro. Utilícela para cifrar el disco en caso de ciertos cambios del sistema. Por ejemplo, puede necesitarlo si cambia los componentes en su equipo o actualice el firmware.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Saber más';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clave de recuperación para el TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Obtenga una clave de recuperación';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-i taastevõti';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Loo endale taastevõti';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Ilma taastevõtmeta võid kaotada ligipääsu kõikidele oma andmetele';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Loo oma taastevõti niipea, kui esimest korda logid sisse $distro operatsioonisüsteemi ning palun märgi ta üles ning hoia turvaliselt kas moodsas digitaalses salasõnalaekas või vana kooli seifis.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Taastevõtme loomiseks lõpeta paigaldus, käivita arvuti uuesti ning käsurealt käivita järgnev käsk:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Hoia taastevõtit turvaliselt kas moodsas digitaalses salasõnalaekas või vana kooli seifis. Mõnede süsteemimuudatuste puhul pead teda kasutama andmekandja dekrüptimiseks. Näiteks võib teda vaja olla, kui muudad oma arvuti raudvaralisi komponente või uuendad püsivara.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Lisateave';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'کلید بازیابی TPM';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'کلید بازیابی TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Saatat menettää kaikki tiedot ilman palautusavainta';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Ota ylös palautusavain heti ensimmäisellä kirjautumiskerralla ${distro}un ja tallenna se turvalliseen paikkaan.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Ottaaksesi ylös palautusavaimen odota asennuksen valmistumista, käynnistä tietokone uudelleen ja suorita seuraava komento päätteessä:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Tallenna palautusavain turvalliseen paikkaan. Sitä voi käyttää levyn salauksen purkuun tietyissä järjestelmämuutostilanteissa. Sitä voidaan tarvita esimerkiksi jos tietokoneen komponentteja vaihdetaan tai sen laiteohjelmisto päivitetään.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Lue lisää';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-palautusavain';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Luo palautusavain';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Vous risquez de perdre toutes vos données sans clé de récupération';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Obtenez une clé de récupération dès que vous vous connectez à $distro et conservez-la en lieu sûr.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Pour obtenir une clé de récupération, terminer l’installation, redémarrer votre ordinateur puis exécuter cette commande dans le terminal :';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Stocker la clé de récupération en lieu sûr. Utilisez-la pour déchiffrer le disque en cas de certains changements du système. Par exemple, vous pourriez en avoir besoin si vous changez les composants de votre ordinateur ou mettez à jour le micrologiciel.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'En savoir plus';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clé de récupération du TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Obtenir une clé de récupération';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Seans go gcaillfidh tú do shonraí go léir gan eochair athshlánaithe';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Faigh eochair athshlánaithe chomh luath agus a logálann tú isteach i $distro den chéad uair agus stóráil áit éigin sábháilte í.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Chun eochair athshlánaithe a fháil, cuir an tsuiteáil i gcrích, atosaigh do ríomhaire, agus rith an t-ordú seo sa teirminéal:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Stóráil an eochair athshlánaithe áit éigin sábháilte. Úsáid é chun an diosca a dhíchriptiú i gcás athruithe córais áirithe. Mar shampla, b\'fhéidir go mbeadh sé ag teastáil uait má athraíonn tú na comhpháirteanna i do ríomhaire nó má nuashonraíonn tú firmware.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Foghlaim níos mó';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Eochair aisghabhála TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Faigh eochair athshlánaithe';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'מפתח שחזור TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'קבלת קוד שחזור';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'הנתונים שלך עלולים ללכת לאיבוד ללא מפתח שחזור';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'אפשר לקבל מפתח שחזור עם הכניסה הראשונה ל־$distro ולאחסן אותו במקום בטוח.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'כדי לקבל מפתח שחזור, יש להשלים את ההתקנה, להפעיל את המחשב מחדש ולהריץ את הפקודה הזאת במסוף:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'יש לאחסן את מפתח השחזור במקום אחר. אפשר להשתמש בו כדי להצפין את הכונן במקרה של שינויים מסוימים במערכת. למשל, יכול להיות שהוא נחוץ במקרה של שינוי הרכיבים במחשב שלך או שדרוג קושחה.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'מידע נוסף';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM helyreállítási kulcs';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Helyreállítási kulcs beszerzése';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Helyreállítási kulcs nélkül elveszítheti az összes adatát';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Szerezzen be egy helyreállítási kulcsot, amint először bejelentkezik a(z) $distro rendszerbe, és tárolja azt biztonságos helyen.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'A helyreállítási kulcs beszerzéséhez fejezze be a telepítést, indítsa újra a számítógépet, majd futtassa ezt a parancsot a terminálban:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Tárolja a helyreállítási kulcsot biztonságos helyen. Használja azt a lemez bizonyos rendszerváltozások esetén történő visszafejtéséhez. Például szüksége lehet rá, ha megváltoztatja a számítógépben lévő alkatrészeket vagy frissíti a belső vezérlőprogramot.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Kunci pemulihan TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Dapatkan kunci pemulihan';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Anda bisa kehilangan semua data Anda tanpa kunci pemulihan';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Dapatkan kunci pemulihan segera setelah Anda log masuk pertama ke $distro dan menyimpannya di suatu tempat aman.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Untuk mendapatkan kunci pemulihan, selesaikan instalasi, restart komputer Anda, dan jalankan perintah ini di terminal:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Simpan kunci pemulihan di suatu tempat aman. Gunakan untuk mengenkripsi disk jika terjadi perubahan sistem tertentu. Misalnya, Anda mungkin perlu jika Anda mengubah komponen di komputer atau memperbarui firmware.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPMリカバリーキー';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'インストール後、次のコマンドでリカバリーキーがわかります:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPMリカバリーキー';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-ის აღდგენის გასაღები';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-ის აღდგენის გასაღები';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 복구 키';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => '설치 후 다음 명령을 사용하여 복구 키에 액세스할 수 있습니다:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 복구 키';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-gjenopprettingsnøkkel';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-gjenopprettingsnøkkel';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM-herstelcode';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Herstelcode opvragen';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Zonder herstelcode kunt u al uw gegevens verliezen';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Vraag een herstelcode op zodra u voor het eerst aanmeldt bij $distro en bewaar deze op een veilige plek.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Om een herstelcode te krijgen, moet u de installatie voltooien, de computer opnieuw opstarten en deze opdracht uitvoeren in de terminal:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Bewaar de herstelcode op een veilige plek. Gebruik hem om de schijf te decoderen in geval van bepaalde systeemwijzigingen. U kunt deze bijvoorbeeld nodig hebben als u bepaalde onderdelen in uw computer vervangt of de firmware bijwerkt.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Meer informatie';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Clau de recuperacion del TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Obténer una clau de recuperacion';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Poiriatz pèrdre totas vòstras donadas sens una clau de recuperacion';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Obtenètz una clau de recuperacion tre la primièra connexion a $distro e gardatz-la en luòc segur.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Per obténer la clau de recuperacion, acabatz l’installacion, reaviatz l’ordenador puèi executatz la comanda seguenta dins un terminal :';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Gardatz la clau de recuperacion en luòc segur. Utilizatz-la per deschifrar lo disc en cas de cambiament de sistèma. Per exemple, vos poiriá far mestièr se modificatz los compausants de l’ordenador o actualizatz lo micrologicial.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Klucz odzyskiwania modułu TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Uzyskaj klucz odzyskiwania';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Bez klucza odzyskiwania możesz utracić wszystkie swoje dane';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Zaraz po pierwszym zalogowaniu do $distro uzyskaj klucz odzyskiwania i przechowuj go w bezpiecznym miejscu.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Aby uzyskać klucz odzyskiwania, zakończ instalację, uruchom ponownie komputer i uruchom to polecenie w terminalu:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Przechowuj klucz odzyskiwania w bezpiecznym miejscu. Używaj go do odszyfrowania dysku w przypadku niektórych zmian w systemie. Przykładowo możesz go potrzebować, jeśli zmienisz komponenty w komputerze lub zaktualizujesz oprogramowanie układowe.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Dowiedz się więcej';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Chave de recuperação TPM';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'Você pode acessar à sua chave de recuperação após a instalação com o seguinte comando:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {
@@ -2053,7 +2062,4 @@ class UbuntuBootstrapLocalizationsPtBr extends UbuntuBootstrapLocalizationsPt {
 
   @override
   String get recoveryKeyTitle => 'Chave de recuperação do TPM';
-
-  @override
-  String get recoveryKeyCommand => 'Você pode acessar sua chave de recuperação após a instalação com o seguinte comando:';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Chave de recuperação TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Без ключа восстановления вы можете потерять все свои данные';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Получите ключ восстановления сразу же после первого входа в систему $distro и храните его в надежном месте.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Чтобы получить ключ восстановления, завершите установку, перезапустите компьютер и выполните следующую команду в терминале:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Храните ключ восстановления в безопасном месте. Используйте его для расшифровки диска в случае некоторых изменений в системе. Например, он может понадобиться при замене компонентов в компьютере или обновлении прошивки.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Узнать больше';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ восстановления TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Получить ключ восстановления';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM ප්‍රතිසාධන කේතය';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM ප්‍රතිසාධන කේතය';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kľúč na obnovenie';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Získanie obnovovacieho kľúča';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Bez obnovovacieho kľúča môžete prísť o všetky svoje údaje';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Získajte obnovovací kľúč hneď po prvom prihlásení do $distro a uložte ho na bezpečné miesto.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Aby ste získali obnovovací kľúč, dokončite inštaláciu, reštartujte počítač a spustite tento príkaz v termináli:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Uložte obnovovací kľúč na bezpečné miesto. Použite ho na dešifrovanie disku v prípade určitých zmien v systéme. Napríklad ho môžete potrebovať, ak zmeníte komponenty vo vašom počítači alebo aktualizujete firmvér.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Zistiť viac';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM кључ за опоравак';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'Можете приступити свом кључу за опоравак након инсталације помоћу следеће команде:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM кључ за опоравак';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Du kan förlora all din data utan en återställningsnyckel';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Skaffa en återställningsnyckel så snart du loggar in till $distro första gången och lagra den någonstans säkert.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'För att få en återställningsnyckel, slutför installationen, starta om din dator och kör detta kommando i terminalen:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Förvara återställningsnyckeln på ett säkert ställe. Använd den för att dekryptera disken vid vissa systemändringar. Du kan till exempel behöva det om du byter komponenter i din dator eller uppdaterar fast programvara.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Läs mer';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM återställningsnyckel';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Skaffa en återställningsnyckel';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'மீட்பு விசை இல்லாமல் உங்கள் எல்லா தரவையும் இழக்க நேரிடும்';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'நீங்கள் முதலில் $distro இல் உள்நுழைந்தவுடன் ஒரு மீட்பு விசையைப் பெற்று, அதை எங்காவது பாதுகாப்பான இடத்தில் சேமிக்கவும்.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'மீட்பு விசையைப் பெற, நிறுவலை முடிக்க, உங்கள் கணினியை மறுதொடக்கம் செய்து, இந்த கட்டளையை முனையத்தில் இயக்கவும்:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'மீட்பு விசையை எங்காவது பாதுகாப்பாக சேமிக்கவும். சில கணினி மாற்றங்கள் ஏற்பட்டால் வட்டு மறைகுறியாக்க இதைப் பயன்படுத்தவும். எடுத்துக்காட்டாக, உங்கள் கணினியில் உள்ள கூறுகளை மாற்றினால் அல்லது ஃபார்ம்வேரைப் புதுப்பித்தால் உங்களுக்குத் தேவைப்படலாம்.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'மேலும் அறிக';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'டிபிஎம் மீட்பு விசை';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'மீட்பு விசையைப் பெறுங்கள்';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kurtarma anahtarı';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -1073,27 +1073,36 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM kurtarma anahtarı';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'Kurtarma anahtarınıza kurulumdan sonra aşağıdaki komutla erişebilirsiniz:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Ключ відновлення TPM';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Отримати ключ відновлення';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => 'Без ключа відновлення ви можете втратити всі свої дані';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Отримайте ключ відновлення одразу після першого входу до $distro і зберігайте його у безпечному місці.';
-  }
-
-  @override
-  String get recoveryKeyCommand => 'Щоб отримати ключ відновлення, завершіть встановлення, перезапустіть комп\'ютер і виконайте цю команду в терміналі:';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => 'Зберігайте ключ відновлення в надійному місці. Використовуйте його, щоб розшифрувати диск у разі певних змін у системі. Наприклад, він може знадобитися, якщо ви заміните компоненти в комп\'ютері або оновите прошивку.';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Докладніше';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'Recovery key';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
@@ -1082,7 +1085,7 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
+  String get recoveryKeyStorageAdvice => 'You will need to provide this recovery key if decryption fails during startup. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
   String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -1070,30 +1070,39 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyTitle => 'TPM recovery key';
+  String get recoveryKeyTitle => 'Recovery key';
 
   @override
-  String get recoveryKeyHeader => 'Get a recovery key';
+  String get recoveryKeyHeader => 'Save your recovery key';
 
   @override
   String get recoveryKeyInfoHeader => 'You may lose all your data without a recovery key';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return 'Get a recovery key as soon as you first log into $distro and store it somewhere safe.';
-  }
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
-  String get recoveryKeyCommand => 'To get a recovery key, complete the installation, restart your computer, and run this command in the terminal:';
+  String get recoveryKeyStorageAdvice => 'If decryption fails during startup, you will need to provide this recovery key. Without the key, you will lose access to all your data. Save it somewhere safe, such as a password manager.';
 
   @override
-  String get recoveryKeyStorageAdvice => 'Store the recovery key somewhere safe. Use it to decrypt the disk in case of certain system changes. For example, you may need it if you change the components in your computer or update firmware.';
-
-  @override
-  String get recoveryKeyConfirmation => 'I understand I may lose all my data if I don\'t have a recovery key';
+  String get recoveryKeyConfirmation => 'I saved my recovery key somewhere safe';
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -1079,12 +1079,7 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyInfoHeader => '没有恢复密钥，您可能丢失所有数据';
 
   @override
-  String recoveryKeyInfoBody(String distro) {
-    return '在您登入 $distro 时立刻获取恢复密钥并将其存储在安全的地方。';
-  }
-
-  @override
-  String get recoveryKeyCommand => '要获取恢复密钥，完成安装，重新启动计算机，然后在终端内执行此命令：';
+  String get recoveryKeyTextFieldLabel => 'Recovery key';
 
   @override
   String get recoveryKeyStorageAdvice => '将恢复密钥存储在安全的地方。当系统发生某些更改时用其解密磁盘。例如，您可能在更改计算机组件或者进行固件更新时需要它。';
@@ -1094,6 +1089,20 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
 
   @override
   String get recoveryKeyLinkLabel => 'Learn more';
+
+  @override
+  String get recoveryKeySaveToFileLabel => 'Save to file';
+
+  @override
+  String get recoveryKeyShowQrCodeLabel => 'Show QR code';
+
+  @override
+  String recoveryKeyQrDialogTitle(String DISTRO) {
+    return '$DISTRO Desktop - Recovery key';
+  }
+
+  @override
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
 
   @override
   String landscapeMagicAttachInstructions(String url) {
@@ -2227,14 +2236,6 @@ class UbuntuBootstrapLocalizationsZhTw extends UbuntuBootstrapLocalizationsZh {
 
   @override
   String get recoveryKeyInfoHeader => '如果沒有復原金鑰，您可能會遺失所有資料';
-
-  @override
-  String recoveryKeyInfoBody(String distro) {
-    return '當您第一次登入 $distro 時，請立即取得還原金鑰，並將它存放在安全的地方。';
-  }
-
-  @override
-  String get recoveryKeyCommand => '若要取得復原金鑰，請完成安裝，重新啟動電腦，然後在終端機執行此命令：';
 
   @override
   String get recoveryKeyStorageAdvice => '將復原金鑰存放在安全的地方。在發生某些系統變更時，使用它來解密磁碟。例如，如果您變更電腦中的零件或更新韌體，您可能需要它。';

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -1073,6 +1073,9 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get recoveryKeyTitle => 'TPM 恢复密钥';
 
   @override
+  String get recoveryKeyTitleBadgeLabel => 'Important';
+
+  @override
   String get recoveryKeyHeader => '获取恢复密钥';
 
   @override
@@ -1102,7 +1105,10 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   }
 
   @override
-  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe and accessible, such as a password manager. You can also take a photo for later use.';
+  String get recoveryKeyQrDialogBody => 'Scan the QR code to copy the recovery key and save it somewhere safe, such as a password manager. You can also take a photo for later use.';
+
+  @override
+  String get recoveryKeyClipboardNotifiaction => 'Copied to clipboard';
 
   @override
   String landscapeMagicAttachInstructions(String url) {

--- a/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_direct_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_direct_model.dart
@@ -4,7 +4,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:ubuntu_bootstrap/ubuntu_bootstrap.dart';
 import 'package:ubuntu_logger/ubuntu_logger.dart';
-import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 import 'package:yaml/yaml.dart';
 
 part 'autoinstall_direct_model.freezed.dart';
@@ -72,8 +71,6 @@ sealed class AutoinstallDirectError with _$AutoinstallDirectError {
 
 @riverpod
 class AutoinstallDirectModel extends _$AutoinstallDirectModel {
-  late final _portal = getService<XdgDesktopPortalClient>();
-
   @override
   AutoinstallDirectState build() => AutoinstallDirectState();
 
@@ -86,34 +83,11 @@ class AutoinstallDirectModel extends _$AutoinstallDirectModel {
     state = state.copyWith(localPath: localPath, url: '', error: null);
   }
 
-  Future<void> pickLocalFile(String title, String filterName) async {
-    try {
-      final result = await _portal.fileChooser.openFile(
-        title: title,
-        filters: [
-          XdgFileChooserFilter(
-            filterName,
-            [
-              XdgFileChooserGlobPattern('*.yaml'),
-              XdgFileChooserGlobPattern('*.yml'),
-              XdgFileChooserMimeTypePattern('application/yaml'),
-            ],
-          ),
-        ],
-      ).first;
-      final uri = Uri.parse(result.uris.first);
-      setLocalPath(uri);
-    } on Exception catch (e) {
-      _log.debug('Caught error during pickLocalFile: $e');
-      state = switch (e) {
-        XdgPortalRequestCancelledException _ =>
-          state.copyWith(localPath: null, isLoading: false),
-        _ => state.copyWith(
-            error: AutoinstallDirectError.from(e),
-            isLoading: false,
-          ),
-      };
-    }
+  void setError(Exception e) {
+    state = state.copyWith(
+      error: AutoinstallDirectError.from(e),
+      isLoading: false,
+    );
   }
 
   /// Returns true on success, which indicates that we can restart subiquity and the UI

--- a/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_direct_model.g.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_direct_model.g.dart
@@ -7,7 +7,7 @@ part of 'autoinstall_direct_model.dart';
 // **************************************************************************
 
 String _$autoinstallDirectModelHash() =>
-    r'049025092e0ea605ad0d68cd068ad904fed526b5';
+    r'b81f54e71519032502468c1eacee7bb29b9edd8f';
 
 /// See also [AutoinstallDirectModel].
 @ProviderFor(AutoinstallDirectModel)

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_model.dart
@@ -40,7 +40,7 @@ class RecoveryKeyModel extends SafeChangeNotifier {
     ].contains(_storage.guidedCapability)) {
       return false;
     }
-    _recoveryKey = '55055-39320-64491-48436-47667-15525-36879-32875';
+    _recoveryKey = await _storage.getCoreBootRecoveryKey();
     return true;
   }
 }

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_model.dart
@@ -30,11 +30,17 @@ class RecoveryKeyModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
+  late final String _recoveryKey;
+  String get recoveryKey => _recoveryKey;
+
   Future<bool> init() async {
-    return switch (_storage.guidedCapability) {
-      GuidedCapability.CORE_BOOT_ENCRYPTED => true,
-      GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED => true,
-      _ => false,
-    };
+    if (![
+      GuidedCapability.CORE_BOOT_ENCRYPTED,
+      GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
+    ].contains(_storage.guidedCapability)) {
+      return false;
+    }
+    _recoveryKey = '55055-39320-64491-48436-47667-15525-36879-32875';
+    return true;
   }
 }

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -138,6 +138,8 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
           title: Text(
             l10n.recoveryKeyConfirmation,
             maxLines: 2,
+            // TODO: remove hardcoded style once this is avialable in yaru.
+            style: Theme.of(context).textTheme.bodyMedium,
           ),
           value: model.confirmed,
           onChanged: model.setConfirmed,

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -48,6 +48,16 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
     return HorizontalPage(
       windowTitle: l10n.recoveryKeyTitle,
       title: l10n.recoveryKeyHeader,
+      trailingTitleWidget: Expanded(
+        child: Row(
+          children: [
+            YaruInfoBadge(
+              title: Text(l10n.recoveryKeyTitleBadgeLabel),
+              yaruInfoType: YaruInfoType.danger,
+            ),
+          ],
+        ),
+      ),
       bottomBar: WizardBar(
         trailing: [
           NextWizardButton(

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -60,11 +60,7 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
       ),
       bottomBar: WizardBar(
         trailing: [
-          NextWizardButton(
-            enabled: ref.watch(
-              recoveryKeyModelProvider.select((model) => model.confirmed),
-            ),
-          ),
+          NextWizardButton(enabled: model.confirmed),
         ],
       ),
       children: <Widget>[

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -26,6 +26,20 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
     return ref.read(recoveryKeyModelProvider).init();
   }
 
+  void saveToClipboard(BuildContext context, String text) {
+    Clipboard.setData(
+      ClipboardData(text: text),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          UbuntuBootstrapLocalizations.of(context)
+              .recoveryKeyClipboardNotifiaction,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = UbuntuBootstrapLocalizations.of(context);
@@ -62,33 +76,36 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
             ),
           ],
         ),
-        TextFormField(
-          initialValue: model.recoveryKey,
-          decoration: InputDecoration(
-            labelText: l10n.recoveryKeyTextFieldLabel,
-            suffixIcon: YaruIconButton(
-              icon: const Icon(YaruIcons.copy, size: 16),
-              onPressed: () {
-                Clipboard.setData(
-                  ClipboardData(text: model.recoveryKey),
-                );
-              },
-            ),
-            suffixIconConstraints: BoxConstraints(
-              maxWidth: 32,
-              maxHeight: 32,
-            ),
-          ),
-          readOnly: true,
-          minLines: 1,
-          maxLines: 2,
-          style: TextStyle(
-            inherit: false,
-            fontFamily: 'Ubuntu Mono',
-            fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
-            textBaseline: TextBaseline.alphabetic,
-            color: Theme.of(context).colorScheme.onSurface,
-          ),
+        Builder(
+          // This builder is needed to access the build context that contains
+          // the ScaffoldMessenger to display the Snackbar
+          builder: (context) {
+            return TextFormField(
+              onTap: () => saveToClipboard(context, model.recoveryKey),
+              initialValue: model.recoveryKey,
+              decoration: InputDecoration(
+                labelText: l10n.recoveryKeyTextFieldLabel,
+                suffixIcon: YaruIconButton(
+                  icon: const Icon(YaruIcons.copy, size: 16),
+                  onPressed: () => saveToClipboard(context, model.recoveryKey),
+                ),
+                suffixIconConstraints: BoxConstraints(
+                  maxWidth: 32,
+                  maxHeight: 32,
+                ),
+              ),
+              readOnly: true,
+              minLines: 1,
+              maxLines: 2,
+              style: TextStyle(
+                inherit: false,
+                fontFamily: 'Ubuntu Mono',
+                fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+                textBaseline: TextBaseline.alphabetic,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+            );
+          },
         ),
         Wrap(
           children: [

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -1,10 +1,11 @@
+import 'package:barcode_widget/barcode_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/recovery_key/recovery_key_model.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
-import 'package:ubuntu_bootstrap/widgets/info_box.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
@@ -29,7 +30,6 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(recoveryKeyModelProvider);
-    final flavor = ref.watch(flavorProvider);
 
     return HorizontalPage(
       windowTitle: l10n.recoveryKeyTitle,
@@ -44,21 +44,6 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       children: <Widget>[
-        InfoBox(
-          title: l10n.recoveryKeyInfoHeader,
-          subtitle: l10n.recoveryKeyInfoBody(flavor.displayName),
-          type: InfoBoxType.warning,
-          isThreeLine: true,
-        ),
-        Text(l10n.recoveryKeyCommand),
-        SelectableText(
-          kRecoveryKeyCommand,
-          style: TextStyle(
-            fontFamily: 'Ubuntu Mono',
-            fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
-            textBaseline: TextBaseline.alphabetic,
-          ),
-        ),
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -77,16 +62,103 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
             ),
           ],
         ),
+        TextFormField(
+          initialValue: model.recoveryKey,
+          decoration: InputDecoration(
+            labelText: 'Recovery key',
+            suffixIcon: YaruIconButton(
+              icon: const Icon(YaruIcons.copy, size: 16),
+              onPressed: () {
+                Clipboard.setData(
+                  ClipboardData(text: model.recoveryKey),
+                );
+              },
+            ),
+            suffixIconConstraints: BoxConstraints(
+              maxWidth: 32,
+              maxHeight: 32,
+            ),
+          ),
+          readOnly: true,
+          minLines: 1,
+          maxLines: 2,
+          style: TextStyle(
+            inherit: false,
+            fontFamily: 'Ubuntu Mono',
+            fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+            textBaseline: TextBaseline.alphabetic,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
+        ),
+        Wrap(
+          children: [
+            OutlinedButton(
+              // TODO: file picker
+              onPressed: () {},
+              // TODO: l10n string
+              child: Text('Save to file'),
+            ),
+            OutlinedButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (_) =>
+                    _RecoveryKeyDialog(recoveryKey: model.recoveryKey),
+              ),
+              // TODO: l10n string
+              child: Text('Show QR code'),
+            ),
+          ].withSpacing(kWizardSpacing / 2),
+        ),
         YaruCheckButton(
           title: Text(
             l10n.recoveryKeyConfirmation,
             maxLines: 2,
           ),
-          contentPadding: kWizardPadding,
           value: model.confirmed,
           onChanged: model.setConfirmed,
         ),
       ].withSpacing(kWizardSpacing),
+    );
+  }
+}
+
+class _RecoveryKeyDialog extends StatelessWidget {
+  const _RecoveryKeyDialog({
+    required this.recoveryKey,
+  });
+
+  final String recoveryKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: YaruDialogTitleBar(),
+      titlePadding: EdgeInsets.zero,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          BarcodeWidget(
+            margin: const EdgeInsets.symmetric(
+              vertical: kWizardSpacing,
+            ),
+            color: Theme.of(context).colorScheme.onSurface,
+            barcode: Barcode.qrCode(),
+            data: recoveryKey,
+            width: 200,
+            height: 200,
+          ),
+          Text(
+            recoveryKey,
+            style: TextStyle(
+              inherit: false,
+              fontFamily: 'Ubuntu Mono',
+              fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+              textBaseline: TextBaseline.alphabetic,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -65,7 +65,7 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
         TextFormField(
           initialValue: model.recoveryKey,
           decoration: InputDecoration(
-            labelText: 'Recovery key',
+            labelText: l10n.recoveryKeyTextFieldLabel,
             suffixIcon: YaruIconButton(
               icon: const Icon(YaruIcons.copy, size: 16),
               onPressed: () {
@@ -95,8 +95,7 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
             OutlinedButton(
               // TODO: file picker
               onPressed: () {},
-              // TODO: l10n string
-              child: Text('Save to file'),
+              child: Text(l10n.recoveryKeySaveToFileLabel),
             ),
             OutlinedButton(
               onPressed: () => showDialog(
@@ -104,8 +103,7 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
                 builder: (_) =>
                     _RecoveryKeyDialog(recoveryKey: model.recoveryKey),
               ),
-              // TODO: l10n string
-              child: Text('Show QR code'),
+              child: Text(l10n.recoveryKeyShowQrCodeLabel),
             ),
           ].withSpacing(kWizardSpacing / 2),
         ),
@@ -122,7 +120,7 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
   }
 }
 
-class _RecoveryKeyDialog extends StatelessWidget {
+class _RecoveryKeyDialog extends ConsumerWidget {
   const _RecoveryKeyDialog({
     required this.recoveryKey,
   });
@@ -130,34 +128,40 @@ class _RecoveryKeyDialog extends StatelessWidget {
   final String recoveryKey;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = UbuntuBootstrapLocalizations.of(context);
+    final flavor = ref.watch(flavorProvider);
     return AlertDialog(
-      title: YaruDialogTitleBar(),
+      title: YaruDialogTitleBar(
+        title: Text(l10n.recoveryKeyQrDialogTitle(flavor.displayName)),
+      ),
       titlePadding: EdgeInsets.zero,
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          BarcodeWidget(
-            margin: const EdgeInsets.symmetric(
-              vertical: kWizardSpacing,
-            ),
-            color: Theme.of(context).colorScheme.onSurface,
-            barcode: Barcode.qrCode(),
-            data: recoveryKey,
-            width: 200,
-            height: 200,
-          ),
-          Text(
-            recoveryKey,
-            style: TextStyle(
-              inherit: false,
-              fontFamily: 'Ubuntu Mono',
-              fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
-              textBaseline: TextBaseline.alphabetic,
+      content: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 500),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(l10n.recoveryKeyQrDialogBody),
+            BarcodeWidget(
+              margin: const EdgeInsets.all(2 * kWizardSpacing),
               color: Theme.of(context).colorScheme.onSurface,
+              barcode: Barcode.qrCode(),
+              data: recoveryKey,
+              width: 200,
+              height: 200,
             ),
-          ),
-        ],
+            Text(
+              recoveryKey,
+              style: TextStyle(
+                inherit: false,
+                fontFamily: 'Ubuntu Mono',
+                fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+                textBaseline: TextBaseline.alphabetic,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/ubuntu_bootstrap/lib/services/storage_service.dart
+++ b/apps/ubuntu_bootstrap/lib/services/storage_service.dart
@@ -176,4 +176,10 @@ class StorageService {
   Future<List<Disk>> reformatDisk(Disk disk) {
     return _client.reformatDiskV2(disk).then(_updateStorage);
   }
+
+  /// Returns the recovery key for CORE_BOOT_ENCRYPTED guided scenarios. Needs
+  /// to be called after [setGuidedStorage].
+  Future<String> getCoreBootRecoveryKey() {
+    return _client.getCoreBootRecoveryKeyV2();
+  }
 }

--- a/apps/ubuntu_bootstrap/test/recovery_key/recovery_key_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/recovery_key/recovery_key_model_test.dart
@@ -6,6 +6,8 @@ import 'package:ubuntu_bootstrap/pages/recovery_key/recovery_key_model.dart';
 import '../test_utils.dart';
 
 void main() {
+  const testRecoveryKey = '12345-12345-12345-12345-12345-12345-12345-12345';
+
   test('init', () async {
     final storage = MockStorageService();
     final model = RecoveryKeyModel(storage: storage);
@@ -15,6 +17,10 @@ void main() {
 
     when(storage.guidedCapability)
         .thenReturn(GuidedCapability.CORE_BOOT_ENCRYPTED);
+    when(storage.getCoreBootRecoveryKey()).thenAnswer(
+      (_) async => testRecoveryKey,
+    );
     expect(await model.init(), isTrue);
+    expect(model.recoveryKey, equals(testRecoveryKey));
   });
 }

--- a/apps/ubuntu_bootstrap/test/recovery_key/recovery_key_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/recovery_key/recovery_key_page_test.dart
@@ -23,10 +23,11 @@ void main() {
     );
   }
 
-  testWidgets('command', (tester) async {
-    final model = buildRecoveryKeyModel();
+  testWidgets('display recovery key', (tester) async {
+    const recoveryKey = '12345-12345-12345-12345-12345-12345-12345-12345';
+    final model = buildRecoveryKeyModel(recoveryKey: recoveryKey);
     await tester.pumpApp((_) => buildPage(model));
 
-    expect(find.text(kRecoveryKeyCommand), findsOneWidget);
+    expect(find.text(recoveryKey), findsOneWidget);
   });
 }

--- a/apps/ubuntu_bootstrap/test/recovery_key/test_recovery_key.dart
+++ b/apps/ubuntu_bootstrap/test/recovery_key/test_recovery_key.dart
@@ -6,9 +6,13 @@ import 'test_recovery_key.mocks.dart';
 export 'test_recovery_key.mocks.dart';
 
 @GenerateMocks([RecoveryKeyModel])
-RecoveryKeyModel buildRecoveryKeyModel({bool? init}) {
+RecoveryKeyModel buildRecoveryKeyModel({
+  bool? init,
+  String? recoveryKey,
+}) {
   final model = MockRecoveryKeyModel();
   when(model.init()).thenAnswer((_) async => init ?? false);
   when(model.confirmed).thenReturn(true);
+  when(model.recoveryKey).thenReturn(recoveryKey ?? '');
   return model;
 }

--- a/apps/ubuntu_bootstrap/test/recovery_key/test_recovery_key.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/recovery_key/test_recovery_key.mocks.dart
@@ -3,10 +3,11 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
-import 'dart:ui' as _i4;
+import 'dart:async' as _i4;
+import 'dart:ui' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i3;
 import 'package:ubuntu_bootstrap/pages/recovery_key/recovery_key_model.dart'
     as _i2;
 
@@ -38,6 +39,15 @@ class MockRecoveryKeyModel extends _i1.Mock implements _i2.RecoveryKeyModel {
       ) as bool);
 
   @override
+  String get recoveryKey => (super.noSuchMethod(
+        Invocation.getter(#recoveryKey),
+        returnValue: _i3.dummyValue<String>(
+          this,
+          Invocation.getter(#recoveryKey),
+        ),
+      ) as String);
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -59,16 +69,16 @@ class MockRecoveryKeyModel extends _i1.Mock implements _i2.RecoveryKeyModel {
       );
 
   @override
-  _i3.Future<bool> init() => (super.noSuchMethod(
+  _i4.Future<bool> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i3.Future<bool>.value(false),
-      ) as _i3.Future<bool>);
+        returnValue: _i4.Future<bool>.value(false),
+      ) as _i4.Future<bool>);
 
   @override
-  void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -77,7 +87,7 @@ class MockRecoveryKeyModel extends _i1.Mock implements _i2.RecoveryKeyModel {
       );
 
   @override
-  void removeListener(_i4.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i5.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/apps/ubuntu_bootstrap/test/services/storage_service_test.dart
+++ b/apps/ubuntu_bootstrap/test/services/storage_service_test.dart
@@ -9,6 +9,7 @@ void main() {
   final testTargets = testDisks
       .map((disk) => GuidedStorageTargetReformat(diskId: disk.id))
       .toList();
+  const testRecoveryKey = '12345-12345-12345-12345-12345-12345-12345-12345';
 
   late SubiquityClient client;
 
@@ -36,6 +37,8 @@ void main() {
     );
     when(client.resetStorageV2())
         .thenAnswer((_) async => fakeStorageResponse());
+    when(client.getCoreBootRecoveryKeyV2())
+        .thenAnswer((_) async => testRecoveryKey);
   });
 
   test('get guided storage', () async {
@@ -324,5 +327,14 @@ void main() {
     await service.setGuidedStorage();
     verify(client.setGuidedStorageV2(choice)).called(1);
     verify(client.setStorageV2()).called(1);
+  });
+
+  test('get recovery key', () async {
+    final service = StorageService(client);
+    await service.init();
+
+    final result = await service.getCoreBootRecoveryKey();
+    expect(result, equals(testRecoveryKey));
+    verify(client.getCoreBootRecoveryKeyV2()).called(1);
   });
 }

--- a/apps/ubuntu_bootstrap/test/test_utils.dart
+++ b/apps/ubuntu_bootstrap/test/test_utils.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gsettings/gsettings.dart';
 import 'package:mockito/annotations.dart';
@@ -38,29 +37,24 @@ extension WidgetTesterX on WidgetTester {
     view.devicePixelRatio = 1;
     view.physicalSize = const Size(960, 680);
 
-    // The root level `ProviderScope` is needed so that the file picker dialog from the autoinstall
-    // flow can access providers. (We push a `DialogRoute` containing a `ModalBarrier` onto the
-    // root navigator to block the UI while showing the external XDG file picker)
-    return ProviderScope(
-      child: MaterialApp(
-        localizationsDelegates: GlobalUbuntuBootstrapLocalizations.delegates,
-        theme: yaruLight,
-        home: Wizard(
-          routes: {
-            '/': WizardRoute(
-              builder: builder,
-              onNext: (settings) => '/next',
+    return MaterialApp(
+      localizationsDelegates: GlobalUbuntuBootstrapLocalizations.delegates,
+      theme: yaruLight,
+      home: Wizard(
+        routes: {
+          '/': WizardRoute(
+            builder: builder,
+            onNext: (settings) => '/next',
+          ),
+          '/next': WizardRoute(
+            builder: (_) => const Row(
+              children: [
+                Text('Next page'),
+                BackWizardButton(),
+              ],
             ),
-            '/next': WizardRoute(
-              builder: (_) => const Row(
-                children: [
-                  Text('Next page'),
-                  BackWizardButton(),
-                ],
-              ),
-            ),
-          },
-        ),
+          ),
+        },
       ),
     );
   }

--- a/apps/ubuntu_bootstrap/test/test_utils.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/test_utils.mocks.dart
@@ -627,6 +627,21 @@ class MockStorageService extends _i1.Mock implements _i12.StorageService {
         ),
         returnValue: _i9.Future<List<_i5.Disk>>.value(<_i5.Disk>[]),
       ) as _i9.Future<List<_i5.Disk>>);
+
+  @override
+  _i9.Future<String> getCoreBootRecoveryKey() => (super.noSuchMethod(
+        Invocation.method(
+          #getCoreBootRecoveryKey,
+          [],
+        ),
+        returnValue: _i9.Future<String>.value(_i8.dummyValue<String>(
+          this,
+          Invocation.method(
+            #getCoreBootRecoveryKey,
+            [],
+          ),
+        )),
+      ) as _i9.Future<String>);
 }
 
 /// A class which mocks [PageImages].

--- a/packages/subiquity_client/lib/src/client.dart
+++ b/packages/subiquity_client/lib/src/client.dart
@@ -430,6 +430,11 @@ class SubiquityClient {
     );
   }
 
+  Future<String> getCoreBootRecoveryKeyV2() async {
+    final request = await _openUrl('GET', 'storage/v2/core_boot_recovery_key');
+    return _receive('getCoreBootRecoveryKeyV2()', request);
+  }
+
   Future<void> reboot({bool immediate = false}) async {
     final params = {
       'mode': jsonEncode('REBOOT'),

--- a/packages/subiquity_test/lib/src/generated.mocks.dart
+++ b/packages/subiquity_test/lib/src/generated.mocks.dart
@@ -747,6 +747,21 @@ class MockSubiquityClient extends _i1.Mock implements _i4.SubiquityClient {
       ) as _i5.Future<_i2.StorageResponseV2>);
 
   @override
+  _i5.Future<String> getCoreBootRecoveryKeyV2() => (super.noSuchMethod(
+        Invocation.method(
+          #getCoreBootRecoveryKeyV2,
+          [],
+        ),
+        returnValue: _i5.Future<String>.value(_i6.dummyValue<String>(
+          this,
+          Invocation.method(
+            #getCoreBootRecoveryKeyV2,
+            [],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
   _i5.Future<void> reboot({bool? immediate = false}) => (super.noSuchMethod(
         Invocation.method(
           #reboot,

--- a/packages/ubuntu_provision/lib/src/widgets/file_picker_dialog.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/file_picker_dialog.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ubuntu_logger/ubuntu_logger.dart';
+import 'package:ubuntu_service/ubuntu_service.dart';
+import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
+
+final _log = Logger('file_picker');
+
+enum _FilePickerAction {
+  open,
+  save,
+}
+
+Future<Uri?> showOpenFileDialog({
+  required BuildContext context,
+  required String title,
+  List<XdgFileChooserFilter> filters = const [],
+}) =>
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _FilePicker(
+        title: title,
+        filters: filters,
+        action: _FilePickerAction.open,
+      ),
+    );
+
+Future<Uri?> showSaveFileDialog({
+  required BuildContext context,
+  required String title,
+  String? defaultFileName,
+  List<XdgFileChooserFilter> filters = const [],
+}) =>
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _FilePicker(
+        title: title,
+        filters: filters,
+        defaultFileName: defaultFileName,
+        action: _FilePickerAction.save,
+      ),
+    );
+
+class _FilePicker extends ConsumerStatefulWidget {
+  const _FilePicker({
+    required this.title,
+    required this.filters,
+    required this.action,
+    this.defaultFileName,
+  });
+
+  final String title;
+  final List<XdgFileChooserFilter> filters;
+  final _FilePickerAction action;
+  final String? defaultFileName;
+
+  @override
+  ConsumerState<_FilePicker> createState() => _FilePickerState();
+}
+
+class _FilePickerState extends ConsumerState<_FilePicker> {
+  late final _portal = getService<XdgDesktopPortalClient>();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => showPicker());
+  }
+
+  Future<void> showPicker() async {
+    try {
+      final uri = Uri.parse(
+        await switch (widget.action) {
+          _FilePickerAction.open => _portal.fileChooser
+              .openFile(
+                title: widget.title,
+                filters: widget.filters,
+              )
+              .first
+              .then((result) => result.uris.first),
+          _FilePickerAction.save => _portal.fileChooser
+              .saveFile(
+                title: widget.title,
+                filters: widget.filters,
+                currentName: widget.defaultFileName,
+              )
+              .first
+              .then((result) => result.uris.first)
+        },
+      );
+      if (mounted) {
+        Navigator.of(context).pop(uri);
+      }
+    } on XdgPortalRequestCancelledException catch (e) {
+      _log.debug('XDG dialog cancelled during ${widget.action}: $e');
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
+}

--- a/packages/ubuntu_provision/lib/widgets.dart
+++ b/packages/ubuntu_provision/lib/widgets.dart
@@ -1,3 +1,4 @@
+export 'src/widgets/file_picker_dialog.dart';
 export 'src/widgets/horizontal_page.dart';
 export 'src/widgets/journal_view.dart';
 export 'src/widgets/mascot_avatar.dart';

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   udev: ^0.0.3
   upower: ^0.7.0
   url_launcher: ^6.2.5
+  xdg_desktop_portal: ^0.1.13
   yaml: ^3.1.2
   yaru: ^7.0.0
 


### PR DESCRIPTION
![Screenshot From 2025-05-30 16-40-14](https://github.com/user-attachments/assets/76b0e026-defb-47da-99da-a1cbed33fa34)
![Screenshot From 2025-05-30 16-40-27](https://github.com/user-attachments/assets/9ca62384-2677-4953-9b33-643312af9e03)

This uses the stub endpoint introduced in https://github.com/canonical/subiquity/pull/2211, which is why the format of the recovery key shown in the screenshots doesn't match the TPM/FDE specs yet.

I'll add the 'save to file' dialog in a separate PR.

UDENG-7046