### PR TITLE
fix(a11y): "Announce" new page navigation

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_page.dart
@@ -24,7 +24,11 @@ class RefreshPage extends ConsumerWidget with ProvisioningPage {
 
     return WizardPage(
       title: YaruWindowTitleBar(
-        title: Text(l10n.refreshPageTitle),
+        title: Semantics(
+          focused: true,
+          header: true,
+          child: Text(l10n.refreshPageTitle),
+        ),
         style: model.state.busy
             ? YaruTitleBarStyle.undecorated
             : YaruTitleBarStyle.normal,

--- a/packages/ubuntu_provision/lib/src/identity/identity_page.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_page.dart
@@ -34,13 +34,22 @@ class IdentityPage extends ConsumerWidget with ProvisioningPage {
         ],
       ),
       children: [
-        const RealNameFormField(),
-        const HostnameFormField(),
-        const UsernameFormField(),
-        const PasswordFormField(),
-        const ConfirmPasswordFormField(),
-        const AutoLoginCheckButton(),
-        const UseActiveDirectoryCheckButton(),
+        Semantics(
+          header: true,
+          label: lang.identityPageTitle,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const RealNameFormField(),
+              const HostnameFormField(),
+              const UsernameFormField(),
+              const PasswordFormField(),
+              const ConfirmPasswordFormField(),
+              const AutoLoginCheckButton(),
+              const UseActiveDirectoryCheckButton(),
+            ].withSpacing(kWizardSpacing),
+          ),
+        ),
       ].withSpacing(kWizardSpacing),
     );
   }

--- a/packages/ubuntu_provision/lib/src/timezone/timezone_page.dart
+++ b/packages/ubuntu_provision/lib/src/timezone/timezone_page.dart
@@ -45,62 +45,66 @@ class TimezonePage extends ConsumerWidget with ProvisioningPage {
         children: <Widget>[
           Padding(
             padding: kWizardPadding,
-            child: Row(
-              children: <Widget>[
-                Expanded(
-                  child: YaruAutocomplete<GeoLocation>(
-                    initialValue: TextEditingValue(
-                      text: formatLocation(model.selectedLocation),
+            child: Semantics(
+              label: lang.timezonePageTitle,
+              header: true,
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: YaruAutocomplete<GeoLocation>(
+                      initialValue: TextEditingValue(
+                        text: formatLocation(model.selectedLocation),
+                      ),
+                      fieldViewBuilder:
+                          (context, editor, focusNode, onSubmitted) {
+                        if (!focusNode.hasFocus) {
+                          editor.text = formatLocation(model.selectedLocation);
+                        }
+                        return TextFormField(
+                          focusNode: focusNode,
+                          controller: editor,
+                          decoration: InputDecoration(
+                            labelText: lang.timezoneLocationLabel,
+                          ),
+                          onFieldSubmitted: (value) => onSubmitted(),
+                        );
+                      },
+                      displayStringForOption: formatLocation,
+                      optionsBuilder: (value) {
+                        return model.searchLocation(value.text);
+                      },
+                      onSelected: model.selectLocation,
                     ),
-                    fieldViewBuilder:
-                        (context, editor, focusNode, onSubmitted) {
-                      if (!focusNode.hasFocus) {
-                        editor.text = formatLocation(model.selectedLocation);
-                      }
-                      return TextFormField(
-                        focusNode: focusNode,
-                        controller: editor,
-                        decoration: InputDecoration(
-                          labelText: lang.timezoneLocationLabel,
-                        ),
-                        onFieldSubmitted: (value) => onSubmitted(),
-                      );
-                    },
-                    displayStringForOption: formatLocation,
-                    optionsBuilder: (value) {
-                      return model.searchLocation(value.text);
-                    },
-                    onSelected: model.selectLocation,
                   ),
-                ),
-                const SizedBox(width: kWizardSpacing),
-                Expanded(
-                  child: YaruAutocomplete<GeoLocation>(
-                    initialValue: TextEditingValue(
-                      text: formatTimezone(model.selectedLocation),
+                  const SizedBox(width: kWizardSpacing),
+                  Expanded(
+                    child: YaruAutocomplete<GeoLocation>(
+                      initialValue: TextEditingValue(
+                        text: formatTimezone(model.selectedLocation),
+                      ),
+                      fieldViewBuilder:
+                          (context, editor, focusNode, onFieldSubmitted) {
+                        if (!focusNode.hasFocus) {
+                          editor.text = formatTimezone(model.selectedLocation);
+                        }
+                        return TextFormField(
+                          focusNode: focusNode,
+                          controller: editor,
+                          decoration: InputDecoration(
+                            labelText: lang.timezoneTimezoneLabel,
+                          ),
+                          onFieldSubmitted: (value) => onFieldSubmitted(),
+                        );
+                      },
+                      displayStringForOption: formatTimezone,
+                      optionsBuilder: (value) {
+                        return model.searchTimezone(value.text);
+                      },
+                      onSelected: model.selectTimezone,
                     ),
-                    fieldViewBuilder:
-                        (context, editor, focusNode, onFieldSubmitted) {
-                      if (!focusNode.hasFocus) {
-                        editor.text = formatTimezone(model.selectedLocation);
-                      }
-                      return TextFormField(
-                        focusNode: focusNode,
-                        controller: editor,
-                        decoration: InputDecoration(
-                          labelText: lang.timezoneTimezoneLabel,
-                        ),
-                        onFieldSubmitted: (value) => onFieldSubmitted(),
-                      );
-                    },
-                    displayStringForOption: formatTimezone,
-                    optionsBuilder: (value) {
-                      return model.searchTimezone(value.text);
-                    },
-                    onSelected: model.selectTimezone,
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           const SizedBox(height: kWizardSpacing),

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -197,9 +197,13 @@ class _Headline extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Expanded(
-            child: Text(
-              title,
-              style: theme.textTheme.titleLarge,
+            child: Semantics(
+              focused: true,
+              header: true,
+              child: Text(
+                title,
+                style: theme.textTheme.titleLarge,
+              ),
             ),
           ),
           if (trailingTitleWidget != null) trailingTitleWidget!,


### PR DESCRIPTION
Due to the inability to use an actual semantic announcement, this change relies on focusing the header of new pages, which isn't amazing behavior but it's the only thing we can do at the moment.

---

UDENG-7686