### PR TITLE
feat: add support for desktop-agnostic keyboard layout persistence

### DIFF
--- a/apps/ubuntu_bootstrap/lib/services/keyboard_service.dart
+++ b/apps/ubuntu_bootstrap/lib/services/keyboard_service.dart
@@ -68,13 +68,19 @@ class SubiquityKeyboardService implements KeyboardService {
     @visibleForTesting GSettings? inputSourceSettings,
     @visibleForTesting
     Future<ProcessResult> Function(String, List<String>)? runProcess,
+    @visibleForTesting
+    Future<void> Function(String layout, String variant)? setLocale1X11Keyboard,
   })  : _inputSourceSettings = inputSourceSettings ??
             createService<GSettings, String>('org.gnome.desktop.input-sources'),
-        _runProcess = runProcess ?? Process.run;
+        _runProcess = runProcess ?? Process.run,
+        _setLocale1X11KeyboardImpl =
+            setLocale1X11Keyboard ?? _defaultSetLocale1X11Keyboard;
 
   final SubiquityClient _subiquity;
   final GSettings _inputSourceSettings;
   final Future<ProcessResult> Function(String, List<String>) _runProcess;
+  final Future<void> Function(String layout, String variant)
+      _setLocale1X11KeyboardImpl;
   final bool liveRun;
 
   @override
@@ -91,6 +97,7 @@ class SubiquityKeyboardService implements KeyboardService {
     if (liveRun) {
       unawaited(_setXkbInputSource(setting));
       await _setGsettingsInputSource(setting);
+      await _setLocale1InputSource(setting);
     }
   }
 
@@ -110,12 +117,13 @@ class SubiquityKeyboardService implements KeyboardService {
       await _inputSourceSettings.set(
         'sources',
         DBusArray(
-            DBusSignature.struct([DBusSignature.string, DBusSignature.string]),
-            [
-              DBusStruct([const DBusString('xkb'), DBusString(xkbString)]),
-              if (nonLatinLayouts.contains(setting.layout))
-                DBusStruct([const DBusString('xkb'), DBusString('us')]),
-            ]),
+          DBusSignature.struct([DBusSignature.string, DBusSignature.string]),
+          [
+            DBusStruct([const DBusString('xkb'), DBusString(xkbString)]),
+            if (nonLatinLayouts.contains(setting.layout))
+              DBusStruct([const DBusString('xkb'), DBusString('us')]),
+          ],
+        ),
       );
     } on Exception catch (e) {
       _log.error('Failed to set input source via gsettings', e);
@@ -123,16 +131,60 @@ class SubiquityKeyboardService implements KeyboardService {
   }
 
   Future<void> _setXkbInputSource(KeyboardSetting setting) async {
-    final result = await _runProcess(
-      'setxkbmap',
-      [
-        '-layout',
-        setting.layout,
-        if (setting.variant.isNotEmpty) ...['-variant', setting.variant],
-      ],
-    );
+    final result = await _runProcess('setxkbmap', [
+      '-layout',
+      setting.layout,
+      if (setting.variant.isNotEmpty) ...['-variant', setting.variant],
+    ]);
     if (result.exitCode != 0) {
       _log.error('Failed to set input source via setxkbmap', result.stderr);
     }
+  }
+
+  Future<void> _setLocale1InputSource(KeyboardSetting setting) async {
+    // Call org.freedesktop.locale1 SetX11Keyboard() to store the layout in a
+    // desktop-agnostic way. Desktops such as KDE Plasma (with FollowLocale1=true
+    // in kxkbrc) will pick this up without needing any desktop-specific calls.
+    try {
+      final layout = nonLatinLayouts.contains(setting.layout)
+          ? '${setting.layout},us'
+          : setting.layout;
+      final variant = nonLatinLayouts.contains(setting.layout)
+          ? '${setting.variant},'
+          : setting.variant;
+      await _setLocale1X11KeyboardImpl(layout, variant);
+    } on Exception catch (e) {
+      _log.error('Failed to set input source via locale1', e);
+    }
+  }
+}
+
+Future<void> _defaultSetLocale1X11Keyboard(
+  String layout,
+  String variant,
+) async {
+  final client = DBusClient.system();
+  try {
+    final locale1 = DBusRemoteObject(
+      client,
+      name: 'org.freedesktop.locale1',
+      path: DBusObjectPath('/org/freedesktop/locale1'),
+    );
+    final args = [
+      DBusString(layout), // x11Layout
+      const DBusString(''), // x11Model
+      DBusString(variant), // x11Variant
+      const DBusString(''), // x11Options
+      const DBusBoolean(false), // convert (do not propagate to vconsole)
+      const DBusBoolean(false), // interactive (no polkit prompt)
+    ];
+    await locale1.callMethod(
+      'org.freedesktop.locale1',
+      'SetX11Keyboard',
+      args,
+      replySignature: DBusSignature(''),
+    );
+  } finally {
+    await client.close();
   }
 }

