### PR TITLE
fix(ci): remove cleanup step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,12 +312,6 @@ jobs:
           go install github.com/AlekSi/gocov-xml@latest
           gocov convert /tmp/coverage.out | gocov-xml > coverage/report_co.xml
 
-      - name: Cleanup
-        run: |
-          melos clean
-          melos exec -c 1 flutter clean
-          rm -rf .fvm
-
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Similar to what we previously did in the app-center - this step is no longer required due to some changes on the tiobe side.

UDENG-7356