### PR TITLE
fix: remove duplicate network devices

### DIFF
--- a/packages/ubuntu_provision/lib/src/network/network_device.dart
+++ b/packages/ubuntu_provision/lib/src/network/network_device.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:ubuntu_provision/services.dart';
@@ -64,7 +65,19 @@ abstract class NetworkDeviceModel<T extends NetworkDevice>
     final previousSelected = _selectedDevice;
     _selectedDevice = null;
     final devices = <T>[];
-    for (final device in getDevices()) {
+    final hwAddresses = <String>{};
+
+    // sort new devices by hwAddress and path, then only retain the first for each
+    // hwAddress to avoid multiple updates of the same device
+    final newDevices = getDevices()
+        .sortedByCompare(
+          (device) => (device.hwAddress, device.path),
+          (a, b) => a.$1.compareTo(a.$2) == 0
+              ? b.$1.compareTo(b.$2)
+              : a.$1.compareTo(a.$2),
+        )
+        .where((device) => hwAddresses.add(device.hwAddress));
+    for (final device in newDevices) {
       var model = _allDevices[device.hwAddress];
       if (model == null) {
         model = createDevice(device);


### PR DESCRIPTION
This fixes a bug in the `NetworkDevice` class which causes an infinite recursive update loop in case the list returned by `getDevices()` contains two or more devices that share the same `hwAddress`.
This bug causes the integration test failures in recent PRs, possibly triggered by changes to the network configuration of github runners. While debugging this, I found the following upate loop in the logs
```
update device:
NetworkManagerDevice(path: /org/freedesktop/NetworkManager/Devices/4) -> NetworkManagerDevice(path: /org/freedesktop/NetworkManager/Devices/3)
acpi-MSFT1000:00-pci-919b:00:02.0 -> acpi-MSFT1000:00
60:45:BD:34:1F:C2 -> 60:45:BD:34:1F:C2

update device:
NetworkManagerDevice(path: /org/freedesktop/NetworkManager/Devices/3) -> NetworkManagerDevice(path: /org/freedesktop/NetworkManager/Devices/4)
acpi-MSFT1000:00 -> acpi-MSFT1000:00-pci-919b:00:02.0
60:45:BD:34:1F:C2 -> 60:45:BD:34:1F:C2

...
```
where the `hwAddress` is always the same, but the `path` is constantly being updated.