--- a/apps/ubuntu_bootstrap/lib/services/keyboard_service.dart
+++ b/apps/ubuntu_bootstrap/lib/services/keyboard_service.dart
@@ -176,7 +176,7 @@ Future<void> _defaultSetLocale1X11Keyboard(
       DBusString(variant), // x11Variant
       const DBusString(''), // x11Options
       const DBusBoolean(false), // convert (do not propagate to vconsole)
-      const DBusBoolean(false), // interactive (no polkit prompt)
+      const DBusBoolean(true), // interactive (allow polkit agent prompt)
     ];
     await locale1.callMethod(
       'org.freedesktop.locale1',

--- a/apps/ubuntu_bootstrap/test/services/keyboard_service_test.dart
+++ b/apps/ubuntu_bootstrap/test/services/keyboard_service_test.dart
@@ -12,14 +12,19 @@ import '../test_utils.dart';
 void main() {
   late MockGSettings inputSourceSettings;
   late MockProcess mockProcess;
+  late MockLocale1 mockLocale1;
 
   setUp(() {
     inputSourceSettings = MockGSettings();
     when(inputSourceSettings.set(any, any)).thenAnswer((_) async {});
 
     mockProcess = MockProcess();
-    when(mockProcess.run(any, any))
-        .thenAnswer((_) async => ProcessResult(0, 0, '', ''));
+    when(
+      mockProcess.run(any, any),
+    ).thenAnswer((_) async => ProcessResult(0, 0, '', ''));
+
+    mockLocale1 = MockLocale1();
+    when(mockLocale1.setX11Keyboard(any, any)).thenAnswer((_) async {});
   });
 
   test('get keyboard', () async {
@@ -30,6 +35,7 @@ void main() {
       client,
       inputSourceSettings: inputSourceSettings,
       runProcess: mockProcess.run,
+      setLocale1X11Keyboard: mockLocale1.setX11Keyboard,
     );
     expect(await service.getKeyboard(), equals(keyboardSetup));
 
@@ -44,6 +50,7 @@ void main() {
       client,
       inputSourceSettings: inputSourceSettings,
       runProcess: mockProcess.run,
+      setLocale1X11Keyboard: mockLocale1.setX11Keyboard,
     );
     await service.setKeyboard(keyboardSetup.setting);
 
@@ -52,19 +59,22 @@ void main() {
 
   test('set input source', () async {
     final client = MockSubiquityClient();
-    when(client.setInputSource(keyboardSetup.setting, user: 'ubuntu'))
-        .thenAnswer((_) async {});
+    when(
+      client.setInputSource(keyboardSetup.setting, user: 'ubuntu'),
+    ).thenAnswer((_) async {});
 
     final service = SubiquityKeyboardService(
       client,
       inputSourceSettings: inputSourceSettings,
       runProcess: mockProcess.run,
+      setLocale1X11Keyboard: mockLocale1.setX11Keyboard,
       liveRun: true,
     );
     await service.setInputSource(keyboardSetup.setting, user: 'ubuntu');
 
-    verify(client.setInputSource(keyboardSetup.setting, user: 'ubuntu'))
-        .called(1);
+    verify(
+      client.setInputSource(keyboardSetup.setting, user: 'ubuntu'),
+    ).called(1);
 
     verify(
       inputSourceSettings.set(
@@ -82,11 +92,11 @@ void main() {
     ).called(1);
 
     verify(
-      mockProcess.run(
-        'setxkbmap',
-        ['-layout', 'us', '-variant', 'altgr-intl'],
-      ),
+      mockProcess.run('setxkbmap', ['-layout', 'us', '-variant', 'altgr-intl']),
     ).called(1);
+
+    // locale1 is called for desktop-agnostic persistence (e.g. KDE Plasma)
+    verify(mockLocale1.setX11Keyboard('us', 'altgr-intl')).called(1);
   });
 
   test('set input source (non-latin)', () async {
@@ -96,9 +106,7 @@ void main() {
         KeyboardLayout(
           code: 'us',
           name: 'English (US)',
-          variants: [
-            KeyboardVariant(code: '', name: 'English (US)'),
-          ],
+          variants: [KeyboardVariant(code: '', name: 'English (US)')],
         ),
         KeyboardLayout(
           code: 'af',
@@ -108,19 +116,22 @@ void main() {
       ],
     );
     final client = MockSubiquityClient();
-    when(client.setInputSource(nonLatinKeyboardSetup.setting, user: 'ubuntu'))
-        .thenAnswer((_) async {});
+    when(
+      client.setInputSource(nonLatinKeyboardSetup.setting, user: 'ubuntu'),
+    ).thenAnswer((_) async {});
 
     final service = SubiquityKeyboardService(
       client,
       inputSourceSettings: inputSourceSettings,
       runProcess: mockProcess.run,
+      setLocale1X11Keyboard: mockLocale1.setX11Keyboard,
       liveRun: true,
     );
     await service.setInputSource(nonLatinKeyboardSetup.setting, user: 'ubuntu');
 
-    verify(client.setInputSource(nonLatinKeyboardSetup.setting, user: 'ubuntu'))
-        .called(1);
+    verify(
+      client.setInputSource(nonLatinKeyboardSetup.setting, user: 'ubuntu'),
+    ).called(1);
 
     verify(
       inputSourceSettings.set(
@@ -128,25 +139,17 @@ void main() {
         DBusArray(
           DBusSignature.struct([DBusSignature.string, DBusSignature.string]),
           [
-            DBusStruct([
-              const DBusString('xkb'),
-              const DBusString('af'),
-            ]),
-            DBusStruct([
-              const DBusString('xkb'),
-              const DBusString('us'),
-            ]),
+            DBusStruct([const DBusString('xkb'), const DBusString('af')]),
+            DBusStruct([const DBusString('xkb'), const DBusString('us')]),
           ],
         ),
       ),
     ).called(1);
 
-    verify(
-      mockProcess.run(
-        'setxkbmap',
-        ['-layout', 'af'],
-      ),
-    ).called(1);
+    verify(mockProcess.run('setxkbmap', ['-layout', 'af'])).called(1);
+
+    // Non-latin layouts get a US fallback added in the locale1 call too
+    verify(mockLocale1.setX11Keyboard('af,us', ',')).called(1);
   });
 
   test('get keyboard step', () async {
@@ -159,6 +162,7 @@ void main() {
       client,
       inputSourceSettings: inputSourceSettings,
       runProcess: mockProcess.run,
+      setLocale1X11Keyboard: mockLocale1.setX11Keyboard,
     );
     await service.getKeyboardStep('1');
 
@@ -177,4 +181,17 @@ class MockProcess extends Mock implements _Process {
         Invocation.method(#run, [executable, arguments]),
         returnValue: Future.value(ProcessResult(0, 0, '', '')),
       ) as Future<ProcessResult>;
+}
+
+abstract class _Locale1 {
+  Future<void> setX11Keyboard(String? layout, String? variant);
+}
+
+class MockLocale1 extends Mock implements _Locale1 {
+  @override
+  Future<void> setX11Keyboard(String? layout, String? variant) =>
+      super.noSuchMethod(
+        Invocation.method(#setX11Keyboard, [layout, variant]),
+        returnValue: Future<void>.value(),
+      ) as Future<void>;
 }


### PR DESCRIPTION
As ubuntu-desktop-bootstrap was built to be used by all Ubuntu flavors, we need to make sure we're not using too many GNOME-specific idioms. Otherwise desktops, such as KDE Plasma, miss out on certain features like setting the keyboard layout. Currently, this is completely missed when one uses this installer on Ubuntu Studio.

This pull request makes the keyboard layout setting more DE-agnostic.