### PR TITLE
fix: explicitly fetch git tags when building curtin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,8 @@ parts:
     source-commit: e7e57942f1f76537d670916adbaa374c62d48fab
     override-pull: |
       craftctl default
+      # Since snapcraft 8.14, the tags are not automatically fetched
+      git fetch --tags
       PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
       sed -e "s,@@PACKAGED_VERSION@@,$PACKAGED_VERSION,g" -i curtin/version.py
     override-build: &pyinstall |


### PR DESCRIPTION
See https://github.com/canonical/subiquity/pull/2323