### PR TITLE
fix: don't allow colons in user's real name

### DIFF
--- a/packages/ubuntu_provision/lib/src/identity/identity_model.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_model.dart
@@ -136,6 +136,7 @@ class IdentityModel extends SafeChangeNotifier with PropertyStreamNotifier {
   bool get isValid {
     return realName.isNotEmpty &&
         realName.length <= kMaxRealNameLength &&
+        realNameOk &&
         hostname.isNotEmpty &&
         hostname.length <= kMaxHostnameLength &&
         username.isNotEmpty &&
@@ -150,6 +151,9 @@ class IdentityModel extends SafeChangeNotifier with PropertyStreamNotifier {
   /// The server response on whether the desired username is available.
   UsernameValidation get usernameValidation => _usernameValidation.value;
   bool get usernameOk => _usernameValidation.value == UsernameValidation.OK;
+  // Colons are not allowed in useradd's COMMENT, where the user's full name is stored.
+  // https://github.com/shadow-maint/shadow/blob/827f69b864461ab6d7549762bef06ab4495d2587/src/useradd.c#L122
+  bool get realNameOk => !realName.contains(':');
 
   Future<void> validate() async {
     if (username.isNotEmpty &&

--- a/packages/ubuntu_provision/lib/src/identity/identity_widgets.dart
+++ b/packages/ubuntu_provision/lib/src/identity/identity_widgets.dart
@@ -16,6 +16,8 @@ class RealNameFormField extends ConsumerWidget {
     final realName =
         ref.watch(identityModelProvider.select((model) => model.realName));
 
+    final model = ref.read(identityModelProvider);
+
     return ValidatedFormField(
       autofocus: true,
       labelText: lang.identityRealNameLabel,
@@ -30,6 +32,10 @@ class RealNameFormField extends ConsumerWidget {
         MaxLengthValidator(
           kMaxRealNameLength,
           errorText: lang.identityRealNameTooLong,
+        ),
+        CallbackValidator(
+          (_) => model.realNameOk,
+          errorText: lang.identityInvalidRealName,
         ),
       ]),
       onChanged: (value) async {

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
@@ -76,6 +76,7 @@
   "identityRealNameLabel": "Your name",
   "identityRealNameRequired": "A name is required",
   "identityRealNameTooLong": "That name is too long.",
+  "identityInvalidRealName": "The name is invalid",
   "identityHostnameLabel": "Your computer's name",
   "identityHostnameInfo": "The name it uses when it talks to other computers.",
   "identityHostnameRequired": "A computer name is required",

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
@@ -531,6 +531,12 @@ abstract class UbuntuProvisionLocalizations {
   /// **'That name is too long.'**
   String get identityRealNameTooLong;
 
+  /// No description provided for @identityInvalidRealName.
+  ///
+  /// In en, this message translates to:
+  /// **'The name is invalid'**
+  String get identityInvalidRealName;
+
   /// No description provided for @identityHostnameLabel.
   ///
   /// In en, this message translates to:

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
@@ -163,6 +163,9 @@ class UbuntuProvisionLocalizationsAm extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
@@ -162,6 +162,9 @@ class UbuntuProvisionLocalizationsAr extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'هذا الاسم طويل جدًا.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'اسم الحاسوب';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsBe extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Гэта імя занадта доўгае.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Імя вашага камп\'ютара';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsBg extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsBn extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsBo extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsBs extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsCa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Aquest nom és massa llarg.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'El nom de l\'ordinador';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsCs extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Jméno je příliš dlouhé.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Název pro váš počítač';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsCy extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Enw eich cyfrifiadur';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsDa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Navnet er for langt.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Din computers navn';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsDe extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Dieser Name ist zu lang.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Name Ihres Computers';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsDz extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
@@ -167,6 +167,9 @@ class UbuntuProvisionLocalizationsEl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Αυτό το όνομα είναι πολύ μεγάλο.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Το όνομα του υπολογιστή σας';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsEn extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsEo extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Tiu nomo estas tro longa.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Nomo de via komputilo';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsEs extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Este nombre es demasiado largo.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'El nombre del equipo';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsEt extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'See nimi on liiga pikk.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Sinu arvuti nimi';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsEu extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Izena luzeegia da.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Ordenagailuaren izena';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsFa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'نام بیش از حد طولانی است.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'نام رایانه‌تان';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsFi extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Nimi on liian pitkä.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Tietokoneen nimi';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
@@ -167,6 +167,9 @@ class UbuntuProvisionLocalizationsFr extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Ce nom est trop long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Le nom de votre ordinateur';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsGa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Tá an t-ainm sin rófhada.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Ainm do ríomhaire';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsGl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Ese nome é demasiado longo.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'O nome do teu equipo';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsGu extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
@@ -162,6 +162,9 @@ class UbuntuProvisionLocalizationsHe extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'השם ארוך מדי.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'שם המחשב שלך';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsHi extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsHr extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsHu extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Ez a név túl hosszú.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'A számítógépének neve';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsId extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Nama itu terlalu panjang.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Nama komputer Anda';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsIs extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsIt extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Il nome è troppo lungo.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Il nome del computer';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
@@ -162,6 +162,9 @@ class UbuntuProvisionLocalizationsJa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'その名前は長すぎます。';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'コンピューターの名前';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsKa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'სახელი მეტისმეტად გრძელია.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'თქვენი კომპიუტერის სახელი';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsKk extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsKm extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsKn extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'ಆ ಹೆಸರು ತುಂಬಾ ಉದ್ದವಾಗಿದೆ.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'ನಿಮ್ಮ ಕಂಪ್ಯೂಟರ್ ಹೆಸರು';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
@@ -162,6 +162,9 @@ class UbuntuProvisionLocalizationsKo extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => '너무 긴 이름입니다.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => '컴퓨터 이름';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsKu extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsLo extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'ຊື່ນັ້ນຍາວເກີນໄປ.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'ຊື່ຄອມພິວເຕີຂອງທ່ານ';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsLt extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Šis vardas per ilgas.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Jūsų kompiuterio pavadinimas';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsLv extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsMk extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsMl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'നിങ്ങളുടെ കമ്പ്യൂട്ടറിന്റെ പേര്';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsMr extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsMy extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsNb extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Navnet er for langt.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Datamaskinens navn';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsNe extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsNl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Die naam is te lang.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'De naam van de computer';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsNn extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsOc extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Aqueste nom es tròp long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Lo nom de l’ordenador';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsPa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsPl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'To imię i nazwisko jest za długie.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Nazwa tego komputera';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsPt extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Esse nome é demasiado comprido.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Nome do seu computador';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsRo extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsRu extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Слишком длинное имя.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Имя компьютера';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsSe extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
@@ -163,6 +163,9 @@ class UbuntuProvisionLocalizationsSi extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'මෙම නම දිග වැඩියි.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'ඔබගේ පරිගණකයේ නම';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsSk extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Meno je príliš dlhé.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Názov pre váš počítač';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsSl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsSq extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
@@ -166,6 +166,9 @@ class UbuntuProvisionLocalizationsSr extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'То име је предуго.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Име вашег рачунара';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsSv extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Det namnet är för långt.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Din dators namn';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
@@ -167,6 +167,9 @@ class UbuntuProvisionLocalizationsTa extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'அந்த பெயர் மிக நீளமானது.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'உங்கள் கணினியின் பெயர்';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsTe extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsTg extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsTh extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'ชื่อนั้นยาวเกินไป';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'ชื่อคอมพิวเตอร์ของคุณ';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsTl extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
@@ -165,6 +165,9 @@ class UbuntuProvisionLocalizationsTr extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Bu isim çok uzun.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Bilgisayar adı';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsUg extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'ئىسىم بەك ئۇزۇن.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'كومپيۇتېرىڭىزنىڭ ئىسمى';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsUk extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'Це ім\'я занадто довге.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Iм\'я вашого комп\'ютера';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
@@ -164,6 +164,9 @@ class UbuntuProvisionLocalizationsVi extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => 'That name is too long.';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => 'Your computer\'s name';
 
   @override

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
@@ -162,6 +162,9 @@ class UbuntuProvisionLocalizationsZh extends UbuntuProvisionLocalizations {
   String get identityRealNameTooLong => '名字过长。';
 
   @override
+  String get identityInvalidRealName => 'The name is invalid';
+
+  @override
   String get identityHostnameLabel => '您的电脑主机名';
 
   @override

--- a/packages/ubuntu_provision/test/identity/identity_model_test.dart
+++ b/packages/ubuntu_provision/test/identity/identity_model_test.dart
@@ -389,6 +389,14 @@ void main() {
       'passwd',
       isFalse,
     );
+    testValid(
+      'real:name:with:colon',
+      'host',
+      'user',
+      'passwd',
+      'passwd',
+      isFalse,
+    );
   });
 
   test('server validation', () async {

--- a/packages/ubuntu_provision/test/identity/test_identity.dart
+++ b/packages/ubuntu_provision/test/identity/test_identity.dart
@@ -40,6 +40,7 @@ IdentityModel buildIdentityModel({
   when(model.autoLogin).thenReturn(autoLogin ?? false);
   when(model.showPassword).thenReturn(showPassword ?? false);
   when(model.usernameOk).thenReturn(true);
+  when(model.realNameOk).thenReturn(true);
   when(model.usernameValidation).thenReturn(UsernameValidation.OK);
   when(model.isConnected).thenReturn(isConnected ?? false);
   when(model.hasActiveDirectorySupport)

--- a/packages/ubuntu_provision/test/identity/test_identity.mocks.dart
+++ b/packages/ubuntu_provision/test/identity/test_identity.mocks.dart
@@ -122,6 +122,12 @@ class MockIdentityModel extends _i1.Mock implements _i2.IdentityModel {
       ) as bool);
 
   @override
+  bool get realNameOk => (super.noSuchMethod(
+        Invocation.getter(#realNameOk),
+        returnValue: false,
+      ) as bool);
+
+  @override
   bool get showPassword => (super.noSuchMethod(
         Invocation.getter(#showPassword),
         returnValue: false,


### PR DESCRIPTION
This prevent users from using a real name that includes a `:`, which is not allowed by `useradd`.

lp:2148493
UDENG-9809