### PR TITLE
feat: skip tpm action page when there's no error

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
@@ -67,6 +67,7 @@ class TpmActionModel extends SafeChangeNotifier {
   Future<SubiquityException?> performAction(
     CoreBootFixActionWithCategoryAndArgs action, {
     bool triggeredByUser = true,
+    VoidCallback? fixedCallback,
   }) async {
     if (triggeredByUser) {
       _isLoading = true;
@@ -90,7 +91,11 @@ class TpmActionModel extends SafeChangeNotifier {
       return performAction(nextAction, triggeredByUser: false);
     }
     _isLoading = false;
-    notifyListeners();
-    return error;
+    if (tpmDisallowedCapability != null) {
+      notifyListeners();
+      return error;
+    }
+    fixedCallback?.call();
+    return null;
   }
 }

--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.dart
@@ -19,6 +19,7 @@ TpmActionModel buildTpmActionModel({
   when(model.tpmDisallowedCapability).thenReturn(tpmDisallowedCapability);
   when(model.confirmationNeeded).thenReturn(confirmationNeeded);
   when(model.isLoading).thenReturn(isLoading);
-  when(model.performAction(any)).thenAnswer((_) async => actionResult);
+  when(model.performAction(any, fixedCallback: anyNamed('fixedCallback')))
+      .thenAnswer((_) async => actionResult);
   return model;
 }

--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/test_tpm_action.mocks.dart
@@ -85,12 +85,16 @@ class MockTpmActionModel extends _i1.Mock implements _i2.TpmActionModel {
   _i3.Future<_i4.SubiquityException?> performAction(
     _i4.CoreBootFixActionWithCategoryAndArgs? action, {
     bool? triggeredByUser = true,
+    _i5.VoidCallback? fixedCallback,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #performAction,
           [action],
-          {#triggeredByUser: triggeredByUser},
+          {
+            #triggeredByUser: triggeredByUser,
+            #fixedCallback: fixedCallback,
+          },
         ),
         returnValue: _i3.Future<_i4.SubiquityException?>.value(),
       ) as _i3.Future<_i4.SubiquityException?>);


### PR DESCRIPTION
Automatically skip to the next page when there are no errors after performing a TPM fix action that doesn't result in a reboot. Also, call `back()` when returning to the page to skip over it in case the user navigates back.

[Screencast From 2026-01-22 12-08-25.webm](https://github.com/user-attachments/assets/7fe007f1-fabd-4b99-9a1a-2487a96280e2)
