### PR TITLE
fix(a11y): Associate keyboard variant button with label

### DIFF
--- a/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
@@ -65,23 +65,26 @@ class KeyboardPage extends ConsumerWidget with ProvisioningPage {
           ),
         ),
         const SizedBox(height: kWizardSpacing),
-        Row(
-          children: [
-            Text(lang.keyboardVariantLabel),
-            const SizedBox(width: kWizardSpacing),
-            Expanded(
-              child: MenuButtonBuilder<int>(
-                selected: model.selectedVariantIndex,
-                values: List.generate(model.variantCount, (index) => index),
-                itemBuilder: (context, index, child) {
-                  return index < 0 || index >= model.variantCount
-                      ? const SizedBox.shrink()
-                      : Text(model.variantName(index));
-                },
-                onSelected: model.selectVariant,
+        Semantics(
+          container: true,
+          child: Row(
+            children: [
+              Text(lang.keyboardVariantLabel),
+              const SizedBox(width: kWizardSpacing),
+              Expanded(
+                child: MenuButtonBuilder<int>(
+                  selected: model.selectedVariantIndex,
+                  values: List.generate(model.variantCount, (index) => index),
+                  itemBuilder: (context, index, child) {
+                    return index < 0 || index >= model.variantCount
+                        ? const SizedBox.shrink()
+                        : Text(model.variantName(index));
+                  },
+                  onSelected: model.selectVariant,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
         const SizedBox(height: kWizardSpacing),
         const Divider(height: 1),


### PR DESCRIPTION
Previously, the label was not read by screen readers.

---

UDENG-7685