### PR TITLE
fix: Revert "fix: Use core22-mesa-backport PPA to fix issues on newer OEM Intel ARL"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,8 +14,6 @@ architectures:
   - build-on: arm64
 
 package-repositories:
-  - type: apt
-    ppa: desktop-snappers/core22-mesa-backports
     # pyroute2 from core22 is not compatible with the pure Python implementation of
     # probert (LP: #2139131).
   - type: apt
@@ -229,8 +227,6 @@ parts:
       - libglib2.0-bin
       - libibus-1.0-5
       - python3-gi
-      - libxcb-dri2-0
-      - libxcb-dri3-0
     prime:
       - usr/lib/*/libEGL*.so.*
       - usr/lib/*/libGL*.so.*


### PR DESCRIPTION
This reverts commit d38e1379662271370c03e300f46c85e3671189bf.

The snap crashes with the following error when testing in a VM:

```
Feb 02 11:58:59 ubuntu kernel: ubuntu_bootstra[6668]: segfault at 77fb56011bd0 ip 000077faa63110c5 sp 00007ffc9687b658 error 4 in libgallium-25.2.8-0ubuntu0~bpo22.04.1~ppa1.so[e110c5,77faa55c7000+17e0000] likely on CPU 1 (core 0, socket 1)
Feb 02 11:58:59 ubuntu kernel: Code: fe 0f 77 26 eb df 0f 1f 80 00 00 00 00 83 c2 03 83 c0 03 83 e2 fc 83 e0 fc 48 8d 44 02 0c 48 29 c6 48 01 c1 48 83 fe 0f 76 bb <83> 79 08 03 8b 41 04 8b 11 75 d8 85 c0 74 d4 83 fa 04 75 cf 81 79
```

@kenvandine Please let me know if you have an alternative solution for the OEM issue, or a fix in the ppa is available. Otherwise we'll need to revert this for the point release.