### PR TITLE
fix: small UI fixes post yaru update

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_page.dart
@@ -121,7 +121,7 @@ class StoragePage extends ConsumerWidget with ProvisioningPage {
             ),
             subtitle: Text(
               lang.installationTypeAlongsideInfo(flavor.displayName),
-              style: theme.textTheme.bodyMedium!.copyWith(
+              style: theme.textTheme.bodySmall!.copyWith(
                 color: canInstallAlongside ? null : theme.disabledColor,
               ),
             ),

--- a/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
+++ b/packages/ubuntu_provision/lib/src/accessibility/accessibility_page.dart
@@ -141,8 +141,9 @@ class _AccessibilityListTile extends ConsumerWidget {
         const Divider(),
         YaruSwitchListTile(
           title: Padding(
-            padding: kWizardIndentation
-                .add(const EdgeInsets.symmetric(vertical: 8.0)),
+            padding: kWizardIndentation.add(
+              const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
+            ),
             child: Text(title),
           ),
           value: model.activeOptions.contains(id),

--- a/packages/ubuntu_wizard/lib/src/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_bar.dart
@@ -56,6 +56,7 @@ class _WizardBarState extends State<WizardBar> {
               : null,
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: widget.trailing?.withSpacing(kWizardBarSpacing) ?? [],
           ),
         ),


### PR DESCRIPTION
* made 'Next' button size match the one of the 'Back' button again
* adjusted alignment in the expandables on the a11y page
* fixed the font size of the tile subtitle for 'alongside' installs on the storage page

|Before|After|
|-|-|
|<img width="2024" height="1464" alt="Screenshot From 2026-03-17 12-48-19" src="https://github.com/user-attachments/assets/f89da1b2-ddb0-4447-ae3e-1fde02f0af3b" />|<img width="2024" height="1464" alt="Screenshot From 2026-03-17 12-47-37" src="https://github.com/user-attachments/assets/ec5f7896-52af-4aab-8d1e-0ad72abeac8b" />|
|<img width="2024" height="1464" alt="Screenshot From 2026-03-17 12-48-33" src="https://github.com/user-attachments/assets/e4da94bd-c60c-4714-ac15-f5cc679b0fee" />|<img width="2024" height="1464" alt="Screenshot From 2026-03-17 12-47-55" src="https://github.com/user-attachments/assets/47b7dbd5-33e2-4260-be1c-4e2e92f11604" />|