### PR TITLE
fix: autologin for SDDM

### DIFF
--- a/snap/local/postinst.d/10_configure_auto_login
+++ b/snap/local/postinst.d/10_configure_auto_login
@@ -74,6 +74,8 @@ EOF
         sed -i 's/PLACEHOLDER/Lubuntu.desktop/' $ROOT/etc/sddm.conf
     elif $chroot $ROOT [ -f /usr/share/xsessions/lxqt.desktop ] || $chroot $ROOT [ -f /usr/share/wayland-sessions/lxqt.desktop ]; then
         sed -i 's/PLACEHOLDER/lxqt.desktop/' $ROOT/etc/sddm.conf
+    elif $chroot $ROOT [ -f /usr/share/xsessions/budgie-desktop.desktop ] || $chroot $ROOT [ -f /usr/share/wayland-sessions/budgie-desktop.desktop ]; then
+        sed -i 's/PLACEHOLDER/budgie-desktop.desktop/' $ROOT/etc/sddm.conf
     else #fallback if some other DE/WM is used
         if [ -d /usr/share/xsessions ]; then
             SDDMSESSION=$(ls /usr/share/xsessions | head -1)


### PR DESCRIPTION
Fixes #1332

@fossfreedom I've published a snap including this fix to `26.04/edge/fix-sddm-autologin`, could you please check if that fixes the issue for you? You can simply run `snap refresh --channel=26.04/edge/fix-sddm-autologin ubuntu-desktop-bootstrap` in the live session.