### PR TITLE
ci: remove local CLA check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,15 +4,6 @@ on:
   pull_request_target:
 
 jobs:
-  cla:
-    if: contains(fromJson('["weblate"]'), github.event.pull_request.user.login) == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
-        with:
-          exempted-bots: dependabot,github-actions,renovate
-
   labeler:
     permissions:
       contents: read


### PR DESCRIPTION
Since there's now an org-wide CLA action, the local workflow is obsolete.