### PR TITLE
fix: don't await AD join result

### DIFF
--- a/packages/ubuntu_provision/lib/src/active_directory/active_directory_page.dart
+++ b/packages/ubuntu_provision/lib/src/active_directory/active_directory_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_provision/src/active_directory/active_directory_dialogs.dart';
@@ -28,13 +30,15 @@ class ActiveDirectoryPage extends ConsumerWidget with ProvisioningPage {
             onNext: () async {
               final model = ref.read(activeDirectoryModelProvider);
               await model.save();
-              await model.getJoinResult().then((result) {
-                if (context.mounted &&
-                    (result == AdJoinResult.JOIN_ERROR ||
-                        result == AdJoinResult.PAM_ERROR)) {
-                  showActiveDirectoryErrorDialog(context);
-                }
-              });
+              unawaited(
+                model.getJoinResult().then((result) {
+                  if (context.mounted &&
+                      (result == AdJoinResult.JOIN_ERROR ||
+                          result == AdJoinResult.PAM_ERROR)) {
+                    showActiveDirectoryErrorDialog(context);
+                  }
+                }),
+              );
             },
           ),
         ],


### PR DESCRIPTION
Fixes a bug where the active directory page would remain in a loading state indefinitely. Looks like this bug was accidentally introduced when stricter linting rules were introduced in https://github.com/canonical/ubuntu-desktop-provision/pull/266.

[lp:2069437](https://bugs.launchpad.net/subiquity/+bug/2069437)