### PR TITLE
fix: hide TPM/FDE option when not offered by subiquity

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/guided_capabilities_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/guided_capabilities_page.dart
@@ -71,19 +71,21 @@ class GuidedCapabilitiesPage extends ConsumerWidget with ProvisioningPage {
                   groupValue: model.guidedCapability,
                   onChanged: (v) => model.guidedCapability = v!.clean(),
                 ),
-              OptionButton<GuidedCapability?>(
-                title: Text(lang.installationTypeTPM),
-                subtitle: Text(
-                  tpmOptionEnabled
-                      ? lang.installationTypeTPMInfoResolute
-                      : lang.installationTypeTPMInfoUnavailable,
+              if (tpmOptionEnabled)
+                OptionButton<GuidedCapability?>(
+                  title: Text(lang.installationTypeTPM),
+                  subtitle: Text(
+                    tpmOptionEnabled
+                        ? lang.installationTypeTPMInfoResolute
+                        : lang.installationTypeTPMInfoUnavailable,
+                  ),
+                  value: GuidedCapability.CORE_BOOT_ENCRYPTED,
+                  groupValue: model.guidedCapability?.clean(),
+                  onChanged: tpmOptionEnabled
+                      ? (v) => model.guidedCapability = v
+                      : null,
+                  isThreeLines: false,
                 ),
-                value: GuidedCapability.CORE_BOOT_ENCRYPTED,
-                groupValue: model.guidedCapability?.clean(),
-                onChanged:
-                    tpmOptionEnabled ? (v) => model.guidedCapability = v : null,
-                isThreeLines: false,
-              ),
               YaruExpandable(
                 expandButtonPosition: YaruExpandableButtonPosition.start,
                 header: Text(lang.installationTypeAdvancedLabel),
@@ -145,27 +147,6 @@ class GuidedCapabilitiesPage extends ConsumerWidget with ProvisioningPage {
           ),
         ),
       ],
-    );
-  }
-}
-
-class TpmOption extends ConsumerWidget {
-  const TpmOption({
-    required this.model,
-    super.key,
-  });
-  final StorageModel model;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final lang = UbuntuBootstrapLocalizations.of(context);
-
-    return OptionButton<GuidedCapability?>(
-      title: Text(lang.installationTypeTPM),
-      subtitle: Text(lang.installationTypeTPMInfoResolute),
-      value: GuidedCapability.CORE_BOOT_ENCRYPTED,
-      groupValue: model.guidedCapability?.clean(),
-      onChanged: (v) => model.guidedCapability = v,
     );
   }
 }


### PR DESCRIPTION
Subiquity currently only offers the `CORE_BOOT_ENCRYPTED` capability (aka TPM/FDE) when using the entire disk (`GuidedStorageTargetReformat`). If TPM/FDE is not available, it will provide error messages and actions via the new actions API - we keep the option enabled in that case and let the user proceed to the TPM action page.
When choosing to install alongside an existing partition, TPM/FDE is not offered, but we currently still display a greyed out button with a misleading subtitle. This PR removes hides the button entirely for this scenario.

P.S. I've also removed the obsolete `TpmOption` which is no longer used.