### PR TITLE
Update documentation links

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/recovery_key/recovery_key_page.dart
@@ -14,7 +14,7 @@ import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
 import 'package:yaru/yaru.dart';
 
 const _fdeLink =
-    'https://canonical-ubuntu-desktop-documentation.readthedocs-hosted.com/en/latest/explanation/hardware-backed-disk-encryption/#recovery-key';
+    'https://documentation.ubuntu.com/desktop/en/latest/explanation/hardware-backed-disk-encryption/#recovery-key';
 const defaultRecoveryKeyFileName = 'recovery-key.txt';
 
 class RecoveryKeyPage extends ConsumerWidget with ProvisioningPage {

--- a/apps/ubuntu_bootstrap/lib/pages/storage/passphrase_type/passphrase_type_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/passphrase_type/passphrase_type_page.dart
@@ -11,7 +11,7 @@ import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
 const _fdeLink =
-    'https://canonical-ubuntu-desktop-documentation.readthedocs-hosted.com/en/latest/explanation/hardware-backed-disk-encryption/#encryption-passphrase';
+    'https://documentation.ubuntu.com/desktop/en/latest/explanation/hardware-backed-disk-encryption/#encryption-passphrase';
 
 class PassphraseTypePage extends ConsumerWidget {
   const PassphraseTypePage({super.key});

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -134,7 +134,7 @@ class StorageModel extends SafeChangeNotifier {
 
   /// The TPM info URL.
   final String tpmInfoUrl =
-      'https://canonical-ubuntu-desktop-documentation.readthedocs-hosted.com/en/latest/explanation/hardware-backed-disk-encryption/';
+      'https://documentation.ubuntu.com/desktop/en/latest/explanation/hardware-backed-disk-encryption/';
 
   /// A list of existing OS installations or null if not detected.
   List<OsProber>? get existingOS => _storage.existingOS;


### PR DESCRIPTION
The installer links to articles about TPM/FDE in the Ubuntu Desktop documentation. The documentation has moved to a new domain at https://documentation.ubuntu.com/desktop/.

The existing links still work and they redirect to the new domain, but to keep things tidy and looking official, I've updated them.