### PR TITLE
feat: don't use monospace font to display recovery key

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -109,7 +109,6 @@ class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {
               maxLines: 2,
               style: TextStyle(
                 inherit: false,
-                fontFamily: 'Ubuntu Mono',
                 fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
                 textBaseline: TextBaseline.alphabetic,
                 color: Theme.of(context).colorScheme.onSurface,
@@ -203,16 +202,7 @@ class _RecoveryKeyDialog extends ConsumerWidget {
               width: 200,
               height: 200,
             ),
-            Text(
-              recoveryKey,
-              style: TextStyle(
-                inherit: false,
-                fontFamily: 'Ubuntu Mono',
-                fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
-                textBaseline: TextBaseline.alphabetic,
-                color: Theme.of(context).colorScheme.onSurface,
-              ),
-            ),
+            Text(recoveryKey),
           ],
         ),
       ),


### PR DESCRIPTION
The monospace font causes issues with OCR, used in automated tests. This PR switches back to the default font.

<img width="2024" height="1464" alt="Screenshot From 2025-09-25 12-36-48" src="https://github.com/user-attachments/assets/5b48f50a-3de5-49c4-bd6c-7b5537bd19d6" />
<img width="2024" height="1464" alt="Screenshot From 2025-09-25 12-36-37" src="https://github.com/user-attachments/assets/982b67a7-461b-40e5-bb65-232c90719a71" />


UDENG-8126