### PR TITLE
fix: remove deprecated `--no-report-storage-user-error`

### DIFF
--- a/snap/local/subiquity-server
+++ b/snap/local/subiquity-server
@@ -35,7 +35,6 @@ args=(
 	--storage-version=2
 	--postinst-hooks-dir=$SNAP/etc/subiquity/postinst.d
 	--no-wlan-listener
-	--no-report-storage-user-error
 )
 
 block_probing_timeout="$(block_probing_timeout)"


### PR DESCRIPTION
I removed it in the [integration tests](https://github.com/canonical/ubuntu-desktop-provision/pull/1322/changes/2c11c438ea6d15ca37a69afc5520279c24eb9a60), but forgot removing it in the actual launcher as well :(