### PR TITLE
fix: update telemetry file when selecting a `guidedCapability`

### DIFF
--- a/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_bootstrap/main.dart' as app;
@@ -79,6 +80,10 @@ void main() {
       locale: locale,
       timezone: timezone,
     );
+    await verifyTelemetryFile({
+      'Language': 'fr',
+      'PartitionMethod': 'use_device',
+    });
   });
 
   testWidgets('OEM', (tester) async {
@@ -107,6 +112,10 @@ void main() {
     await expectLater(windowClosed, completes);
 
     await verifySubiquityConfig(identity: const Identity());
+    await verifyTelemetryFile({
+      'OEM': true,
+      'PartitionMethod': 'use_device',
+    });
   });
 
   testWidgets('LVM Encrypted', (tester) async {
@@ -150,6 +159,9 @@ void main() {
       identity: identity,
       capability: GuidedCapability.LVM_LUKS,
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'use_crypto',
+    });
   });
 
   testWidgets('LVM Encrypted alongside Windows', (tester) async {
@@ -198,6 +210,9 @@ void main() {
       identity: identity,
       capability: GuidedCapability.LVM_LUKS,
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'use_crypto',
+    });
   });
 
   testWidgets('ZFS unencrypted', (tester) async {
@@ -239,6 +254,9 @@ void main() {
       identity: identity,
       capability: GuidedCapability.ZFS,
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'use_zfs',
+    });
   });
 
   testWidgets('ZFS encrypted', (tester) async {
@@ -282,6 +300,9 @@ void main() {
       identity: identity,
       capability: GuidedCapability.ZFS_LUKS_KEYSTORE,
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'use_crypto_zfs',
+    });
   });
 
   testWidgets('tpm', (tester) async {
@@ -333,6 +354,9 @@ void main() {
       identity: identity,
       capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'use_tpmfde',
+    });
   });
 
   testWidgets(
@@ -394,6 +418,9 @@ void main() {
         identity: identity,
         capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
       );
+      await verifyTelemetryFile({
+        'PartitionMethod': 'use_tpmfde',
+      });
     },
   );
 
@@ -459,6 +486,9 @@ void main() {
         identity: identity,
         capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
       );
+      await verifyTelemetryFile({
+        'PartitionMethod': 'use_tpmfde',
+      });
     },
   );
 
@@ -551,6 +581,9 @@ void main() {
         ),
       ],
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'manual',
+    });
   });
 
   // threebuntu-on-msdos has three existing ubuntu partitions:
@@ -741,6 +774,9 @@ void main() {
         ),
       ],
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'resize_use_free',
+    });
   });
 
   testWidgets('alongside windows', (tester) async {
@@ -797,6 +833,9 @@ void main() {
         ),
       ],
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'resize_use_free',
+    });
   });
 
   testWidgets('resize existing ubuntu alongside windows with bitlocker',
@@ -899,6 +938,9 @@ void main() {
         ),
       ],
     );
+    await verifyTelemetryFile({
+      'PartitionMethod': 'resize_use_free',
+    });
   });
 
   testWidgets('welcome', (tester) async {
@@ -1028,6 +1070,9 @@ Future<void> eraseInstallTest({
         );
       }
     }
+    await verifyTelemetryFile({
+      'PartitionMethod': 'replace_partition',
+    });
   }
 }
 
@@ -1147,6 +1192,17 @@ Future<void> verifySubiquityConfig({
       default:
         break;
     }
+  }
+}
+
+Future<void> verifyTelemetryFile(Map<String, dynamic> telemetry) async {
+  final exe = Platform.resolvedExecutable;
+  final path = '${p.dirname(exe)}/.${p.basename(exe)}/telemetry';
+  await expectLater(path, existsLater);
+
+  final yaml = loadYaml(File(path).readAsStringSync());
+  for (final entry in telemetry.entries) {
+    expect(yaml[entry.key], equals(entry.value));
   }
 }
 

--- a/apps/ubuntu_bootstrap/lib/app.dart
+++ b/apps/ubuntu_bootstrap/lib/app.dart
@@ -311,6 +311,9 @@ Future<void> _initInstallerApp(Endpoint endpoint) async {
   }
   final telemetry = getService<TelemetryService>();
 
