### PR TITLE
fix(a11y): Add toggle state to the install logs toggle button

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/install/install_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/install/install_page.dart
@@ -121,14 +121,18 @@ class _SlidePageState extends ConsumerState<_SlidePage> {
                 value: model.isInstalling ? null : 0,
               ),
             ),
-            trailing: IconButton(
-              icon: Icon(
-                YaruIcons.terminal,
-                color:
-                    model.isLogVisible ? Theme.of(context).primaryColor : null,
-                semanticLabel: lang.toggleLogsSemanticLabel,
+            trailing: Semantics(
+              toggled: model.isLogVisible,
+              child: IconButton(
+                icon: Icon(
+                  YaruIcons.terminal,
+                  color: model.isLogVisible
+                      ? Theme.of(context).primaryColor
+                      : null,
+                  semanticLabel: lang.toggleLogsSemanticLabel,
+                ),
+                onPressed: model.toggleLogVisibility,
               ),
-              onPressed: model.toggleLogVisibility,
             ),
             leading: Row(
               children: [


### PR DESCRIPTION
The toggle button for install logs now will convey its pressed state to screen readers.

---

UDENG-8925