### PR TITLE
ci: check for outdated subiquity types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,20 @@ jobs:
           branch: create-pull-request/mocks
           delete-branch: true
 
+  subiquity-types:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: asdf-vm/actions/install@v3
+      - uses: bluefireteam/melos-action@v3
+      - name: Regenerate subiquity types
+        run: make -B
+        working-directory: packages/subiquity_client
+      - name: Check for outdated subiquity types
+        run: ./.github/scripts/check-outdated-files.sh
+
   l10n:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This adds a CI job that runs the type generator for `subiquity_client` and fails in case of a mismatch 

Example test failure: https://github.com/canonical/ubuntu-desktop-provision/actions/runs/20999798760/job/60366358501?pr=1256