### PR TITLE
fix: factory-reset-tools: bump base snap to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,13 +4,13 @@ summary: Factory Reset Tools
 description: |
   A tool to create reset media and reboot into the factory reset menu, for Ubuntu-preinstalled systems.
 
-base: core22
+base: core24
 confinement: strict
 grade: stable
 
 # for now, only build for amd64, since PC OEM does not have other architectures at the moment...
-architectures:
-  - build-on: [amd64]
+platforms:
+  amd64:
 
 apps:
   factory-reset-tools:


### PR DESCRIPTION
Bump base snap of `factory-reset-tools` to `core24`.

This upgrade enables the use of newer `mesa-2404`, providing support for newer Intel graphics on OEM platforms.

Resolves: JIRA WTN-313