### PR TITLE
fix: clear `LD_LIBRARY_PATH` when running `canberra-gtk-play`

### DIFF
--- a/packages/ubuntu_provision/lib/src/services/sound_service.dart
+++ b/packages/ubuntu_provision/lib/src/services/sound_service.dart
@@ -8,7 +8,11 @@ final _log = Logger('sound_service');
 class SoundService {
   Future<void> play(String id) async {
     try {
-      final result = await Process.run('canberra-gtk-play', ['--id=$id']);
+      final result = await Process.run(
+        'canberra-gtk-play',
+        ['--id=$id'],
+        environment: {'LD_LIBRARY_PATH': ''},
+      );
       if (result.exitCode != 0) {
         _log.error(
           'Error playing sound with id: $id: process exited with ${result.exitCode}. stdout: ${result.stdout}, stderr: ${result.stderr}',


### PR DESCRIPTION
On the current daily, the startup sound isn’t played:
```
canberra-gtk-play: /snap/core24/current/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.43' not found (required by /usr/lib/x86_64-linux-gnu/libmvec.so.1)
```

That’s because glibc in the live session is newer than what’s in core24 and gtk-canberra-play mixes libraries from both sources:
```
ldd /usr/bin/canberra-gtk-play | grep libm
/usr/bin/canberra-gtk-play: /snap/core24/current/lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.43' not found (required by /usr/lib/x86_64-linux-gnu/libmvec.so.1)
	libm.so.6 => /snap/core24/current/lib/x86_64-linux-gnu/libm.so.6 (0x000077fd960d4000)
	libmount.so.1 => /snap/core24/current/lib/x86_64-linux-gnu/libmount.so.1 (0x000077fd95d33000)
	libmvec.so.1 => /usr/lib/x86_64-linux-gnu/libmvec.so.1 (0x000077fd956e8000)
	libmd.so.0 => /snap/core24/current/lib/x86_64-linux-gnu/libmd.so.0 (0x000077fd9543b000)
```

Since the installer relies on `canberra-gtk-play` from the live system, I suggest simply clearing `LD_LIBRARY_PATH`, which is set by the classic snap environment to include the libraries shipped with the snap.

UDENG-9584