### PR TITLE
feat: adopt snap version from tag

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -331,7 +331,7 @@ parts:
               sed -E 's#^ubuntu-desktop-bootstrap/##' |
               sed -E 's#-[0-9]+-g([0-9a-f]+)$#-\1#'
       )
-      if [ -n $(git status --porcelain) ]; then
+      if [ -n "$(git status --porcelain)" ]; then
           version="${version}.dirty"
       fi
       craftctl set version="${version}"


### PR DESCRIPTION
This adds tag-based versioning to the snapcraft.yaml.

Since we're building multiple snaps from this repository, we'll need to use snap-specific tags. I'd propose using e.g. `ubuntu-desktop-bootstrap/26.04`. For the `ubuntu-desktop-bootstrap` snap the tag-based version after stripping the prefix should then simply be `26.04`.
For snap builds based on commits ahead of the tag, we should follow the default snapcraft behavior when using `version: git`, e.g. `26.04+git123.01234abcd` (commit `01234abcd`, 123 commits ahead of `ubuntu-desktop-bootstrap/26.04`.

To make the snap build including this change pass in the CI, I'd suggest tagging 31940d804 (corresponds to snap revision 441, [seeded on the 25.10 iso](https://www.releases.ubuntu.com/questing/ubuntu-25.10-desktop-amd64.manifest)) as `ubuntu-desktop-bootstrap/25.10`.

UDENG-9368