### PR TITLE
feat(landscape): add /attach suffix to url and qr code url

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_landscape_qr_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_landscape_qr_page.dart
@@ -56,7 +56,8 @@ class AutoinstallLandscapeQrPage extends ConsumerWidget with ProvisioningPage {
             ),
             color: Theme.of(context).colorScheme.onSurface,
             barcode: Barcode.qrCode(),
-            data: '${model.domainUrl}?magic-attach-code=${model.userCode}',
+            data:
+                '${model.domainUrl}/attach?magic-attach-code=${model.userCode}',
             width: 200,
             height: 200,
           ),
@@ -68,7 +69,7 @@ class AutoinstallLandscapeQrPage extends ConsumerWidget with ProvisioningPage {
           children: [
             Html(
               data: l10n.landscapeMagicAttachInstructions(
-                model.domainUrl.replaceFirst('https://', ''),
+                '${model.domainUrl}/attach'.replaceFirst('https://', ''),
               ),
               style: {
                 'body':


### PR DESCRIPTION
The Landscape team have asked us to append `/attach` to the url's

<img width="973" height="689" alt="Screenshot From 2025-09-10 09-51-43" src="https://github.com/user-attachments/assets/91b65eed-2520-4501-8539-797774e56274" />
