### PR TITLE
fix: Restrict protobuf to ^3.1.0

### DIFF
--- a/packages/landscape_client/pubspec.yaml
+++ b/packages/landscape_client/pubspec.yaml
@@ -5,9 +5,12 @@ version: 0.0.1
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.32.1"
+
 dependencies:
   grpc: ^4.0.1
+  protobuf: ^3.1.0
   landscape_stubs: ^0.0.1
+
 dev_dependencies:
   mockito: 5.4.4
   build_runner: ^2.4.8

--- a/packages/landscape_stubs/pubspec.yaml
+++ b/packages/landscape_stubs/pubspec.yaml
@@ -5,8 +5,11 @@ version: 0.0.1
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.32.1"
+
 dependencies:
   grpc: ^4.0.1
+  protobuf: ^3.1.0
+
 dev_dependencies:
   build_runner: ^2.4.8
   test: any


### PR DESCRIPTION
grpc was pulling in protobuf 5, which ends up generating incompatible dart proto files.

Ideally we should just bump our deps, but we can't reliably do that until we can bump Flutter/dart.