### PR TITLE
feat: show error page for startup errors

### DIFF
--- a/apps/ubuntu_bootstrap/lib/services/installer_service.dart
+++ b/apps/ubuntu_bootstrap/lib/services/installer_service.dart
@@ -21,9 +21,12 @@ class InstallerService {
   List<String> get experimentalFeatures => _experimentalFeatures ?? [];
 
   Future<void> init() async {
+    final status = await monitorStatus()
+        .firstWhere((s) => s?.isLoading == false || (s?.isError ?? false));
+    if (status?.isError ?? false) {
+      return;
+    }
     await _client.setVariant(Variant.DESKTOP);
-    final status =
-        await monitorStatus().firstWhere((s) => s?.isLoading == false);
     if (status?.interactive ?? false) {
       // Use the default values for a number of endpoints that aren't used in
       // the bootstrap stage, or for which a UI page isn't implemented yet.
@@ -100,4 +103,5 @@ extension ApplicationStatusX on ApplicationStatus {
   bool get isInstalling =>
       state.index >= ApplicationState.RUNNING.index &&
       state.index < ApplicationState.DONE.index;
+  bool get isError => state == ApplicationState.ERROR;
 }

--- a/apps/ubuntu_bootstrap/test/services/installer_service_test.dart
+++ b/apps/ubuntu_bootstrap/test/services/installer_service_test.dart
@@ -56,6 +56,27 @@ void main() {
     verifyNever(client.markConfigured(any));
   });
 
+  test('init error', () async {
+    final client = MockSubiquityClient();
+    when(client.getInteractiveSections()).thenAnswer((_) async => null);
+    when(client.monitorStatus()).thenAnswer(
+      (_) => Stream.fromIterable([
+        fakeApplicationStatus(ApplicationState.STARTING_UP),
+        fakeApplicationStatus(ApplicationState.CLOUD_INIT_WAIT),
+        fakeApplicationStatus(ApplicationState.EARLY_COMMANDS),
+        fakeApplicationStatus(ApplicationState.ERROR),
+      ]),
+    );
+
+    final pageConfigService = setupMockPageConfig();
+    final service = InstallerService(client, pageConfig: pageConfigService);
+    await expectLater(service.init(), completes);
+
+    verify(client.monitorStatus()).called(1);
+    verifyNever(client.setVariant(any));
+    verifyNever(client.markConfigured(any));
+  });
+
   test('load interactive', () async {
     final client = MockSubiquityClient();
     when(client.getInteractiveSections()).thenAnswer((_) async => null);


### PR DESCRIPTION
If subiquity enters an error state during the startup phase (e.g. due to failing commands in an autoinstall's `early-commands`), currently the UI will be stuck on the loading screen indefinitely. This PR makes sure the initialization of the `InstallerService` is unblocked in case of an error, so that the wizard can proceed to the error page.

[Screencast From 2026-01-21 10-59-28.webm](https://github.com/user-attachments/assets/9340fd23-32f5-4cc4-b8ff-7d90f4b2d488)


For testing purposes, the following `autoinstall.yaml` can be used:
```
version: 1
early-commands:
  - /bin/false
```

In a future PR, we should provide error details and possible actions to the user, instead of showing a generic error page. See also https://github.com/canonical/subiquity/pull/2296.

cc @ogayot 

UDENG-8862