### PR TITLE
fix(a11y): Add icon semantic labels

### DIFF
--- a/apps/factory_reset_tools/pubspec.lock
+++ b/apps/factory_reset_tools/pubspec.lock
@@ -613,10 +613,10 @@ packages:
     dependency: transitive
     description:
       name: ubuntu_widgets
-      sha256: "7c4e6c230327cb73dc66dc07953609a67adb5c42096c280a00e0dda31bfca55d"
+      sha256: "2bee8f081b62fd10ce18f4799f1ae293e28056c5d3b7ae5c299572eb31a9d0d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2+1"
+    version: "0.7.3"
   ubuntu_wizard:
     dependency: "direct main"
     description:
@@ -628,10 +628,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -1012,5 +1012,7 @@
   "landscapeConfirmPageSuccessInfoTitle": "Ubuntu will install with the configuration provided by your organization",
   "@landscapeConfirmPageSuccessInfoTitle": {},
   "landscapeConfirmPageSuccessInfoContent": "You can review the autoinstall file imported from Landscape below.",
-  "@landscapeConfirmPageSuccessInfoContent": {}
+  "@landscapeConfirmPageSuccessInfoContent": {},
+  "successIconSemanticLabel": "Success",
+  "errorIconSemanticLabel": "Error"
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -2397,6 +2397,18 @@ abstract class UbuntuBootstrapLocalizations {
   /// In en, this message translates to:
   /// **'You can review the autoinstall file imported from Landscape below.'**
   String get landscapeConfirmPageSuccessInfoContent;
+
+  /// No description provided for @successIconSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Success'**
+  String get successIconSemanticLabel;
+
+  /// No description provided for @errorIconSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get errorIconSemanticLabel;
 }
 
 class _UbuntuBootstrapLocalizationsDelegate

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -1344,4 +1344,10 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -1348,4 +1348,10 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -1347,4 +1347,10 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -1346,4 +1346,10 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Níže si můžete prohlédnout soubor s nastaveními pro automatickou instalaci, načtený z Landscape.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -1346,4 +1346,10 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -1343,4 +1343,10 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -1361,4 +1361,10 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Sie können die aus Landscape importierte autoinstall-Datei unten einsehen.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -1351,4 +1351,10 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Vi povas revizii la aŭtomatan instalan dosieron el Landscape ĉi-sube.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -1355,4 +1355,10 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Puede revisar el archivo autoinstall importado desde Landscape a continuación.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -1354,4 +1354,10 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Landscape\'i teenusest imporditud automaatse paigalduse juhtfaili sisu saad vaadata alljärgnevalt.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -1347,4 +1347,10 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -1343,4 +1343,10 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -1347,4 +1347,10 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Voit käydä läpi Landscapesta tuodun autoinstall-tiedoston sisältöä alla.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -1359,4 +1359,10 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Vous pouvez consulter ci-dessous le fichier d’installation automatique importé de Landscape.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -1356,4 +1356,10 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Is féidir leat athbhreithniú a dhéanamh ar an gcomhad uathshuiteála a allmhairítear ó Landscape thíos.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -1334,4 +1334,10 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'אפשר לסקור את קובץ ההתקנה האוטומטית (autoinstall) מ־Landscape להלן.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -1358,4 +1358,10 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Az alábbiakban áttekintheti a Landscape-ből importált automatikus telepítőfájlt.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -1350,4 +1350,10 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Anda dapat meninjau berkas autoinstall yang diimpor dari Landscape di bawah ini.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -1347,4 +1347,10 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -1320,4 +1320,10 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -1349,4 +1349,10 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -1318,4 +1318,10 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -1349,4 +1349,10 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -1349,4 +1349,10 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -1348,4 +1348,10 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -1358,4 +1358,10 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Je kunt het automatische installatiebestand dat uit Landscape is geïmporteerd hieronder bekijken.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -1357,4 +1357,10 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Podètz repassar lo fichièr d\'autoinstall importat de Landscape çai jos.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -1353,4 +1353,10 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Poniżej możesz przejrzeć plik autoinstalacji zaimportowany z Landscape.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -1351,6 +1351,12 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -1351,4 +1351,10 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Ниже вы можете просмотреть файл автоматической установки, импортированный из Landscape.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -1339,4 +1339,10 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -1350,4 +1350,10 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Nižšie si môžete skontrolovať súbor autoinštalácie importovaný z Landscape.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -1346,4 +1346,10 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -1348,4 +1348,10 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -1347,4 +1347,10 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Du kan granska autoinstallationsfilen som importeras från Landscape nedan.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -1360,4 +1360,10 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'கீழே உள்ள நிலப்பரப்பில் இருந்து இறக்குமதி செய்யப்பட்ட ஆட்டோஇன்ச்டால் கோப்பை நீங்கள் மதிப்பாய்வு செய்யலாம்.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -1347,4 +1347,10 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -1353,4 +1353,10 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'Нижче ви можете переглянути файл автоматичного встановлення, імпортований з Landscape.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -1345,4 +1345,10 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -1287,6 +1287,12 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   @override
   String get landscapeConfirmPageSuccessInfoContent =>
       'You can review the autoinstall file imported from Landscape below.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
