### PR TITLE
fix: remove 'ubuntu' scope when copying dconf settings

### DIFF
--- a/snap/local/postinst.d/10_override_desktop_settings
+++ b/snap/local/postinst.d/10_override_desktop_settings
@@ -13,10 +13,10 @@ fi
 dconf_dump() {
     target_schema=$target_schemas/20_ubuntu-desktop-installer-$1.gschema.override
     sudo -u $user dconf dump /org/gnome/desktop/$1/ > $target_schema
-    # - [foo] -> [org.gnome.desktop.$1.foo:ubuntu]
-    sed -i -E "s/^\[([^/]*)\]/\[org.gnome.desktop.$1.\1:ubuntu\]/g" $target_schema
-    # - [/] -> [org.gnome.desktop.$1:ubuntu]
-    sed -i -E "s/^\[\/\]$/\[org.gnome.desktop.$1:ubuntu\]/g" $target_schema
+    # - [foo] -> [org.gnome.desktop.$1.foo]
+    sed -i -E "s/^\[([^/]*)\]/\[org.gnome.desktop.$1.\1\]/g" $target_schema
+    # - [/] -> [org.gnome.desktop.$1]
+    sed -i -E "s/^\[\/\]$/\[org.gnome.desktop.$1\]/g" $target_schema
     [ -s $target_schema ] || rm $target_schema
 }
 


### PR DESCRIPTION
This ensures that the dconf settings configured in the live session are available in GDM.

UDENG-8370