### PR TITLE
fix(a11y): Make keyboard test label persistent

### DIFF
--- a/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
@@ -88,7 +88,7 @@ class KeyboardPage extends ConsumerWidget with ProvisioningPage {
         const SizedBox(height: kWizardSpacing),
         TextField(
           decoration: InputDecoration(
-            hintText: lang.keyboardTestHint,
+            labelText: lang.keyboardTestHint,
           ),
         ),
       ],


### PR DESCRIPTION
This retains the visual label when the text field is being typed in.

| Not Typed | Typed |
|-----------|-------|
| <img width="1012" height="732" alt="image" src="https://github.com/user-attachments/assets/5897abfa-57ca-430f-953c-43c744f636bc" /> | <img width="1012" height="732" alt="image" src="https://github.com/user-attachments/assets/ba54a4ab-1bb3-47be-a680-f8e3c83384da" /> |

---

UDENG-7684