### PR TITLE
fix: ensure only allowed GuidedCapabilities are set

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/guided_capabilities_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/guided_capabilities_page.dart
@@ -1,9 +1,9 @@
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_model.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_x.dart';
 import 'package:ubuntu_bootstrap/widgets/info_badge.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 import 'package:ubuntu_utils/ubuntu_utils.dart';
@@ -149,24 +149,4 @@ class GuidedCapabilitiesPage extends ConsumerWidget with ProvisioningPage {
       ],
     );
   }
-}
-
-extension on GuidedCapability {
-  GuidedCapability clean() => switch (this) {
-// We shouldn't send CORE_BOOT_PREFER_ENCRYPTED to the server
-// See https://github.com/canonical/subiquity/blob/f759d19336c5cc33545755095fcc2aced3ef6a9f/subiquity/common/types.py#L354-L356
-        GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED =>
-          GuidedCapability.CORE_BOOT_ENCRYPTED,
-        _ => this,
-      };
-}
-
-extension on GuidedStorageTarget {
-  String? get tpmDisallowedReason => disallowed
-      .firstWhereOrNull(
-        (e) =>
-            e.capability == GuidedCapability.CORE_BOOT_ENCRYPTED ||
-            e.capability == GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
-      )
-      ?.message;
 }

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -7,6 +7,7 @@ import 'package:safe_change_notifier/safe_change_notifier.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_bootstrap/pages.dart';
 import 'package:ubuntu_bootstrap/pages/storage/storage_page.dart';
+import 'package:ubuntu_bootstrap/pages/storage/storage_x.dart';
 import 'package:ubuntu_bootstrap/services.dart';
 import 'package:ubuntu_provision/ubuntu_provision.dart';
 
@@ -266,6 +267,13 @@ class StorageModel extends SafeChangeNotifier {
       StorageTypeManual() => null,
       null => null,
     };
+
+    if (guidedTarget?.allowed
+            .map((c) => c.clean())
+            .contains(guidedCapability) ==
+        false) {
+      _storage.guidedCapability = guidedTarget?.allowed.firstOrNull;
+    }
   }
 
   String? _resolvePartitionMethod() {

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_x.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_x.dart
@@ -1,0 +1,22 @@
+import 'package:collection/collection.dart';
+import 'package:subiquity_client/subiquity_client.dart';
+
+extension GuidedCapabilityX on GuidedCapability {
+  GuidedCapability clean() => switch (this) {
+// We shouldn't send CORE_BOOT_PREFER_ENCRYPTED to the server
+// See https://github.com/canonical/subiquity/blob/f759d19336c5cc33545755095fcc2aced3ef6a9f/subiquity/common/types.py#L354-L356
+        GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED =>
+          GuidedCapability.CORE_BOOT_ENCRYPTED,
+        _ => this,
+      };
+}
+
+extension GuidedStorageTargetX on GuidedStorageTarget {
+  String? get tpmDisallowedReason => disallowed
+      .firstWhereOrNull(
+        (e) =>
+            e.capability == GuidedCapability.CORE_BOOT_ENCRYPTED ||
+            e.capability == GuidedCapability.CORE_BOOT_PREFER_ENCRYPTED,
+      )
+      ?.message;
+}

--- a/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/storage_model_test.dart
@@ -101,6 +101,7 @@ void main() {
     final storage = MockStorageService();
     when(storage.hasMultipleDisks).thenReturn(false);
     when(storage.guidedCapability).thenReturn(null);
+    when(storage.guidedTarget).thenReturn(null);
 
     final telemetry = MockTelemetryService();
     final model = StorageModel(


### PR DESCRIPTION
Currently it's possible to select a `GuidedCapability`, return to the previous page, and then select a different installation type, that doesn't support this capability (e.g. select TPM/FDE, go back, select 'Install alongside .. ').
This PR adds a check that reverts back to the first allowed capability in that case.