### PR TITLE
fix(i18n): remove hardcoded colon from confirm page summary

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -183,7 +183,7 @@ class _SummarySection extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(child: Text('${entry.key}: ')),
+                  Expanded(child: Text(entry.key)),
                   Expanded(child: entry.value),
                 ],
               ),


### PR DESCRIPTION
Removes the hardcoded colon and space from the summary section keys to prevent translation and formatting issues in certain locales.

Fixes #1417