### PR TITLE
fix: bin/curtin is a bash script, don't run it with Python

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,7 @@ apps:
   probert:
     command: bin/subiquity/bin/subiquity-cmd $SNAP/usr/bin/python3.12 $SNAP/bin/probert
   curtin:
-    command: bin/subiquity/bin/subiquity-cmd $SNAP/usr/bin/python3.12 $SNAP/bin/curtin
+    command: bin/subiquity/bin/subiquity-cmd $SNAP/bin/curtin
     environment:
       PYTHON: $SNAP/usr/bin/python3.12
       PATH: $PATH:$SNAP/bin


### PR DESCRIPTION
In commit e656e651f9d094a4c70c1d3bebe04123426e2716, I added support for ubuntu-desktop-bootstrap.curtin but made a mistake and used the wrong interpreter.

Oops!