### PR TITLE
fix: update factory-reset-tools path to match new repo structure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
 
       dart pub global activate melos
       dart pub global run melos bootstrap
-      cd packages/factory_reset_tools
+      cd apps/factory_reset_tools
       flutter build linux --release -v
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
 
@@ -80,12 +80,12 @@ parts:
       dart pub global activate melos
       dart pub global run melos bootstrap
 
-      pushd packages/factory_reset_tools
+      pushd apps/factory_reset_tools
       dart compile exe -o factory-reset-tools-cli lib/dbus/cmdline.dart
       cp factory-reset-tools-cli $CRAFT_PART_INSTALL/bin/
       popd
 
-      pushd packages/factory_reset_tools/lib/dbus/polkit_agent_helper
+      pushd apps/factory_reset_tools/lib/dbus/polkit_agent_helper
       make helper.so
       cp helper.so $CRAFT_PART_INSTALL/bin/polkit_agent_helper/
       popd
@@ -135,7 +135,7 @@ parts:
     source-type: git
     organize:
       # note that the filename polkit interface takes is "${plug_name}.*.policy"
-      packages/factory_reset_tools/data/polkit-com-canonical-oem-factory-reset-tools.x.policy: meta/polkit/
+      apps/factory_reset_tools/data/polkit-com-canonical-oem-factory-reset-tools.x.policy: meta/polkit/
 
   # copied from fwupd
   # https://github.com/fwupd/fwupd/blob/main/contrib/snap/snapcraft.yaml


### PR DESCRIPTION
This PR resolves the snap installation failure from the latest/edge channel.

```
ubuntu@ubuntu-Precision-5490:~$ sudo snap install factory-reset-tools --channel latest/edge
error: cannot perform the following tasks:
- Setup snap "factory-reset-tools" (58) security profiles for auto-connections (cannot obtain polkit specification for snap "factory-reset-tools": cannot find any policy files for plug "polkit-com-canonical-oem-factory-reset-tools")
```

The repository restructure in commit badd0159 invalidated the path to the polkit policy file in snapcraft.yaml. This change updates the path to the correct location, fixing the security profile setup error.

