### PR TITLE
feat: add support for riscv64

### DIFF
--- a/snap/local/riscv64-tool.patch
+++ b/snap/local/riscv64-tool.patch
@@ -1,0 +1,668 @@
+commit 03f313d12ed3d2c381cb48617442d7a4c5f9d643
+Author: Valentin Haudiquet <valentin.haudiquet@canonical.com>
+Date:   Tue Dec 2 19:52:25 2025 +0100
+
+    [ Tool ] Support riscv64 architecture
+    
+    This adds support for buildind desktop linux applications for riscv64 on the flutter tool, as well as basic riscv64 support for the tool.
+
+diff --git a/bin/internal/update_dart_sdk.sh b/bin/internal/update_dart_sdk.sh
+index 9ab6151021a..878c9e59ea9 100755
+--- a/bin/internal/update_dart_sdk.sh
++++ b/bin/internal/update_dart_sdk.sh
+@@ -89,6 +89,9 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
+       x86_64)
+         ARCH="x64"
+         ;;
++      riscv64)
++        ARCH="riscv64"
++        ;;
+       *)
+         ARCH="arm64"
+         ;;
+diff --git a/packages/flutter_tools/lib/src/android/android_device.dart b/packages/flutter_tools/lib/src/android/android_device.dart
+index 2813a7ea069..fae4fb66575 100644
+--- a/packages/flutter_tools/lib/src/android/android_device.dart
++++ b/packages/flutter_tools/lib/src/android/android_device.dart
+@@ -228,6 +228,7 @@ class AndroidDevice extends Device {
+       case TargetPlatform.fuchsia_x64:
+       case TargetPlatform.ios:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.tester:
+       case TargetPlatform.web_javascript:
+@@ -551,6 +552,7 @@ class AndroidDevice extends Device {
+       case TargetPlatform.fuchsia_x64:
+       case TargetPlatform.ios:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.tester:
+       case TargetPlatform.web_javascript:
+diff --git a/packages/flutter_tools/lib/src/artifacts.dart b/packages/flutter_tools/lib/src/artifacts.dart
+index 545b594ec45..3cb6fd2f21a 100644
+--- a/packages/flutter_tools/lib/src/artifacts.dart
++++ b/packages/flutter_tools/lib/src/artifacts.dart
+@@ -30,6 +30,7 @@ enum Artifact {
+   /// The tool which compiles a dart kernel file into native code.
+   genSnapshot,
+   genSnapshotArm64,
++  genSnapshotRiscv64,
+   genSnapshotX64,
+ 
+   /// The flutter tester binary.
+@@ -155,6 +156,7 @@ TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
+     case TargetPlatform.darwin:
+     case TargetPlatform.linux_x64:
+     case TargetPlatform.linux_arm64:
++    case TargetPlatform.linux_riscv64:
+     case TargetPlatform.windows_x64:
+     case TargetPlatform.windows_arm64:
+     case TargetPlatform.fuchsia_arm64:
+@@ -177,6 +179,8 @@ String? _artifactToFileName(Artifact artifact, Platform hostPlatform, [BuildMode
+       return 'gen_snapshot';
+     case Artifact.genSnapshotArm64:
+       return 'gen_snapshot_arm64';
++    case Artifact.genSnapshotRiscv64:
++      return 'gen_snapshot_riscv64';
+     case Artifact.genSnapshotX64:
+       return 'gen_snapshot_x64';
+     case Artifact.flutterTester:
+@@ -519,6 +523,7 @@ class CachedArtifacts implements Artifacts {
+       case TargetPlatform.darwin:
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.windows_x64:
+       case TargetPlatform.windows_arm64:
+         return _getDesktopArtifactPath(artifact, platform!, mode);
+@@ -550,6 +555,7 @@ class CachedArtifacts implements Artifacts {
+     switch (artifact) {
+       case Artifact.genSnapshot:
+       case Artifact.genSnapshotArm64:
++      case Artifact.genSnapshotRiscv64:
+       case Artifact.genSnapshotX64:
+         return _fileSystem.path.join(engineDir, _artifactToFileName(artifact, _platform));
+       case Artifact.engineDartSdkPath:
+@@ -590,6 +596,7 @@ class CachedArtifacts implements Artifacts {
+     switch (artifact) {
+       case Artifact.genSnapshot:
+       case Artifact.genSnapshotArm64:
++      case Artifact.genSnapshotRiscv64:
+       case Artifact.genSnapshotX64:
+         assert(mode != BuildMode.debug, 'Artifact $artifact only available in non-debug mode.');
+ 
+@@ -647,6 +654,7 @@ class CachedArtifacts implements Artifacts {
+     switch (artifact) {
+       case Artifact.genSnapshot:
+       case Artifact.genSnapshotArm64:
++      case Artifact.genSnapshotRiscv64:
+       case Artifact.genSnapshotX64:
+       case Artifact.flutterXcframework:
+         final String artifactFileName = _artifactToFileName(artifact, _platform)!;
+@@ -699,6 +707,7 @@ class CachedArtifacts implements Artifacts {
+         final genSnapshot = mode.isRelease ? 'gen_snapshot_product' : 'gen_snapshot';
+         return _fileSystem.path.join(root, runtime, 'dart_binaries', genSnapshot);
+       case Artifact.genSnapshotArm64:
++      case Artifact.genSnapshotRiscv64:
+       case Artifact.genSnapshotX64:
+         throw ArgumentError('$artifact is not available on this platform');
+       case Artifact.flutterPatchedSdkPath:
+@@ -757,6 +766,7 @@ class CachedArtifacts implements Artifacts {
+     switch (artifact) {
+       case Artifact.genSnapshot:
+       case Artifact.genSnapshotArm64:
++      case Artifact.genSnapshotRiscv64:
+       case Artifact.genSnapshotX64:
+         // For script snapshots any gen_snapshot binary will do. Returning gen_snapshot for
+         // android_arm in profile mode because it is available on all supported host platforms.
+@@ -878,6 +888,7 @@ class CachedArtifacts implements Artifacts {
+     switch (platform) {
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.darwin:
+       case TargetPlatform.windows_x64:
+       case TargetPlatform.windows_arm64:
+@@ -919,9 +930,11 @@ TargetPlatform _currentHostPlatform(Platform platform, OperatingSystemUtils oper
+     return TargetPlatform.darwin;
+   }
+   if (platform.isLinux) {
+-    return operatingSystemUtils.hostPlatform == HostPlatform.linux_x64
+-        ? TargetPlatform.linux_x64
+-        : TargetPlatform.linux_arm64;
++    return switch (operatingSystemUtils.hostPlatform) {
++      HostPlatform.linux_x64 => TargetPlatform.linux_x64,
++      HostPlatform.linux_riscv64 => TargetPlatform.linux_riscv64,
++      _ => TargetPlatform.linux_arm64,
++    };
+   }
+   if (platform.isWindows) {
+     return operatingSystemUtils.hostPlatform == HostPlatform.windows_arm64
+@@ -1197,6 +1210,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
+     switch (artifact) {
+       case Artifact.genSnapshot:
+       case Artifact.genSnapshotArm64:
++      case Artifact.genSnapshotRiscv64:
+       case Artifact.genSnapshotX64:
+         return _genSnapshotPath(artifact);
+       case Artifact.flutterTester:
+@@ -1338,6 +1352,8 @@ class CachedLocalEngineArtifacts implements Artifacts {
+     switch (hostPlatform) {
+       case TargetPlatform.darwin:
+         return 'macos-x64';
++      case TargetPlatform.linux_riscv64:
++        return 'linux-riscv64';
+       case TargetPlatform.linux_arm64:
+         return 'linux-arm64';
+       case TargetPlatform.linux_x64:
+@@ -1373,6 +1389,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
+       'clang_x86',
+       'clang_i386',
+       'clang_arm64',
++      'clang_riscv64',
+     ];
+     final String genSnapshotName = _artifactToFileName(artifact, _platform)!;
+     for (final clangDir in clangDirs) {
+@@ -1445,6 +1462,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
+           );
+         case Artifact.genSnapshot:
+         case Artifact.genSnapshotArm64:
++        case Artifact.genSnapshotRiscv64:
+         case Artifact.genSnapshotX64:
+         case Artifact.flutterTester:
+         case Artifact.flutterFramework:
+@@ -1570,6 +1588,8 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
+         return 'macos-x64';
+       case TargetPlatform.linux_arm64:
+         return 'linux-arm64';
++      case TargetPlatform.linux_riscv64:
++        return 'linux-riscv64';
+       case TargetPlatform.linux_x64:
+         return 'linux-x64';
+       case TargetPlatform.windows_x64:
+diff --git a/packages/flutter_tools/lib/src/base/build.dart b/packages/flutter_tools/lib/src/base/build.dart
+index 4551708cbfe..9cd34be24c3 100644
+--- a/packages/flutter_tools/lib/src/base/build.dart
++++ b/packages/flutter_tools/lib/src/base/build.dart
+@@ -360,6 +360,7 @@ class AOTSnapshotter {
+       TargetPlatform.darwin,
+       TargetPlatform.linux_x64,
+       TargetPlatform.linux_arm64,
++      TargetPlatform.linux_riscv64,
+       TargetPlatform.windows_x64,
+       TargetPlatform.windows_arm64,
+     ].contains(platform);
+diff --git a/packages/flutter_tools/lib/src/base/os.dart b/packages/flutter_tools/lib/src/base/os.dart
+index 5b499fef54f..297bf10159c 100644
+--- a/packages/flutter_tools/lib/src/base/os.dart
++++ b/packages/flutter_tools/lib/src/base/os.dart
+@@ -279,6 +279,8 @@ class _PosixUtils extends OperatingSystemUtils {
+         );
+       } else if (hostPlatformCheck.stdout.trim().endsWith('x86_64')) {
+         _hostPlatform = HostPlatform.linux_x64;
++      } else if (hostPlatformCheck.stdout.trim().endsWith('riscv64')) {
++        _hostPlatform = HostPlatform.linux_riscv64;
+       } else {
+         // We default to ARM if it's not x86_64 and we did not get an error.
+         _hostPlatform = HostPlatform.linux_arm64;
+@@ -611,6 +613,7 @@ enum HostPlatform {
+   darwin_arm64,
+   linux_x64,
+   linux_arm64,
++  linux_riscv64,
+   windows_x64,
+   windows_arm64;
+ 
+@@ -619,6 +622,7 @@ enum HostPlatform {
+     HostPlatform.darwin_arm64 => 'arm64',
+     HostPlatform.linux_x64 => 'x64',
+     HostPlatform.linux_arm64 => 'arm64',
++    HostPlatform.linux_riscv64 => 'riscv64',
+     HostPlatform.windows_x64 => 'x64',
+     HostPlatform.windows_arm64 => 'arm64',
+   };
+@@ -630,6 +634,7 @@ String getNameForHostPlatform(HostPlatform platform) {
+     HostPlatform.darwin_arm64 => 'darwin-arm64',
+     HostPlatform.linux_x64 => 'linux-x64',
+     HostPlatform.linux_arm64 => 'linux-arm64',
++    HostPlatform.linux_riscv64 => 'linux-riscv64',
+     HostPlatform.windows_x64 => 'windows-x64',
+     HostPlatform.windows_arm64 => 'windows-arm64',
+   };
+diff --git a/packages/flutter_tools/lib/src/build_info.dart b/packages/flutter_tools/lib/src/build_info.dart
+index b59d4b3912b..f923af4c7d0 100644
+--- a/packages/flutter_tools/lib/src/build_info.dart
++++ b/packages/flutter_tools/lib/src/build_info.dart
+@@ -576,6 +576,7 @@ enum TargetPlatform {
+   darwin,
+   linux_x64,
+   linux_arm64,
++  linux_riscv64,
+   windows_x64,
+   windows_arm64,
+   fuchsia_arm64,
+@@ -604,6 +605,7 @@ enum TargetPlatform {
+       case TargetPlatform.darwin:
+       case TargetPlatform.ios:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.tester:
+       case TargetPlatform.web_javascript:
+@@ -618,6 +620,7 @@ enum TargetPlatform {
+     switch (this) {
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+         return 'linux';
+       case TargetPlatform.darwin:
+         return 'macos';
+@@ -652,6 +655,8 @@ enum TargetPlatform {
+       case TargetPlatform.linux_arm64:
+       case TargetPlatform.windows_arm64:
+         return 'arm64';
++      case TargetPlatform.linux_riscv64:
++        return 'riscv64';
+       case TargetPlatform.android:
+       case TargetPlatform.android_arm:
+       case TargetPlatform.android_arm64:
+@@ -786,6 +791,7 @@ String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch? darwinArch
+     TargetPlatform.android_x64 => 'android-x64',
+     TargetPlatform.linux_x64 => 'linux-x64',
+     TargetPlatform.linux_arm64 => 'linux-arm64',
++    TargetPlatform.linux_riscv64 => 'linux-riscv64',
+     TargetPlatform.windows_x64 => 'windows-x64',
+     TargetPlatform.windows_arm64 => 'windows-arm64',
+     TargetPlatform.fuchsia_arm64 => 'fuchsia-arm64',
+@@ -811,6 +817,7 @@ TargetPlatform getTargetPlatformForName(String platform) {
+     'darwin' || 'darwin-x64' || 'darwin-arm64' => TargetPlatform.darwin,
+     'linux-x64' => TargetPlatform.linux_x64,
+     'linux-arm64' => TargetPlatform.linux_arm64,
++    'linux-riscv64' => TargetPlatform.linux_riscv64,
+     'windows-x64' => TargetPlatform.windows_x64,
+     'windows-arm64' => TargetPlatform.windows_arm64,
+     'web-javascript' => TargetPlatform.web_javascript,
+diff --git a/packages/flutter_tools/lib/src/build_system/targets/common.dart b/packages/flutter_tools/lib/src/build_system/targets/common.dart
+index 63eb1c736e8..f4695404411 100644
+--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
++++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
+@@ -228,6 +228,7 @@ class KernelSnapshot extends Target {
+       case TargetPlatform.fuchsia_x64:
+       case TargetPlatform.ios:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.tester:
+       case TargetPlatform.web_javascript:
+         forceLinkPlatform = false;
+@@ -243,7 +244,9 @@ class KernelSnapshot extends Target {
+       TargetPlatform.android_x64 => 'android',
+       TargetPlatform.darwin => 'macos',
+       TargetPlatform.ios => 'ios',
+-      TargetPlatform.linux_arm64 || TargetPlatform.linux_x64 => 'linux',
++      TargetPlatform.linux_arm64 ||
++      TargetPlatform.linux_riscv64 ||
++      TargetPlatform.linux_x64 => 'linux',
+       TargetPlatform.windows_arm64 || TargetPlatform.windows_x64 => 'windows',
+       TargetPlatform.tester || TargetPlatform.web_javascript => null,
+       TargetPlatform.unsupported => TargetPlatform.throwUnsupportedTarget(),
+diff --git a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+index db28675db2d..c2f8820945c 100644
+--- a/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
++++ b/packages/flutter_tools/lib/src/build_system/tools/shader_compiler.dart
+@@ -112,6 +112,7 @@ class ShaderCompiler {
+       case TargetPlatform.android:
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.windows_x64:
+       case TargetPlatform.windows_arm64:
+         return <String>[
+diff --git a/packages/flutter_tools/lib/src/commands/assemble.dart b/packages/flutter_tools/lib/src/commands/assemble.dart
+index 2e7b11ad1e5..26b2dad909f 100644
+--- a/packages/flutter_tools/lib/src/commands/assemble.dart
++++ b/packages/flutter_tools/lib/src/commands/assemble.dart
+@@ -46,10 +46,13 @@ var _kDefaultTargets = <Target>[
+   // Linux targets
+   const DebugBundleLinuxAssets(TargetPlatform.linux_x64),
+   const DebugBundleLinuxAssets(TargetPlatform.linux_arm64),
++  const DebugBundleLinuxAssets(TargetPlatform.linux_riscv64),
+   const ProfileBundleLinuxAssets(TargetPlatform.linux_x64),
+   const ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
++  const ProfileBundleLinuxAssets(TargetPlatform.linux_riscv64),
+   const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
+   const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
++  const ReleaseBundleLinuxAssets(TargetPlatform.linux_riscv64),
+   const ReleaseAndroidApplication(),
+   // This is a one-off rule for bundle and aot compat.
+   const CopyFlutterBundle(),
+diff --git a/packages/flutter_tools/lib/src/commands/build_bundle.dart b/packages/flutter_tools/lib/src/commands/build_bundle.dart
+index 927edb22877..06d0ef67a76 100644
+--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
++++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
+@@ -46,6 +46,7 @@ class BuildBundleCommand extends BuildSubCommand {
+           'darwin',
+           'linux-x64',
+           'linux-arm64',
++          'linux-riscv64',
+           'windows-x64',
+           'windows-arm64',
+         ],
+@@ -122,6 +123,7 @@ class BuildBundleCommand extends BuildSubCommand {
+         }
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+         if (!featureFlags.isLinuxEnabled) {
+           throwToolExit('Linux is not a supported target platform.');
+         }
+diff --git a/packages/flutter_tools/lib/src/commands/build_linux.dart b/packages/flutter_tools/lib/src/commands/build_linux.dart
+index 832be184a32..f948f87f0aa 100644
+--- a/packages/flutter_tools/lib/src/commands/build_linux.dart
++++ b/packages/flutter_tools/lib/src/commands/build_linux.dart
+@@ -23,13 +23,15 @@ class BuildLinuxCommand extends BuildSubCommand {
+   }) : _operatingSystemUtils = operatingSystemUtils,
+        super(verboseHelp: verboseHelp) {
+     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
+-    final defaultTargetPlatform = (_operatingSystemUtils.hostPlatform == HostPlatform.linux_arm64)
+-        ? 'linux-arm64'
+-        : 'linux-x64';
++    final String defaultTargetPlatform = switch (_operatingSystemUtils.hostPlatform) {
++      HostPlatform.linux_arm64 => 'linux-arm64',
++      HostPlatform.linux_riscv64 => 'linux-riscv64',
++      _ => 'linux-x64',
++    };
+     argParser.addOption(
+       'target-platform',
+       defaultsTo: defaultTargetPlatform,
+-      allowed: <String>['linux-arm64', 'linux-x64'],
++      allowed: <String>['linux-arm64', 'linux-x64', 'linux-riscv64'],
+       help: 'The target platform for which the app is compiled.',
+     );
+     argParser.addOption(
+@@ -79,9 +81,8 @@ class BuildLinuxCommand extends BuildSubCommand {
+     if (!globals.platform.isLinux) {
+       throwToolExit('"build linux" only supported on Linux hosts.');
+     }
+-    // Cross-building for x64 targets on arm64 hosts is not supported.
+-    if (_operatingSystemUtils.hostPlatform != HostPlatform.linux_x64 &&
+-        targetPlatform != TargetPlatform.linux_arm64) {
++    // Cross-building is only supported on x64 hosts
++    if (_operatingSystemUtils.hostPlatform != HostPlatform.linux_x64 && needCrossBuild) {
+       throwToolExit('"cross-building" only supported on Linux x64 hosts.');
+     }
+     // TODO(fujino): https://github.com/flutter/flutter/issues/74929
+@@ -91,6 +92,14 @@ class BuildLinuxCommand extends BuildSubCommand {
+         'Cross-build from Linux x64 host to Linux arm64 target is not currently supported.',
+       );
+     }
++    // Building for riscv64 (on a non-riscv64 host) is experimental
++    if (_operatingSystemUtils.hostPlatform != HostPlatform.linux_riscv64 &&
++        targetPlatform == TargetPlatform.linux_riscv64 &&
++        !featureFlags.isRiscv64SupportEnabled) {
++      throwToolExit(
++        'Building for Linux riscv64 is currently an experimental feature. To enable, run "flutter config --enable-riscv64"',
++      );
++    }
+     final Logger logger = globals.logger;
+     await buildLinux(
+       project.linux,
+diff --git a/packages/flutter_tools/lib/src/features.dart b/packages/flutter_tools/lib/src/features.dart
+index fdbfbfdca2e..ac2f5dbefb8 100644
+--- a/packages/flutter_tools/lib/src/features.dart
++++ b/packages/flutter_tools/lib/src/features.dart
+@@ -76,6 +76,9 @@ abstract class FeatureFlags {
+   /// Whether UIScene migration is enabled.
+   bool get isUISceneMigrationEnabled;
+ 
++  /// Wether riscv64 support is enabled.
++  bool get isRiscv64SupportEnabled;
++
+   /// Whether a particular feature is enabled for the current channel.
+   ///
+   /// Prefer using one of the specific getters above instead of this API.
+@@ -99,6 +102,7 @@ abstract class FeatureFlags {
+     windowingFeature,
+     lldbDebugging,
+     uiSceneMigration,
++    riscv64,
+   ];
+ 
+   /// All current Flutter feature flags that can be configured.
+@@ -268,6 +272,16 @@ const uiSceneMigration = Feature(
+   stable: FeatureChannelSetting(available: true),
+ );
+ 
++/// The [Feature] for building code targetting riscv64 architecture
++const riscv64 = Feature(
++  name: 'support for riscv64 architecture',
++  configSetting: 'enable-riscv64',
++  environmentOverride: 'FLUTTER_RISCV64',
++  master: FeatureChannelSetting(available: true, enabledByDefault: true),
++  beta: FeatureChannelSetting(available: true),
++  stable: FeatureChannelSetting(available: true),
++);
++
+ /// A [Feature] is a process for conditionally enabling tool features.
+ ///
+ /// All settings are optional, and if not provided will generally default to
+diff --git a/packages/flutter_tools/lib/src/flutter_application_package.dart b/packages/flutter_tools/lib/src/flutter_application_package.dart
+index 75eaeea481e..c61de499a28 100644
+--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
++++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
+@@ -91,6 +91,7 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
+         return WebApplicationPackage(FlutterProject.current());
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+         return applicationBinary == null
+             ? LinuxApp.fromLinuxProject(FlutterProject.current().linux)
+             : LinuxApp.fromPrebuiltApp(applicationBinary);
+diff --git a/packages/flutter_tools/lib/src/flutter_cache.dart b/packages/flutter_tools/lib/src/flutter_cache.dart
+index 31f5fbc825a..46b8eb48b23 100644
+--- a/packages/flutter_tools/lib/src/flutter_cache.dart
++++ b/packages/flutter_tools/lib/src/flutter_cache.dart
+@@ -683,6 +683,7 @@ class FlutterRunnerDebugSymbols extends CachedArtifact {
+     }
+     await _downloadDebugSymbols('x64', artifactUpdater);
+     await _downloadDebugSymbols('arm64', artifactUpdater);
++    await _downloadDebugSymbols('riscv64', artifactUpdater);
+   }
+ }
+ 
+diff --git a/packages/flutter_tools/lib/src/flutter_features.dart b/packages/flutter_tools/lib/src/flutter_features.dart
+index c1102780346..ee7fb68b6ab 100644
+--- a/packages/flutter_tools/lib/src/flutter_features.dart
++++ b/packages/flutter_tools/lib/src/flutter_features.dart
+@@ -66,6 +66,9 @@ mixin FlutterFeatureFlagsIsEnabled implements FeatureFlags {
+ 
+   @override
+   bool get isUISceneMigrationEnabled => isEnabled(uiSceneMigration);
++
++  @override
++  bool get isRiscv64SupportEnabled => isEnabled(riscv64);
+ }
+ 
+ interface class FlutterFeatureFlags extends FeatureFlags with FlutterFeatureFlagsIsEnabled {
+diff --git a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+index 1ed907c050a..86d0010f495 100644
+--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
++++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+@@ -666,6 +666,7 @@ OS getNativeOSFromTargetPlatform(TargetPlatform platform) {
+       return OS.macOS;
+     case TargetPlatform.linux_x64:
+     case TargetPlatform.linux_arm64:
++    case TargetPlatform.linux_riscv64:
+       return OS.linux;
+     case TargetPlatform.windows_x64:
+     case TargetPlatform.windows_arm64:
+diff --git a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+index cc0de9f2452..d036e29a352 100644
+--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
++++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+@@ -69,6 +69,8 @@ sealed class AssetBuildTarget {
+         return _linuxTarget(supportedAssetTypes, Architecture.x64);
+       case TargetPlatform.linux_arm64:
+         return _linuxTarget(supportedAssetTypes, Architecture.arm64);
++      case TargetPlatform.linux_riscv64:
++        return _linuxTarget(supportedAssetTypes, Architecture.riscv64);
+       case TargetPlatform.windows_arm64:
+         return _windowsTarget(supportedAssetTypes, Architecture.arm64);
+       case TargetPlatform.darwin:
+@@ -402,6 +404,7 @@ List<AndroidArch> _androidArchs(TargetPlatform targetPlatform, String? androidAr
+     case TargetPlatform.fuchsia_x64:
+     case TargetPlatform.ios:
+     case TargetPlatform.linux_arm64:
++    case TargetPlatform.linux_riscv64:
+     case TargetPlatform.linux_x64:
+     case TargetPlatform.tester:
+     case TargetPlatform.web_javascript:
+diff --git a/packages/flutter_tools/lib/src/linux/build_linux.dart b/packages/flutter_tools/lib/src/linux/build_linux.dart
+index 6525bb9e61d..aa86e904948 100644
+--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
++++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
+@@ -163,6 +163,8 @@ Future<void> _runCmake(
+   final String buildFlag = sentenceCase(buildModeName);
+   final bool needCrossBuildOptionsForArm64 =
+       needCrossBuild && targetPlatform == TargetPlatform.linux_arm64;
++  final bool needCrossBuildOptionsForRiscv64 =
++      needCrossBuild && targetPlatform == TargetPlatform.linux_riscv64;
+   int result;
+   if (!globals.processManager.canRun('cmake')) {
+     throwToolExit(globals.userMessages.cmakeMissing);
+@@ -179,6 +181,9 @@ Future<void> _runCmake(
+       if (needCrossBuild) '-DFLUTTER_TARGET_PLATFORM_SYSROOT=$targetSysroot',
+       if (needCrossBuildOptionsForArm64) '-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu',
+       if (needCrossBuildOptionsForArm64) '-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu',
++      // Support cross-building for riscv64 targets on x64 hosts.
++      if (needCrossBuildOptionsForRiscv64) '-DCMAKE_C_COMPILER_TARGET=riscv64-linux-gnu',
++      if (needCrossBuildOptionsForRiscv64) '-DCMAKE_CXX_COMPILER_TARGET=riscv64-linux-gnu',
+       sourceDir.path,
+     ],
+     workingDirectory: buildDir.path,
+diff --git a/packages/flutter_tools/lib/src/linux/linux_device.dart b/packages/flutter_tools/lib/src/linux/linux_device.dart
+index a42d783ed09..b352cee0203 100644
+--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
++++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
+@@ -49,6 +49,8 @@ class LinuxDevice extends DesktopDevice {
+   late final Future<TargetPlatform> targetPlatform = () async {
+     if (_operatingSystemUtils.hostPlatform == HostPlatform.linux_x64) {
+       return TargetPlatform.linux_x64;
++    } else if (_operatingSystemUtils.hostPlatform == HostPlatform.linux_riscv64) {
++      return TargetPlatform.linux_riscv64;
+     }
+     return TargetPlatform.linux_arm64;
+   }();
+diff --git a/packages/flutter_tools/lib/src/mdns_discovery.dart b/packages/flutter_tools/lib/src/mdns_discovery.dart
+index b21795ddb3e..0840c95b637 100644
+--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
++++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
+@@ -599,6 +599,7 @@ class MDnsVmServiceDiscovery {
+       case TargetPlatform.fuchsia_arm64:
+       case TargetPlatform.fuchsia_x64:
+       case TargetPlatform.linux_arm64:
++      case TargetPlatform.linux_riscv64:
+       case TargetPlatform.linux_x64:
+       case TargetPlatform.tester:
+       case TargetPlatform.web_javascript:
+diff --git a/packages/flutter_tools/lib/src/resident_runner.dart b/packages/flutter_tools/lib/src/resident_runner.dart
+index 7fb86c0cc9a..10f58eedda8 100644
+--- a/packages/flutter_tools/lib/src/resident_runner.dart
++++ b/packages/flutter_tools/lib/src/resident_runner.dart
+@@ -1611,6 +1611,7 @@ Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async
+     case TargetPlatform.fuchsia_arm64:
+     case TargetPlatform.fuchsia_x64:
+     case TargetPlatform.linux_arm64:
++    case TargetPlatform.linux_riscv64:
+     case TargetPlatform.linux_x64:
+     case TargetPlatform.tester:
+     case TargetPlatform.web_javascript:
+diff --git a/packages/flutter_tools/lib/src/runner/flutter_command.dart b/packages/flutter_tools/lib/src/runner/flutter_command.dart
+index 1c5811835d4..075d565eb58 100644
+--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
++++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
+@@ -2090,6 +2090,7 @@ DevelopmentArtifact? artifactFromTargetPlatform(TargetPlatform targetPlatform) {
+       return null;
+     case TargetPlatform.linux_x64:
+     case TargetPlatform.linux_arm64:
++    case TargetPlatform.linux_riscv64:
+       if (featureFlags.isLinuxEnabled) {
+         return DevelopmentArtifact.linux;
+       }
+diff --git a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+index b625816f366..11a7003a35c 100644
+--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
++++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+@@ -90,6 +90,7 @@ void main() {
+         'darwin-x64': false,
+         'linux-x64': false,
+         'linux-arm64': false,
++        'linux-riscv64': false,
+         'windows-x64': false,
+         'web-javascript': true,
+         'ios': false,
+diff --git a/packages/flutter_tools/test/general.shard/cache_test.dart b/packages/flutter_tools/test/general.shard/cache_test.dart
+index f4743bb66a3..8b78ff91ddf 100644
+--- a/packages/flutter_tools/test/general.shard/cache_test.dart
++++ b/packages/flutter_tools/test/general.shard/cache_test.dart
+@@ -574,6 +574,7 @@ void main() {
+     expect(packageResolver.resolved, <List<String>>[
+       <String>['fuchsia-debug-symbols-x64', '123456'],
+       <String>['fuchsia-debug-symbols-arm64', '123456'],
++      <String>['fuchsia-debug-symbols-riscv64', '123456'],
+     ]);
+   });
+ 
+diff --git a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+index 050bd3d6c6d..f0a864f0424 100644
+--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
++++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+@@ -824,6 +824,9 @@ class FakeFlutterFeatures extends FeatureFlags {
+   @override
+   bool get isUISceneMigrationEnabled => _enabled;
+ 
++  @override
++  bool get isRiscv64SupportEnabled => _enabled;
++
+   @override
+   final List<Feature> allFeatures;
+ 
+diff --git a/packages/flutter_tools/test/src/fakes.dart b/packages/flutter_tools/test/src/fakes.dart
+index fe3e8730e1e..7df0fa1fe53 100644
+--- a/packages/flutter_tools/test/src/fakes.dart
++++ b/packages/flutter_tools/test/src/fakes.dart
+@@ -532,6 +532,7 @@ class TestFeatureFlags implements FeatureFlags {
+     this.isWindowingEnabled = false,
+     this.isLLDBDebuggingEnabled = false,
+     this.isUISceneMigrationEnabled = false,
++    this.isRiscv64SupportEnabled = false,
+   });
+ 
+   @override
+@@ -582,6 +583,9 @@ class TestFeatureFlags implements FeatureFlags {
+   @override
+   final bool isUISceneMigrationEnabled;
+ 
++  @override
++  final bool isRiscv64SupportEnabled;
++
+   @override
+   bool isEnabled(Feature feature) {
+     return switch (feature) {
+@@ -600,6 +604,7 @@ class TestFeatureFlags implements FeatureFlags {
+       windowingFeature => isWindowingEnabled,
+       lldbDebugging => isLLDBDebuggingEnabled,
+       uiSceneMigration => isUISceneMigrationEnabled,
++      riscv64 => isRiscv64SupportEnabled,
+       _ => false,
+     };
+   }
+@@ -622,6 +627,7 @@ class TestFeatureFlags implements FeatureFlags {
+     windowingFeature,
+     lldbDebugging,
+     uiSceneMigration,
++    riscv64,
+   ];
+ 
+   @override

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ base: core24
 platforms:
   amd64:
   arm64:
+  riscv64:
 
 apps:
   subiquity-server:
@@ -58,6 +59,10 @@ parts:
     source-type: git
     build-attributes: [enable-patchelf]
     override-build: |
+      if [ $CRAFT_ARCH_BUILD_FOR = riscv64 ]; then
+        export FLUTTER_STORAGE_BASE_URL=https://flutter-experimental.ubuntu.com
+      fi
+
       set -eux
       mkdir -p $CRAFT_PART_INSTALL/bin
       git submodule update --init --recursive
@@ -168,9 +173,23 @@ parts:
       fi
 
       craftctl default
-      FLUTTER_VERSION=$(sed -n "s/^flutter \([0-9.]\+\).*/\1/p" .tool-versions)
-      git clone -b $FLUTTER_VERSION --depth 1 https://github.com/flutter/flutter.git
+
+      if [ $CRAFT_ARCH_BUILD_FOR = riscv64 ]; then
+        git clone -b 3.38.9 --depth 1 https://github.com/flutter/flutter.git
+
+        # Apply tool patch for riscv64 support
+        cp /root/project/snap/local/riscv64-tool.patch $CRAFT_PART_SRC/flutter/
+        git -C $CRAFT_PART_SRC/flutter apply riscv64-tool.patch
+        rm $CRAFT_PART_SRC/flutter/riscv64-tool.patch
+      else
+        FLUTTER_VERSION=$(sed -n "s/^flutter \([0-9.]\+\).*/\1/p" .tool-versions)
+        git clone -b $FLUTTER_VERSION --depth 1 https://github.com/flutter/flutter.git
+      fi
     override-build: |
+      if [ $CRAFT_ARCH_BUILD_FOR = riscv64 ]; then
+        export FLUTTER_STORAGE_BASE_URL=https://flutter-experimental.ubuntu.com
+      fi
+
       mkdir -p $CRAFT_PART_INSTALL/usr/bin
       mkdir -p $CRAFT_PART_INSTALL/usr/libexec
       cp -r $CRAFT_PART_SRC/flutter $CRAFT_PART_INSTALL/usr/libexec/flutter
@@ -208,12 +227,15 @@ parts:
     build-attributes: [enable-patchelf]
     stage-packages:
       - libatk1.0-0t64
+      - libc6
+      - libc6-dev
       - libcairo-gobject2
       - libcairo2
       - libegl-mesa0
       - libegl1
       # Needed for the dri drivers see https://github.com/canonical/ubuntu-desktop-installer/issues/2391
       - libelf1t64
+      - libgcc-s1
       - libgl1
       - libgles2
       - libglib2.0-0t64
@@ -242,6 +264,7 @@ parts:
       - usr/lib/*/libGL*.so.*
       - usr/lib/*/libX*.so.*
       - usr/lib/*/liba*.so.*
+      - usr/lib/*/libc*.so.*
       - usr/lib/*/libcairo*.so.*
       - usr/lib/*/libe*.so.*
       - usr/lib/*/libf*.so.*


### PR DESCRIPTION
WIP: This is still a work-in-progress. It builds as-is, but needs `flutter-experimental.ubuntu.com` to be up which is not yet the case. Also, the commit-ref will need to be updated to point to the real main branch. Right now, it points to an experimental branch which removes a dependency not available on riscv64. We need that dependency to be moved and some files to be refactored before merging this. Otherwise, open to suggestions for any other change.

This adds support for the riscv64 architecture, using experimental Flutter deployment and a Flutter tool patch. We should be able to drop those gradually as everything gets merged and built upstream.
