### PR TITLE
fix: restrict autoinstall URL input to a single line

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_direct_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/autoinstall/autoinstall_direct_page.dart
@@ -44,7 +44,7 @@ class AutoinstallDirectPage extends ConsumerWidget with ProvisioningPage {
           enabled: directModel.localPath == null,
           initialValue: directModel.url,
           onChanged: notifier.setUrl,
-          maxLines: null,
+          maxLines: 1,
           autovalidateMode: AutovalidateMode.onUserInteraction,
           validator: (_) => directModel.error != null ? '' : null,
         ),

--- a/apps/ubuntu_bootstrap/test/autoinstall/autoinstall_direct_page_test.dart
+++ b/apps/ubuntu_bootstrap/test/autoinstall/autoinstall_direct_page_test.dart
@@ -27,6 +27,15 @@ void main() {
             ),
         parsedUri: null,
       ),
+      (
+        name: 'url with newline',
+        url: 'https://example.com/autoinstall.yaml\n',
+        expectedError: (UbuntuBootstrapLocalizations l10n) => (
+              l10n.autoinstallDirectErrorInvalidUrlTitle,
+              l10n.autoinstallDirectErrorInvalidUrlBody,
+            ),
+        parsedUri: null,
+      ),
     ]) {
       testWidgets(testCase.name, (tester) async {
         final mockService = registerMockAutoinstallService();


### PR DESCRIPTION
Fixes #1428

The autoinstall URL TextFormField had maxLines: null, which allowed newlines to be typed or pasted into the field. So I have set maxlines: 1 since url cannot contain line break. I have also added a test case for this.