### PR TITLE
fix(refresh): correctly display progress percentage

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
@@ -47,7 +47,7 @@ class RefreshView extends ConsumerWidget {
               state.progress! > 0 &&
               state.progress! < 1,
           child: Text(
-            '${(state.progress ?? 0 * 100).ceil()}%',
+            '${((state.progress ?? 0) * 100).ceil()}%',
             style: Theme.of(context).textTheme.titleLarge,
           ),
         ),

--- a/apps/ubuntu_bootstrap/test/refresh/refresh_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/refresh/refresh_page_test.dart
@@ -111,6 +111,7 @@ void main() {
     final progress = tester.widget<CircularProgressIndicator>(indicator);
     expect(progress, isNotNull);
     expect(progress.value, 0.25);
+    expect(find.text('25%'), findsOneWidget);
 
     expect(find.byType(OutlinedButton), findsNothing);
   });


### PR DESCRIPTION
This adds missing parentheses in the expression to calculate the progress percentage displayed on the refresh page.