### PR TITLE
feat: ignore missing whitespace in `{{ DISTRO }}` tag in slides l10n

### DIFF
--- a/apps/ubuntu_bootstrap/lib/providers/slides_provider.dart
+++ b/apps/ubuntu_bootstrap/lib/providers/slides_provider.dart
@@ -127,8 +127,10 @@ class SlidesModel {
         content = await file.readAsString();
       }
 
-      final flavorSpecificContent =
-          content.replaceAll('{{ DISTRO }}', _flavor.displayName);
+      final flavorSpecificContent = content.replaceAll(
+        RegExp(r'{{\s*DISTRO\s*}}'),
+        _flavor.displayName,
+      );
 
       final bundledHtml = await _replaceImages(
         flavorSpecificContent,


### PR DESCRIPTION
Some translators accidentally remove the whitespace in the `{{ DISTRO }}` tag used in the translatable strings for the slideshow. Let's account for that when replacing it with the actual distro name.