### PR TITLE
fix: stage libc only on riscv64 to allow builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,11 @@ parts:
     source-commit: &commit-ref ce6beb72033cd2b85e5760f91f742db4137304fc
     source-type: git
     build-attributes: [enable-patchelf]
+    stage-packages:
+      - to riscv64:
+        - libc6
+        - libc6-dev
+        - libgcc-s1
     override-build: |
       if [ $CRAFT_ARCH_BUILD_FOR = riscv64 ]; then
         export FLUTTER_STORAGE_BASE_URL=https://flutter-experimental.ubuntu.com


### PR DESCRIPTION
For some reason, staging libc seems to be the only way that the snap builds on riscv64. This might need further investigation, but for now we can build it this way.