### PR TITLE
chore: update go

### DIFF
--- a/provd/go.mod
+++ b/provd/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ubuntu-desktop-provision/provd
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf


### PR DESCRIPTION
Bump the go version to appease [govulncheck](https://pkg.go.dev/vuln/GO-2026-4340)