### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,9 +2,6 @@ name: UI bug report for Ubuntu Desktop Provision
 description: Report an issue to help the development
 labels:
   - bug
-assignees:
-  - d-loose
-  - matthew-hagemann
 body:
 - type: markdown
   attributes:
@@ -15,7 +12,7 @@ body:
   attributes:
     label: Is there an existing issue for this?
     description: |
-      Please check whether an issue already exists for this feature: https://github.com/canonical/ubuntu-desktop-provision/issues.
+      Please check whether an issue already exists for this bug: https://github.com/canonical/ubuntu-desktop-provision/issues.
     options:
     - label: I have searched the existing issues and found none matching what I'm reporting.
       required: true
@@ -44,25 +41,10 @@ body:
       A clear and concise description of what you expected to happen.
   validations:
     required: false
-- type: dropdown
+- type: input
   attributes:
     label: Ubuntu release
-    description: What version of our Ubuntu are you running?
-    options:
-      - '24.10'
-      - 24.04 LTS
-      - Other (specify in the last field)
-  validations:
-    required: false
-- type: dropdown
-  attributes:
-    label: What architecture are you using?
-    multiple: false
-    options:
-      - amd64
-      - arm64
-      - Other (specify in the last field)
-      - I don't know
+    description: What version of Ubuntu are you running? E.g. '26.04 LTS'. You can find it in Settings > About, or by running `lsb_release -d` in the terminal.
   validations:
     required: false
 - type: textarea
@@ -70,7 +52,7 @@ body:
     label: System info
     description: |
       Please run this command in your terminal:
-      ```uname -rv && snap info ubuntu-desktop-bootstrap snapd```
+      ```uname -rvm && snap info ubuntu-desktop-bootstrap snapd```
       and paste the output here. It will give us information about your system such as the kernel version and the versions of the relevant packages.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,9 +2,6 @@ name: Feature request
 description: Suggest an idea for Ubuntu Desktop Provision
 labels:
   - enhancement
-assignees:
-  - d-loose
-  - matthew-hagemann
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
- Remove auto-assignees from all templates
- Fix duplicate-check description: 'for this feature' → 'for this bug' in the bug report
- Replace the Ubuntu release dropdown with a free-text input field, updated with a helpful description and example
- Remove the architecture dropdown (covered by the System info command output)

UDENG-10151