### PR TITLE
feat: force software rendering while flutter rendering issue persists

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ apps:
       LIVE_RUN: 1
       LOG_LEVEL: debug
       SNAP_PYTHON: python3
+      FLUTTER_LINUX_RENDERER: software
 
   probert:
     command: bin/probert


### PR DESCRIPTION
To mitigate the flickering issue present on Flutter 3.35, let's use the software renderer for now.