### PR TITLE
postinst: write BirthDate to target AccountsService keyfile

### DIFF
--- a/snap/local/postinst.d/10_configure_birth_date
+++ b/snap/local/postinst.d/10_configure_birth_date
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+installer_conf=/tmp/bootstrap-postinst.conf
+
+if ! source $installer_conf 2>/dev/null || [ -z "$BirthDate" ] || [ -z "$Username" ]; then
+    exit
+fi
+
+ACCT_DIR=/target/var/lib/AccountsService/users
+ACCT_FILE="$ACCT_DIR/$Username"
+
+mkdir -p "$ACCT_DIR"
+
+if [ -f "$ACCT_FILE" ]; then
+    if grep -q '^\[User\]' "$ACCT_FILE"; then
+        sed -i "/^\[User\]/a BirthDate=$BirthDate" "$ACCT_FILE"
+    else
+        printf '\n[User]\nBirthDate=%s\n' "$BirthDate" >> "$ACCT_FILE"
+    fi
+else
+    printf '[User]\nBirthDate=%s\n' "$BirthDate" > "$ACCT_FILE"
+fi


### PR DESCRIPTION
## Summary

Add a postinst hook that writes the user's birth date to the target system's AccountsService keyfile during live installation.

## How it works

The Flutter UI writes `BirthDate=YYYY-MM-DD` to `/tmp/bootstrap-postinst.conf` (alongside `AutoLoginUser`). This hook reads both values and writes the birth date to `/target/var/lib/AccountsService/users/<username>`.

This handles the **ubuntu_bootstrap** (live installer) path. The **ubuntu_init** (first-boot OOBE) path is handled by provd's `SetBirthDate` D-Bus call in #1338.

## Motivation

Age verification legislation (California AB-1043, effective Jan 1 2027) requires OS providers to collect date of birth during account setup. See #1338 for full context.

## Integration

- #1338 — provd + Flutter UI changes (targets `main`)
- [accountsservice MR](https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/176) — `BirthDate` property + `SetBirthDate` method
- [systemd PR #40954](https://github.com/systemd/systemd/pull/40954) — `birthDate` in JSON user records
- [xdg-desktop-portal PR #1922](https://github.com/flatpak/xdg-desktop-portal/pull/1922) — portal API for age brackets