### PR TITLE
feat: release backported subiquity/curtin fixes for noble

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
     after: [flutter-git]
     plugin: nil
     source: .
-    source-commit: &commit-ref 8060df931aee303bcd06dff098088020badbee10
+    source-commit: &commit-ref 65491c99edbc1776d205156de8a74220d7aaa71e
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
@@ -72,7 +72,7 @@ parts:
     plugin: nil
     source: https://git.launchpad.net/curtin
     source-type: git
-    source-commit: 0ab394917d66d2b6c51e297bf9bf5d26ef36c360
+    source-commit: 0fd15cd64ba6380f3835d9c2226fae1061547c31
     override-pull: |
       craftctl default
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"


### PR DESCRIPTION
See https://github.com/canonical/ubuntu-desktop-provision/pull/1273