### PR TITLE
feat(tpm-action): perform reboot action without further user interaction

### DIFF
--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.mocks.dart
@@ -83,11 +83,14 @@ class MockTpmActionModel extends _i1.Mock implements _i2.TpmActionModel {
 
   @override
   _i3.Future<_i4.SubiquityException?> performAction(
-          _i4.CoreBootFixActionWithCategoryAndArgs? action) =>
+    _i4.CoreBootFixActionWithCategoryAndArgs? action, {
+    bool? triggeredByUser = true,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #performAction,
           [action],
+          {#triggeredByUser: triggeredByUser},
         ),
         returnValue: _i3.Future<_i4.SubiquityException?>.value(),
       ) as _i3.Future<_i4.SubiquityException?>);


### PR DESCRIPTION
TPM fix actions that perform some action via the PPI (e.g. clear the TPM) usually require a subsequent reboot. The action API handles this by presenting `ErrorKindReboot`, which includes the `ActionReboot` action, see [here](https://github.com/canonical/secboot/blob/f90034359baca73182566ed5811645bbbb7c3fbe/efi/preinstall/actions.go#L82-L85). Currently the UI would display this as a separate error like this:

[Screencast From 2026-01-14 15-07-37.webm](https://github.com/user-attachments/assets/0daa746c-e790-424c-a653-dd0c60e4f8e9)

This PR simplifies the UX by automatically performing the following action if it is an `ActionReboot`:

[Screencast From 2026-01-14 15-04-00.webm](https://github.com/user-attachments/assets/9daa03c2-6778-4b43-ab3f-1099d08e4690)

