### PR TITLE
fix(a11y): Add semantic label to timezone map

### DIFF
--- a/packages/ubuntu_provision/lib/src/timezone/timezone_page.dart
+++ b/packages/ubuntu_provision/lib/src/timezone/timezone_page.dart
@@ -102,12 +102,16 @@ class TimezonePage extends ConsumerWidget with ProvisioningPage {
           ),
           const SizedBox(height: kWizardSpacing),
           Expanded(
-            child: TimezoneMap(
-              size: TimezoneMapSize.medium,
-              offset: model.selectedLocation?.offset,
-              marker: model.selectedLocation?.coordinates,
-              onPressed: (coordinates) =>
-                  model.searchMap(coordinates).then(model.selectLocation),
+            child: Semantics(
+              label: model.selectedLocation?.name,
+              button: true,
+              child: TimezoneMap(
+                size: TimezoneMapSize.medium,
+                offset: model.selectedLocation?.offset,
+                marker: model.selectedLocation?.coordinates,
+                onPressed: (coordinates) =>
+                    model.searchMap(coordinates).then(model.selectLocation),
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
The timezone map already seems to ignore tab navigation (desired), so this just gives it a label of the currently selected location for convenience.

---

Audit 1858984
UDEAA-122