### PR TITLE
feat: support arguments for CoreBootFixActions

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
@@ -63,13 +63,15 @@ class TpmActionModel extends SafeChangeNotifier {
     notifyListeners();
   }
 
-  Future<SubiquityException?> performAction(CoreBootFixAction action) async {
+  Future<SubiquityException?> performAction(
+    CoreBootFixActionWithCategoryAndArgs action,
+  ) async {
     _isLoading = true;
     notifyListeners();
     SubiquityException? error;
     await _subiquity
         .coreBootFixEncryptionSupportV2(
-      CoreBootFixActionWithArgs(type: action),
+      CoreBootFixActionWithArgs(type: action.type, args: action.args),
     )
         .onError<SubiquityException>((e, _) {
       _log.error(

--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
@@ -89,7 +89,7 @@ class _ActionBody extends ConsumerStatefulWidget {
     this.isLoading = false,
   });
 
-  final CoreBootFixAction action;
+  final CoreBootFixActionWithCategoryAndArgs action;
   final CoreBootAvailabilityErrorKind? errorKind;
   final bool isLoading;
 
@@ -180,9 +180,8 @@ extension on TpmActionModel {
   CoreBootEncryptionSupportError? get tpmError =>
       tpmDisallowedCapability?.errors?.first;
 
-  List<CoreBootFixAction> get actions =>
-      tpmError?.actions.where((a) => !a.forUser).map((a) => a.type).toList() ??
-      [];
+  List<CoreBootFixActionWithCategoryAndArgs> get actions =>
+      tpmError?.actions.where((a) => !a.forUser).toList() ?? [];
 
   bool get isFixed => tpmDisallowedCapability == null;
 }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_x.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_x.dart
@@ -81,12 +81,12 @@ extension CoreBootAvailabilityErrorKindL10n on CoreBootAvailabilityErrorKind {
       'Description for $this';
 }
 
-extension CoreBootFixActionL10n on CoreBootFixAction {
+extension CoreBootFixActionL10n on CoreBootFixActionWithCategoryAndArgs {
   String title(
     UbuntuBootstrapLocalizations l10n, [
     CoreBootAvailabilityErrorKind? error,
   ]) =>
-      switch ((this, error)) {
+      switch ((type, error)) {
         (CoreBootFixAction.REBOOT, _) => l10n.tpmActionFixActionReboot,
         (CoreBootFixAction.SHUTDOWN, _) => l10n.tpmActionFixActionShutdown,
         (
@@ -144,7 +144,7 @@ extension CoreBootFixActionL10n on CoreBootFixAction {
         (CoreBootFixAction.PROCEED, _) => l10n.tpmActionFixActionProceed,
       };
 
-  String label(UbuntuBootstrapLocalizations l10n) => switch (this) {
+  String label(UbuntuBootstrapLocalizations l10n) => switch (type) {
         CoreBootFixAction.REBOOT ||
         CoreBootFixAction.REBOOT_TO_FW_SETTINGS =>
           l10n.tpmActionRestartLabel,
@@ -162,9 +162,9 @@ extension CoreBootFixActionL10n on CoreBootFixAction {
       };
 
   String description(UbuntuBootstrapLocalizations l10n) =>
-      'Description for $this';
+      'Description for $type';
 
-  DestructiveActionWarning? get warning => switch (this) {
+  DestructiveActionWarning? get warning => switch (type) {
         CoreBootFixAction.CLEAR_TPM ||
         CoreBootFixAction.CLEAR_TPM_VIA_FIRMWARE ||
         CoreBootFixAction.ENABLE_AND_CLEAR_TPM_VIA_FIRMWARE =>

--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.mocks.dart
@@ -83,7 +83,7 @@ class MockTpmActionModel extends _i1.Mock implements _i2.TpmActionModel {
 
   @override
   _i3.Future<_i4.SubiquityException?> performAction(
-          _i4.CoreBootFixAction? action) =>
+          _i4.CoreBootFixActionWithCategoryAndArgs? action) =>
       (super.noSuchMethod(
         Invocation.method(
           #performAction,

--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/tpm_action_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/tpm_action_model_test.dart
@@ -118,11 +118,26 @@ void main() {
     final subiquity = MockSubiquityClient();
 
     final model = TpmActionModel(storage, subiquity);
-    await model.performAction(CoreBootFixAction.REBOOT_TO_FW_SETTINGS);
+    await model.performAction(
+      CoreBootFixActionWithCategoryAndArgs(
+        type: CoreBootFixAction.REBOOT_TO_FW_SETTINGS,
+        forUser: false,
+        args: CoreBootFixActionArgs(
+          errorKinds: [
+            CoreBootAvailabilityErrorKind.TPM_DEVICE_LOCKOUT_LOCKED_OUT,
+          ],
+        ),
+      ),
+    );
     verify(
       subiquity.coreBootFixEncryptionSupportV2(
         CoreBootFixActionWithArgs(
           type: CoreBootFixAction.REBOOT_TO_FW_SETTINGS,
+          args: CoreBootFixActionArgs(
+            errorKinds: [
+              CoreBootAvailabilityErrorKind.TPM_DEVICE_LOCKOUT_LOCKED_OUT,
+            ],
+          ),
         ),
       ),
     ).called(1);

--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/tpm_action_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/tpm_action_page_test.dart
@@ -41,6 +41,8 @@ void main() {
     ],
   );
 
+  final testAction = testDisallowedCapability.errors!.first.actions.first;
+
   testWidgets('show error and action', (tester) async {
     final model = buildTpmActionModel(
       useTpm: true,
@@ -57,7 +59,7 @@ void main() {
       find.text(
         tester.lang.tpmActionSolutionLabel(
           1,
-          CoreBootFixAction.REBOOT_TO_FW_SETTINGS.title(tester.lang),
+          testAction.title(tester.lang),
         ),
       ),
       findsOneWidget,
@@ -84,13 +86,13 @@ void main() {
           find.text(
             tester.lang.tpmActionSolutionLabel(
               1,
-              CoreBootFixAction.REBOOT_TO_FW_SETTINGS.title(tester.lang),
+              testAction.title(tester.lang),
             ),
           ),
         );
         await tester.pumpAndSettle();
         await tester.tap(
-          find.text(CoreBootFixAction.REBOOT_TO_FW_SETTINGS.label(tester.lang)),
+          find.text(testAction.label(tester.lang)),
         );
         await tester.pumpAndSettle();
 

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -427,7 +427,12 @@ extension UbuntuBootstrapPageTester on WidgetTester {
     }
 
     if (action != null) {
-      await tapButton(action.label(l10n));
+      await tapButton(
+        CoreBootFixActionWithCategoryAndArgs(
+          type: action,
+          forUser: false,
+        ).label(l10n),
+      );
       await pump();
     }
   }


### PR DESCRIPTION
Passes arguments associated with a `CoreBootFixAction` to subiquity when posting to `/storage/v2/core_boot_fix_encryption_support`.
See https://github.com/canonical/subiquity/pull/2277
