### PR TITLE
chore: bump bootstrap and curtin to include ZFS fix for 24.04

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref e7a80f89b8cd17df5da4a824ed604255095bfccc
+    source-commit: &commit-ref 17588a78ed32d87ec081c5b261e1db8cd23b9d11
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
@@ -68,7 +68,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 2a5390a3436c53bd89226afd73751d3954aaef3d
+    source-commit: 0ab394917d66d2b6c51e297bf9bf5d26ef36c360
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"


### PR DESCRIPTION
See #1135