### PR TITLE
feat: track subiquity from main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "subiquity"]
 	path = packages/subiquity_client/subiquity
 	url = https://github.com/canonical/subiquity.git
-	branch = ubuntu/resolute
+	branch = main


### PR DESCRIPTION
I've created a separate branch for [26.04](https://github.com/canonical/ubuntu-desktop-provision/tree/ubuntu/26.04), so we can now track subiquity's `main` branch again.