### PR TITLE
feat: add debounce delay to pin/pass text fields

### DIFF
--- a/apps/ubuntu_bootstrap/pubspec.lock
+++ b/apps/ubuntu_bootstrap/pubspec.lock
@@ -303,7 +303,7 @@ packages:
     source: hosted
     version: "2.1.1"
   fake_async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: fake_async
       sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"

--- a/apps/ubuntu_bootstrap/pubspec.yaml
+++ b/apps/ubuntu_bootstrap/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   collection: ^1.17.0
   crypt: ^4.3.1
   dbus: ^0.7.10
+  fake_async: ^1.3.2
   file: ^7.0.0
   flutter:
     sdk: flutter

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/passphrase_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/passphrase_page_test.dart
@@ -36,7 +36,7 @@ void main() {
     final textField = find.textField('foo');
     expect(textField, findsOneWidget);
     await tester.enterText(textField, 'bar');
-    verify(model.passphrase = 'bar').called(1);
+    verify(model.setPassphraseAndEntropy('bar', debounce: true)).called(1);
   });
 
   testWidgets('passphrase confirmation', (tester) async {
@@ -47,9 +47,9 @@ void main() {
     final textFields = find.textField('foo');
     expect(textFields, findsNWidgets(2));
     await tester.enterText(textFields.first, 'bar');
-    verify(model.passphrase = 'bar').called(1);
+    verify(model.setPassphraseAndEntropy('bar', debounce: true)).called(1);
     await tester.enterText(textFields.last, 'bar');
-    verify(model.confirmedPassphrase = 'bar').called(1);
+    verify(model.setConfirmedPassphrase('bar', debounce: true)).called(1);
   });
 
   testWidgets('valid input', (tester) async {
@@ -98,7 +98,7 @@ void main() {
     final textField = find.textField('1234');
     expect(textField, findsOneWidget);
     await tester.enterText(textField, '4b3kk21');
-    verify(model.passphrase = '4321').called(1);
+    verify(model.setPassphraseAndEntropy('4321', debounce: true)).called(1);
   });
 
   group('pin/passphrase entropy', () {

--- a/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/passphrase/test_passphrase.mocks.dart
@@ -43,15 +43,6 @@ class MockPassphraseModel extends _i1.Mock implements _i2.PassphraseModel {
       ) as String);
 
   @override
-  set passphrase(String? value) => super.noSuchMethod(
-        Invocation.setter(
-          #passphrase,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
   String get confirmedPassphrase => (super.noSuchMethod(
         Invocation.getter(#confirmedPassphrase),
         returnValue: _i3.dummyValue<String>(
@@ -59,15 +50,6 @@ class MockPassphraseModel extends _i1.Mock implements _i2.PassphraseModel {
           Invocation.getter(#confirmedPassphrase),
         ),
       ) as String);
-
-  @override
-  set confirmedPassphrase(String? value) => super.noSuchMethod(
-        Invocation.setter(
-          #confirmedPassphrase,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   bool get showPassphrase => (super.noSuchMethod(
@@ -113,6 +95,34 @@ class MockPassphraseModel extends _i1.Mock implements _i2.PassphraseModel {
         Invocation.getter(#isDisposed),
         returnValue: false,
       ) as bool);
+
+  @override
+  void setPassphraseAndEntropy(
+    String? passphrase, {
+    bool? debounce = false,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setPassphraseAndEntropy,
+          [passphrase],
+          {#debounce: debounce},
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void setConfirmedPassphrase(
+    String? value, {
+    bool? debounce = false,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #setConfirmedPassphrase,
+          [value],
+          {#debounce: debounce},
+        ),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<bool> init() => (super.noSuchMethod(

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -447,7 +447,7 @@ extension UbuntuBootstrapPageTester on WidgetTester {
       passphrase,
     );
 
-    await pumpAndSettle();
+    await pumpAndSettle(const Duration(milliseconds: 500));
 
     if (screenshot != null) {
       await takeScreenshot(screenshot);


### PR DESCRIPTION
[Screencast From 2025-07-02 12-24-52.webm](https://github.com/user-attachments/assets/1963d916-e6f9-4f34-8081-9b42675373d3)

Since I had to swap out the `ValidatedTextField` with plain `TextFormFields`, I also addressed the other remaining UI issues (icon alignment, adding an error icon).

UDENG-7268