### PR TITLE
fix(a11y): Adjust ListTile color scheme for better contrast

### DIFF
--- a/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
+++ b/packages/ubuntu_provision/lib/src/keyboard/keyboard_page.dart
@@ -52,7 +52,7 @@ class KeyboardPage extends ConsumerWidget with ProvisioningPage {
             itemCount: model.layoutCount,
             tabFocusNode: nextFocusNode,
             itemBuilder: (context, index) => ThemedListTile(
-              valueKey: ValueKey(index),
+              key: ValueKey(index),
               title: Text(model.layoutName(index)),
               selected: index == model.selectedLayoutIndex,
               onTap: () => model.selectLayout(index),

--- a/packages/ubuntu_provision/lib/src/locale/locale_page.dart
+++ b/packages/ubuntu_provision/lib/src/locale/locale_page.dart
@@ -51,7 +51,7 @@ class LocalePage extends ConsumerWidget with ProvisioningPage {
             selectedIndex: model.selectedIndex,
             itemCount: model.languageCount,
             itemBuilder: (context, index) => ThemedListTile(
-              valueKey: ValueKey(index),
+              key: ValueKey(index),
               selected: index == model.selectedIndex,
               onTap: () => model.selectLanguage(index),
               title: Text(

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -203,7 +203,7 @@ class WifiListTile extends ConsumerWidget {
     final accessPoints = <Widget>[
       for (final accessPoint in device.accessPoints)
         ThemedListTile(
-          valueKey: ValueKey(accessPoint.name),
+          key: ValueKey(accessPoint.name),
           title: Text(accessPoint.name),
           leading: _leadingIcon(accessPoint, device, iconSize),
           selected: selected && device.isSelectedAccessPoint(accessPoint),

--- a/packages/ubuntu_provision/lib/src/widgets/themed_list_tile.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/themed_list_tile.dart
@@ -3,7 +3,6 @@ import 'package:yaru/yaru.dart';
 
 class ThemedListTile extends StatefulWidget {
   const ThemedListTile({
-    required this.valueKey,
     required this.selected,
     required this.title,
     super.key,
@@ -12,7 +11,6 @@ class ThemedListTile extends StatefulWidget {
     this.trailing,
   });
 
-  final ValueKey<dynamic> valueKey;
   final bool selected;
   final Widget title;
 
@@ -41,7 +39,6 @@ class _ThemedListTileState extends State<ThemedListTile> {
         ),
       ),
       child: ListTile(
-        key: widget.valueKey,
         onFocusChange: (value) => setState(() {
           _focused = value;
         }),


### PR DESCRIPTION
Adjusts the `ListTile` widget to have better contrast in different states.

Example below. From top to bottom the states shown are hovered, selected, and focused.

| | Dark | Light |
|-|------|-------|
| Default | <img width="1012" height="732" alt="image" src="https://github.com/user-attachments/assets/dc20127b-aea4-4c21-afbe-3265e6ab738a" /> | <img width="1012" height="732" alt="image" src="https://github.com/user-attachments/assets/e9ff7ca6-3300-4b1d-ab69-bd1ab74ae1db" /> |
| HC | <img width="1012" height="732" alt="image" src="https://github.com/user-attachments/assets/76d8cdfa-3484-4ec4-91b6-541b7350b2bc" /> | <img width="1012" height="732" alt="image" src="https://github.com/user-attachments/assets/5e990f08-976e-4122-ab10-839ebf1b2e73" /> |

---

UDENG-7683

Related to https://github.com/ubuntu/yaru.dart/issues/979