### PR TITLE
Snapcraft enhance subiquity debug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,8 @@ apps:
       LIVE_RUN: 1
       LOG_LEVEL: debug
       SNAP_PYTHON: python3
+
+  # Debug tools for Subiquity
   probert:
     command: bin/subiquity/bin/subiquity-cmd $SNAP/usr/bin/python3.12 $SNAP/bin/probert
   curtin:
@@ -53,6 +55,8 @@ apps:
     environment:
       PYTHON: $SNAP/usr/bin/python3.12
       PATH: $PATH:$SNAP/bin
+  python:
+    command: bin/subiquity/bin/subiquity-cmd $SNAP/usr/bin/python3.12
 
 parts:
   ubuntu-bootstrap:


### PR DESCRIPTION
Running `snap run ubuntu-desktop-bootstrap.probert` was failing because it was using the wrong Python interpreter and not using the site-packages modules from the snap.

I took the opportunity to add two new `ubuntu-desktop-bootstrap` commands: 
 * snap run ubuntu-desktop-bootstrap.curtin
 * snap run ubuntu-desktop-bootstrap.python

They are very useful for debugging code in the live environment.