### PR TITLE
fix(a11y): Add locale to language selector

### DIFF
--- a/packages/ubuntu_provision/lib/src/locale/locale_page.dart
+++ b/packages/ubuntu_provision/lib/src/locale/locale_page.dart
@@ -51,7 +51,10 @@ class LocalePage extends ConsumerWidget with ProvisioningPage {
             itemCount: model.languageCount,
             itemBuilder: (context, index) => ListTile(
               key: ValueKey(index),
-              title: Text(model.language(index)),
+              title: Text(
+                model.language(index),
+                locale: model.locale(index),
+              ),
               selected: index == model.selectedIndex,
               onTap: () => model.selectLanguage(index),
             ),


### PR DESCRIPTION
This fixes an issue where the screen reader may not know the underlying language of text in the language selector, since each language is in its native locale.

Note that this isn't fully functional as of Flutter 3.32, but is being actively implemented, so it should work in the next major Flutter version.

---

UDENG-7680