### PR TITLE
feat: enable subiquity's user errors

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -35,6 +35,7 @@ args=(
 	--storage-version=2
 	--postinst-hooks-dir=$SNAP/etc/subiquity/postinst.d
 	--no-wlan-listener
+	--no-report-storage-user-error
 )
 
 block_probing_timeout="$(block_probing_timeout)"


### PR DESCRIPTION
Enable subiquity's feature flag for recoverable errors introduced in https://github.com/canonical/subiquity/pull/1987

UDENG-8913