+  final isOem = (await tryGetService<ConfigService>()?.provisioningMode) ==
+      ProvisioningMode.oem;
+
   final services = [
     getService<InstallerService>().init(),
     tryGetService<DesktopService>()?.inhibit() ?? Future.value(),
@@ -318,7 +321,7 @@ Future<void> _initInstallerApp(Endpoint endpoint) async {
     geo.init(),
     telemetry.init({
       'Type': 'Flutter',
-      'OEM': false,
+      'OEM': isOem,
       'Media': getService<ProductService>().getProductInfo().toString(),
     }),
   ];

--- a/apps/ubuntu_bootstrap/lib/pages/storage/guided_capabilities_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/guided_capabilities_page.dart
@@ -27,6 +27,7 @@ class GuidedCapabilitiesPage extends ConsumerWidget with ProvisioningPage {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final model = ref.watch(storageModelProvider);
+    final notifier = ref.read(storageModelProvider.notifier);
     final lang = UbuntuBootstrapLocalizations.of(context);
     final experimentalBadgeText =
         UbuntuBootstrapLocalizations.of(context).installationTypeExperimental;
@@ -39,7 +40,7 @@ class GuidedCapabilitiesPage extends ConsumerWidget with ProvisioningPage {
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
         trailing: [
-          NextWizardButton(),
+          NextWizardButton(onNext: notifier.writeTelemetry),
         ],
       ),
       children: [

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -287,6 +287,8 @@ class StorageModel extends SafeChangeNotifier {
       return 'use_lvm';
     } else if (guidedCapability == GuidedCapability.ZFS) {
       return 'use_zfs';
+    } else if (guidedCapability == GuidedCapability.ZFS_LUKS_KEYSTORE) {
+      return 'use_crypto_zfs';
     } else if (guidedCapability == GuidedCapability.LVM_LUKS) {
       return 'use_crypto';
     } else if (guidedCapability == GuidedCapability.CORE_BOOT_ENCRYPTED) {

--- a/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/storage_model.dart
@@ -253,11 +253,7 @@ class StorageModel extends SafeChangeNotifier {
 
   /// Saves the storage type selection.
   Future<void> save() async {
-    final partitionMethod = _resolvePartitionMethod();
-    if (partitionMethod != null) {
-      await _telemetry?.addMetric('PartitionMethod', partitionMethod);
-    }
-
+    await writeTelemetry();
     _storage.guidedTarget = switch (_type) {
       StorageTypeAlongside() => _firstTarget<GuidedStorageTargetResize>() ??
           _firstTarget<GuidedStorageTargetUseGap>(),
@@ -273,6 +269,13 @@ class StorageModel extends SafeChangeNotifier {
             .contains(guidedCapability) ==
         false) {
       _storage.guidedCapability = guidedTarget?.allowed.firstOrNull;
+    }
+  }
+
+  Future<void> writeTelemetry() async {
+    final partitionMethod = _resolvePartitionMethod();
+    if (partitionMethod != null) {
+      await _telemetry?.addMetric('PartitionMethod', partitionMethod);
     }
   }
 

--- a/apps/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
+++ b/apps/ubuntu_bootstrap/test/storage/test_storage.mocks.dart
@@ -227,6 +227,16 @@ class MockStorageModel extends _i1.Mock implements _i3.StorageModel {
       ) as _i8.Future<void>);
 
   @override
+  _i8.Future<void> writeTelemetry() => (super.noSuchMethod(
+        Invocation.method(
+          #writeTelemetry,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+
+  @override
   _i8.Future<void> resetStorage() => (super.noSuchMethod(
         Invocation.method(
           #resetStorage,


### PR DESCRIPTION
We recently added a new telemetry option to detect TPM/FDE installations in #1384. While testing this I noticed that we never see any telemetry regarding 'advanced features' such as TPM/FDE, ZFS, etc. It looks like this is due to #917 where the old 'advanced features' dialog was moved to a dedicated page. The call to the telemetry service is still made on the 'storage' page, so later changes to the `guidedCapability` aren’t reflected in the telemetry file.

This PR adds an additional call to the telemetry service to ensure the `PartitionMethod` is updated when the `guidedCapability` is changed. It also adds a dedicated option for encrypted ZFS and fixes the OEM status (which was always set to `false`).
I've added corresponding checks to the integration test as well.

UDENG-9638