### PR TITLE
chore:update TiCS URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,6 @@ jobs:
         with:
           mode: qserver
           project: ubuntu-desktop-provision
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true


### PR DESCRIPTION
Last week TiCS jobs started failing with
```
[ERROR 5056] Project 'ubuntu-desktop-provision' not defined in PROJECTS.yaml. Use TicsBuildConfig to add this project.
TICS closed with code -1
```

This is because of an update on the tiobe side that requires us to change the url in the github action.