+
+  @override
+  String get errorIconSemanticLabel => 'Error';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).

--- a/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_landscape_qr_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_landscape_qr_page.dart
@@ -98,7 +98,9 @@ class AutoinstallLandscapeQrPage extends ConsumerWidget with ProvisioningPage {
                         service.AuthenticationStatus.errorCodeExpired => Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const ErrorIcon(),
+                              ErrorIcon(
+                                semanticLabel: l10n.errorIconSemanticLabel,
+                              ),
                               const SizedBox(width: kWizardSpacing / 4),
                               Text(
                                 l10n.landscapeCodeExpiredWarning,
@@ -118,7 +120,9 @@ class AutoinstallLandscapeQrPage extends ConsumerWidget with ProvisioningPage {
                         _ => Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const ErrorIcon(),
+                              ErrorIcon(
+                                semanticLabel: l10n.errorIconSemanticLabel,
+                              ),
                               const SizedBox(width: kWizardSpacing / 4),
                               Text(
                                 l10n.landscapeLoginFailedWarning,

--- a/apps/ubuntu_bootstrap/lib/pages/secure_boot/secure_boot_widgets.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/secure_boot/secure_boot_widgets.dart
@@ -30,7 +30,9 @@ class SecurityKeyFormField extends ConsumerWidget {
         validator: RequiredValidator(
           errorText: lang.configureSecureBootSecurityKeyRequired,
         ),
-        successWidget: const SuccessIcon(),
+        successWidget: SuccessIcon(
+          semanticLabel: lang.successIconSemanticLabel,
+        ),
       ),
     );
   }
@@ -57,8 +59,11 @@ class SecurityKeyConfirmFormField extends ConsumerWidget {
         enabled: model.areTextFieldsEnabled,
         initialValue: model.confirmKey,
         onChanged: model.setConfirmKey,
-        successWidget:
-            model.securityKey.isNotEmpty ? const SuccessIcon() : null,
+        successWidget: model.securityKey.isNotEmpty
+            ? SuccessIcon(
+                semanticLabel: lang.successIconSemanticLabel,
+              )
+            : null,
         validator: EqualValidator(
           model.securityKey,
           errorText: lang.secureBootSecurityKeysDontMatch,

--- a/apps/ubuntu_bootstrap/pubspec.lock
+++ b/apps/ubuntu_bootstrap/pubspec.lock
@@ -875,10 +875,10 @@ packages:
     dependency: transitive
     description:
       name: pdfrx
-      sha256: afacb1bd02d570eab914d14915c890bdf1747d25d8a7eeb1e7f7d4073f0c52ca
+      sha256: bf3376b375f8628976ac2c77fb0ec90067734a6ed8d38aa0303befdc47477148
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.4"
   petitparser:
     dependency: transitive
     description:
@@ -1362,10 +1362,10 @@ packages:
     dependency: "direct main"
     description:
       name: ubuntu_widgets
-      sha256: "7c4e6c230327cb73dc66dc07953609a67adb5c42096c280a00e0dda31bfca55d"
+      sha256: "2bee8f081b62fd10ce18f4799f1ae293e28056c5d3b7ae5c299572eb31a9d0d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2+1"
+    version: "0.7.3"
   ubuntu_wizard:
     dependency: "direct main"
     description:
@@ -1393,10 +1393,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:

--- a/apps/ubuntu_bootstrap/pubspec.yaml
+++ b/apps/ubuntu_bootstrap/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   ubuntu_provision: ^0.1.0
   ubuntu_service: ^0.3.1
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.7.1
+  ubuntu_widgets: ^0.7.3
   ubuntu_wizard: ^0.1.0
   xdg_desktop_portal: ^0.1.13
   yaml: ^3.1.2

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_en.arb
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_en.arb
@@ -121,5 +121,6 @@
   "ubuntuProSucessAttachHeader": "Ubuntu Pro is now enabled in this machine",
   "@ubuntuProSucessAttachHeader": {},
   "ubuntuProSucessAttachDescription": "You can manage your Pro services in the Software & Updates application.",
-  "@ubuntuProSucessAttachDescription": {}
+  "@ubuntuProSucessAttachDescription": {},
+  "successIconSemanticLabel": "Success"
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations.dart
@@ -488,6 +488,12 @@ abstract class UbuntuInitLocalizations {
   /// In en, this message translates to:
   /// **'You can manage your Pro services in the Software & Updates application.'**
   String get ubuntuProSucessAttachDescription;
+
+  /// No description provided for @successIconSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Success'**
+  String get successIconSemanticLabel;
 }
 
 class _UbuntuInitLocalizationsDelegate

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_am.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_am.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsAm extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ar.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ar.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsAr extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_be.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_be.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsBe extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Вы заўсёды можаце кіраваць сваімі службамі Ubuntu Pro у праграме «Праграмнае забеспячэнне і абнаўленні».';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bg.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bg.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsBg extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bn.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bn.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsBn extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bo.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bo.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsBo extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bs.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_bs.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsBs extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ca.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ca.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsCa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_cs.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_cs.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsCs extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Své služby Pro můžete spravovat v aplikaci Software a aktualizace.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_cy.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_cy.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsCy extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_da.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_da.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsDa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Du kan håndtere dine Pro-tjenester i programmet Software og opdateringer.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_de.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_de.dart
@@ -156,4 +156,7 @@ class UbuntuInitLocalizationsDe extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Sie können Ihre Pro-Dienste in der Anwendung Software & Aktualisierungen verwalten.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_dz.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_dz.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsDz extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_el.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_el.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsEl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Μπορείτε να κάνετε διαχείριση της Pro υπηρεσίας στην Λογισμικό και Ενημερώσεις εφαρμογή.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_en.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_en.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsEn extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_eo.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_eo.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsEo extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Vi povas administri viajn servojn de Ubuntu Pro per la programo «Programaroj kaj Ĝisdatigoj».';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_es.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_es.dart
@@ -155,4 +155,7 @@ class UbuntuInitLocalizationsEs extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Puedes administrar tus servicios de Ubuntu Pro en Software y Actualizaciones.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_et.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_et.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsEt extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Sa võid hallata oma Ubuntu Pro teenuseid rakenduses „Tarkvara ja uuendused“.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_eu.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_eu.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsEu extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_fa.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_fa.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsFa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_fi.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_fi.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsFi extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Voit hallita Pro-palveluja Ohjelmistot ja päivitykset -sovelluksessa.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_fr.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_fr.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsFr extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Vous pouvez gérer vos services Pro dans l\'application Logiciels & Mises à jour.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ga.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ga.dart
@@ -155,4 +155,7 @@ class UbuntuInitLocalizationsGa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Is féidir leat do sheirbhísí Pro a bhainistiú san fheidhmchlár Bogearraí & Nuashonruithe.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_gl.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_gl.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsGl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_gu.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_gu.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsGu extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_he.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_he.dart
@@ -151,4 +151,7 @@ class UbuntuInitLocalizationsHe extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'אפשר לנהל את שירותי ה־Pro שלך ביישום התוכנה והעדכונים.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_hi.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_hi.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsHi extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_hr.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_hr.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsHr extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_hu.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_hu.dart
@@ -156,4 +156,7 @@ class UbuntuInitLocalizationsHu extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'A Pro szolgáltatásokat a Szoftverek és frissítések alkalmazásban kezelheti.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_id.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_id.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsId extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Anda dapat mengelola layanan Pro Anda dalam aplikasi Perangkat Lunak & Pembaruan.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_is.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_is.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsIs extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_it.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_it.dart
@@ -155,4 +155,7 @@ class UbuntuInitLocalizationsIt extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Puoi gestire i tuoi servizi Pro nell\'applicazione Software e aggiornamenti.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ja.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ja.dart
@@ -149,4 +149,7 @@ class UbuntuInitLocalizationsJa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       '「ソフトウェアとアップデート」アプリでProサービスを設定できます。';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ka.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ka.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsKa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'თქვენი Pro-ის სერვისების მართვა პროგრამებისა და განახლებების აპლიკაციაში შეგიძლიათ.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_kk.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_kk.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsKk extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_km.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_km.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsKm extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_kn.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_kn.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsKn extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ko.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ko.dart
@@ -149,4 +149,7 @@ class UbuntuInitLocalizationsKo extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       '소프트웨어 및 업데이트 애플리케이션에서 Ubuntu Pro 서비스를 관리할 수 있습니다.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ku.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ku.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsKu extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_lo.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_lo.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsLo extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_lt.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_lt.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsLt extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_lv.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_lv.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsLv extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_mk.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_mk.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsMk extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ml.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ml.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsMl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_mr.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_mr.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsMr extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_my.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_my.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsMy extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_nb.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_nb.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsNb extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ne.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ne.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsNe extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_nl.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_nl.dart
@@ -155,4 +155,7 @@ class UbuntuInitLocalizationsNl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'U kunt uw Pro-diensten beheren in de applicatie Software & Updates.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_nn.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_nn.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsNn extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_oc.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_oc.dart
@@ -155,4 +155,7 @@ class UbuntuInitLocalizationsOc extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Podètz gerir los servicis Pro dins l\'aplicacion Logicial e mesas a jorn.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_pa.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_pa.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsPa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_pl.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_pl.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsPl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Usługami Pro możesz zarządzać w aplikacji Oprogramowanie i aktualizacje.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_pt.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_pt.dart
@@ -154,6 +154,9 @@ class UbuntuInitLocalizationsPt extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Pode gerir os seus serviços Pro na aplicação Software e Atualizações.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ro.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ro.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsRo extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ru.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ru.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsRu extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Вы можете управлять услугами Pro в приложении «Программы и обновления».';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_se.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_se.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsSe extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_si.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_si.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsSi extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'ඔබගේ ආධික්‍ය සේවා මෘදුකාංග හා යාවත්කාල යෙදුමෙන් කළමනාකරණයට හැකිය.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sk.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sk.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsSk extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Svoje služby Pro môžete spravovať v aplikácii Softvér a aktualizácie.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sl.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sl.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsSl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sq.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sq.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsSq extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sr.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sr.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsSr extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Можете управљати својим Pro услугама у апликацији Софтвер и ажурирања.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sv.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_sv.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsSv extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Du kan hantera dina Pro-tjänster med programmet Programvara och uppdateringar.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ta.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ta.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsTa extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'மென்பொருள் மற்றும் புதுப்பிப்புகள் பயன்பாட்டில் உங்கள் புரோ சேவைகளை நிர்வகிக்கலாம்.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_te.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_te.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsTe extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_tg.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_tg.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsTg extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_th.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_th.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsTh extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_tl.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_tl.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsTl extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_tr.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_tr.dart
@@ -153,4 +153,7 @@ class UbuntuInitLocalizationsTr extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ug.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_ug.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsUg extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_uk.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_uk.dart
@@ -154,4 +154,7 @@ class UbuntuInitLocalizationsUk extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'Ви можете керувати Pro-послугами у Програмах та оновленні.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_vi.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_vi.dart
@@ -152,4 +152,7 @@ class UbuntuInitLocalizationsVi extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       'You can manage your Pro services in the Software & Updates application.';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_zh.dart
+++ b/apps/ubuntu_init/lib/l10n/ubuntu_init_localizations_zh.dart
@@ -147,6 +147,9 @@ class UbuntuInitLocalizationsZh extends UbuntuInitLocalizations {
   @override
   String get ubuntuProSucessAttachDescription =>
       '您可以在“软件与更新”应用中管理 Ubuntu Pro 服务。';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).

--- a/apps/ubuntu_init/lib/pages/ubuntu_pro/ubuntu_pro_page.dart
+++ b/apps/ubuntu_init/lib/pages/ubuntu_pro/ubuntu_pro_page.dart
@@ -135,7 +135,10 @@ class UbuntuProPage extends ConsumerWidget with ProvisioningPage {
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
-                                  const SuccessIcon(),
+                                  SuccessIcon(
+                                    semanticLabel:
+                                        l10n.successIconSemanticLabel,
+                                  ),
                                   const SizedBox(width: kWizardSpacing / 4),
                                   Expanded(
                                     child: Text(

--- a/apps/ubuntu_init/lib/pages/ubuntu_pro/ubuntu_pro_success_attach_page.dart
+++ b/apps/ubuntu_init/lib/pages/ubuntu_pro/ubuntu_pro_success_attach_page.dart
@@ -44,7 +44,9 @@ class UbuntuProSuccessAttachPage extends ConsumerWidget with ProvisioningPage {
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const SuccessIcon(),
+                    SuccessIcon(
+                      semanticLabel: l10n.successIconSemanticLabel,
+                    ),
                     const SizedBox(width: kWizardSpacing / 2),
                     Flexible(
                       child: Column(

--- a/apps/ubuntu_init/lib/pages/ubuntu_pro/ubuntu_pro_widgets.dart
+++ b/apps/ubuntu_init/lib/pages/ubuntu_pro/ubuntu_pro_widgets.dart
@@ -20,7 +20,9 @@ class TokenTextField extends ConsumerWidget {
           ? Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const SuccessIcon(),
+                SuccessIcon(
+                  semanticLabel: l10n.successIconSemanticLabel,
+                ),
                 const SizedBox(width: kWizardSpacing / 4),
                 Text(
                   l10n.ubuntuProTokenAttachSucess,

--- a/apps/ubuntu_init/pubspec.lock
+++ b/apps/ubuntu_init/pubspec.lock
@@ -843,10 +843,10 @@ packages:
     dependency: transitive
     description:
       name: pdfrx
-      sha256: afacb1bd02d570eab914d14915c890bdf1747d25d8a7eeb1e7f7d4073f0c52ca
+      sha256: bf3376b375f8628976ac2c77fb0ec90067734a6ed8d38aa0303befdc47477148
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.4"
   petitparser:
     dependency: transitive
     description:
@@ -1299,10 +1299,10 @@ packages:
     dependency: "direct main"
     description:
       name: ubuntu_widgets
-      sha256: "7c4e6c230327cb73dc66dc07953609a67adb5c42096c280a00e0dda31bfca55d"
+      sha256: "2bee8f081b62fd10ce18f4799f1ae293e28056c5d3b7ae5c299572eb31a9d0d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2+1"
+    version: "0.7.3"
   ubuntu_wizard:
     dependency: "direct main"
     description:
@@ -1330,10 +1330,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:

--- a/apps/ubuntu_init/pubspec.yaml
+++ b/apps/ubuntu_init/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   ubuntu_service: ^0.3.1
   ubuntu_session: ^0.0.4
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.7.1
+  ubuntu_widgets: ^0.7.3
   ubuntu_wizard: ^0.1.0
   yaru: ^8.0.0
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -46,7 +46,7 @@ command:
       ubuntu_logger: ^0.1.1
       ubuntu_service: ^0.3.1
       ubuntu_session: ^0.0.4
-      ubuntu_widgets: ^0.7.1
+      ubuntu_widgets: ^0.7.3
       udev: ^0.0.3
       upower: ^0.7.0
       url_launcher: ^6.2.5

--- a/packages/ubuntu_provision/lib/src/active_directory/active_directory_widgets.dart
+++ b/packages/ubuntu_provision/lib/src/active_directory/active_directory_widgets.dart
@@ -25,7 +25,9 @@ class DomainNameFormField extends ConsumerWidget {
       autofocus: true,
       labelText: lang.activeDirectoryDomainLabel,
       initialValue: domainName,
-      successWidget: const SuccessIcon(),
+      successWidget: SuccessIcon(
+        semanticLabel: lang.successIconSemanticLabel,
+      ),
       validator: CallbackValidator(
         (_) =>
             validation == null ||
@@ -54,7 +56,9 @@ class AdminNameFormField extends ConsumerWidget {
     return ValidatedFormField(
       labelText: lang.activeDirectoryAdminLabel,
       initialValue: adminName,
-      successWidget: const SuccessIcon(),
+      successWidget: SuccessIcon(
+        semanticLabel: lang.successIconSemanticLabel,
+      ),
       validator: CallbackValidator(
         (_) => validation == AdAdminNameValidation.OK,
         errorText: validation?.localize(context) ?? '',
@@ -81,8 +85,11 @@ class PasswordFormField extends ConsumerWidget {
     return ValidatedFormField(
       labelText: lang.activeDirectoryPasswordLabel,
       obscureText: !showPassword,
-      successWidget:
-          password.isNotEmpty ? const SuccessIcon() : const SizedBox(),
+      successWidget: password.isNotEmpty
+          ? SuccessIcon(
+              semanticLabel: lang.successIconSemanticLabel,
+            )
+          : const SizedBox(),
       initialValue: password,
       suffixIcon: ShowPasswordButton(
         value: showPassword,

--- a/packages/ubuntu_provision/lib/src/identity/identity_widgets.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_widgets.dart
@@ -20,7 +20,9 @@ class RealNameFormField extends ConsumerWidget {
     return ValidatedFormField(
       autofocus: true,
       labelText: lang.identityRealNameLabel,
-      successWidget: const SuccessIcon(),
+      successWidget: SuccessIcon(
+        semanticLabel: lang.successIconSemanticLabel,
+      ),
       initialValue: realName,
       validator: MultiValidator([
         RequiredValidator(
@@ -51,7 +53,9 @@ class HostnameFormField extends ConsumerWidget {
 
     return ValidatedFormField(
       labelText: lang.identityHostnameLabel,
-      successWidget: const SuccessIcon(),
+      successWidget: SuccessIcon(
+        semanticLabel: lang.successIconSemanticLabel,
+      ),
       initialValue: hostname,
       validator: MultiValidator([
         RequiredValidator(
@@ -107,7 +111,9 @@ class UsernameFormField extends ConsumerWidget {
 
     return ValidatedFormField(
       labelText: lang.identityUsernameLabel,
-      successWidget: const SuccessIcon(),
+      successWidget: SuccessIcon(
+        semanticLabel: lang.successIconSemanticLabel,
+      ),
       initialValue: username,
       validator: MultiValidator([
         RequiredValidator(
@@ -182,8 +188,11 @@ class ConfirmPasswordFormField extends ConsumerWidget {
     return ValidatedFormField(
       obscureText: !showPassword,
       labelText: lang.identityConfirmPasswordLabel,
-      successWidget:
-          password.isNotEmpty ? const SuccessIcon() : const SizedBox(),
+      successWidget: password.isNotEmpty
+          ? SuccessIcon(
+              semanticLabel: lang.successIconSemanticLabel,
+            )
+          : const SizedBox(),
       initialValue: confirmedPassword,
       autovalidateMode: AutovalidateMode.always,
       validator: EqualValidator(

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
@@ -143,5 +143,6 @@
   "eulaPageTitle": "License agreement",
   "eulaReviewTerms": "Review the license terms",
   "eulaReadAndAcceptTerms": "To continue setting up this machine, you must read and accept the license agreement terms.",
-  "eulaAcceptTerms": "I have read and accept these terms"
+  "eulaAcceptTerms": "I have read and accept these terms",
+  "successIconSemanticLabel": "Success"
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
@@ -896,6 +896,12 @@ abstract class UbuntuProvisionLocalizations {
   /// In en, this message translates to:
   /// **'I have read and accept these terms'**
   String get eulaAcceptTerms;
+
+  /// No description provided for @successIconSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Success'**
+  String get successIconSemanticLabel;
 }
 
 class _UbuntuProvisionLocalizationsDelegate

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
@@ -357,4 +357,7 @@ class UbuntuProvisionLocalizationsAm extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsAr extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
@@ -362,4 +362,7 @@ class UbuntuProvisionLocalizationsBe extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Я прачытаў(-ла) і прымаю гэтыя ўмовы';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsBg extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsBn extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsBo extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsBs extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsCa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
@@ -361,4 +361,7 @@ class UbuntuProvisionLocalizationsCs extends UbuntuProvisionLocalizations {
   @override
   String get eulaAcceptTerms =>
       'Přečetl(a) jsem si tyto podmínky a souhlasím s nimi';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsCy extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsDa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Jeg har læst og accepterer disse betingelser';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
@@ -366,4 +366,7 @@ class UbuntuProvisionLocalizationsDe extends UbuntuProvisionLocalizations {
   @override
   String get eulaAcceptTerms =>
       'Ich habe diese Bedingungen gelesen und akzeptiere sie';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsDz extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
@@ -361,4 +361,7 @@ class UbuntuProvisionLocalizationsEl extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Έχω διαβάσει και έχω αποδεχτεί τους όρους';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsEn extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsEo extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Mi legis kaj akceptas la jenajn kondiĉojn';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsEs extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'He leído y acepto estos términos';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
@@ -365,4 +365,7 @@ class UbuntuProvisionLocalizationsEt extends UbuntuProvisionLocalizations {
   @override
   String get eulaAcceptTerms =>
       'Ma olen lugenud litsentsilepingut ja nõustun tema tingimustega';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsEu extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsFa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
@@ -361,4 +361,7 @@ class UbuntuProvisionLocalizationsFi extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Olen lukenut lisenssiehdot ja hyväksyn ne';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
@@ -367,4 +367,7 @@ class UbuntuProvisionLocalizationsFr extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'J\'ai lu et accepté ces termes';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
@@ -361,4 +361,7 @@ class UbuntuProvisionLocalizationsGa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Léigh mé agus glacaim leis na téarmaí seo';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsGl extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsGu extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
@@ -354,4 +354,7 @@ class UbuntuProvisionLocalizationsHe extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'קראתי והתנאים האלה מקובלים עליי';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsHi extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsHr extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
@@ -362,4 +362,7 @@ class UbuntuProvisionLocalizationsHu extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Elolvastam és elfogadom ezeket a feltételeket';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
@@ -364,4 +364,7 @@ class UbuntuProvisionLocalizationsId extends UbuntuProvisionLocalizations {
   @override
   String get eulaAcceptTerms =>
       'Saya telah membaca dan menerima syarat-syarat ini';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsIs extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
@@ -360,4 +360,7 @@ class UbuntuProvisionLocalizationsIt extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
@@ -350,4 +350,7 @@ class UbuntuProvisionLocalizationsJa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'よく読んで許諾書条件に同意しました';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsKa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'წავიკითხე და ვეთანხმები ამ პირობებს';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsKk extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsKm extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsKn extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
@@ -350,4 +350,7 @@ class UbuntuProvisionLocalizationsKo extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsKu extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsLo extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
@@ -364,4 +364,7 @@ class UbuntuProvisionLocalizationsLt extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Aš perskaičiau ir sutinku su šiomis sąlygomis';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsLv extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsMk extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
@@ -364,4 +364,7 @@ class UbuntuProvisionLocalizationsMl extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsMr extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsMy extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsNb extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Jeg har lest og godtatt disse vilkårene';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsNe extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
@@ -360,4 +360,7 @@ class UbuntuProvisionLocalizationsNl extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Ik heb deze regels gelezen en ga akkoord';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsNn extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
@@ -361,4 +361,7 @@ class UbuntuProvisionLocalizationsOc extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Ai legit e accèpti aqueste tèrmes';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsPa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
@@ -363,4 +363,7 @@ class UbuntuProvisionLocalizationsPl extends UbuntuProvisionLocalizations {
   @override
   String get eulaAcceptTerms =>
       'Akceptuję niniejsze warunki po ich przeczytaniu';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
@@ -361,6 +361,9 @@ class UbuntuProvisionLocalizationsPt extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsRo extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
@@ -363,4 +363,7 @@ class UbuntuProvisionLocalizationsRu extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Я прочитал(а) эти условия и принимаю их';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsSe extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
@@ -355,4 +355,7 @@ class UbuntuProvisionLocalizationsSi extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'මම මෙම නියම කියවා පිළිගනිමි';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
@@ -365,4 +365,7 @@ class UbuntuProvisionLocalizationsSk extends UbuntuProvisionLocalizations {
   @override
   String get eulaAcceptTerms =>
       'Prečítal(a) som si tieto podmienky a súhlasím s nimi';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsSl extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsSq extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsSr extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Прочитао сам и прихватам ове услове';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
@@ -361,4 +361,7 @@ class UbuntuProvisionLocalizationsSv extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Jag har läst och accepterar dessa villkor';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
@@ -365,4 +365,7 @@ class UbuntuProvisionLocalizationsTa extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'இந்த விதிமுறைகளைப் படித்து ஏற்றுக்கொண்டேன்';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsTe extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsTg extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsTh extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsTl extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsTr extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Koşulları okudum ve kabul ediyorum';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsUg extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
@@ -359,4 +359,7 @@ class UbuntuProvisionLocalizationsUk extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'Я прочитав і приймаю ці умови';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
@@ -358,4 +358,7 @@ class UbuntuProvisionLocalizationsVi extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => 'I have read and accept these terms';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
@@ -346,6 +346,9 @@ class UbuntuProvisionLocalizationsZh extends UbuntuProvisionLocalizations {
 
   @override
   String get eulaAcceptTerms => '我已阅读并同意这些条款';
+
+  @override
+  String get successIconSemanticLabel => 'Success';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   ubuntu_service: ^0.3.1
   ubuntu_session: ^0.0.4
   ubuntu_utils: ^0.1.0
-  ubuntu_widgets: ^0.7.1
+  ubuntu_widgets: ^0.7.3
   ubuntu_wizard: ^0.1.0
   udev: ^0.0.3
   upower: ^0.7.0

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   ubuntu_flavor: ^0.4.0
   ubuntu_localizations: ^0.5.2+2
-  ubuntu_widgets: ^0.7.1
+  ubuntu_widgets: ^0.7.3
   wizard_router: ^1.2.0
   yaru: ^8.0.0
 


### PR DESCRIPTION
Adds semantic labels to the success and error icons provided by `ubuntu_widgets`.

This might look quite large but its mostly just regenerating the translation files.

---

Audit 1858207
UDEAA-120