### PR TITLE
feat: announce current wizard step to screen readers

### DIFF
--- a/apps/ubuntu_bootstrap/lib/app.dart
+++ b/apps/ubuntu_bootstrap/lib/app.dart
@@ -290,7 +290,7 @@ class _InstallerApp extends ConsumerWidget {
             // so screen readers announce the current step.
             final l10n = UbuntuBootstrapLocalizations.of(context);
             WizardBar.defaultStepSemanticsLabel = l10n.stepIndicatorLabel;
-            
+
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const LoadingPage();
             } else if (snapshot.hasError) {

--- a/apps/ubuntu_bootstrap/lib/app.dart
+++ b/apps/ubuntu_bootstrap/lib/app.dart
@@ -283,20 +283,27 @@ class _InstallerApp extends ConsumerWidget {
           rootBundle,
           package: 'ubuntu_bootstrap',
         ),
-        child: FutureBuilder<void>(
-          future: init,
-          builder: (context, snapshot) {
+        child: Builder(
+          builder: (context) {
             // Provide a localized semantic label for the step indicator
             // so screen readers announce the current step.
             final l10n = UbuntuBootstrapLocalizations.of(context);
-            WizardBar.defaultStepSemanticsLabel = l10n.stepIndicatorLabel;
-
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const LoadingPage();
-            } else if (snapshot.hasError) {
-              return const ErrorPage(allowRestart: false);
-            }
-            return InstallerWizard(key: ValueKey(ref.watch(restartProvider)));
+            return WizardBarTheme(
+              stepSemanticsLabel: l10n.stepIndicatorLabel,
+              child: FutureBuilder<void>(
+                future: init,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const LoadingPage();
+                  } else if (snapshot.hasError) {
+                    return const ErrorPage(allowRestart: false);
+                  }
+                  return InstallerWizard(
+                    key: ValueKey(ref.watch(restartProvider)),
+                  );
+                },
+              ),
+            );
           },
         ),
       ),

--- a/apps/ubuntu_bootstrap/lib/app.dart
+++ b/apps/ubuntu_bootstrap/lib/app.dart
@@ -286,6 +286,11 @@ class _InstallerApp extends ConsumerWidget {
         child: FutureBuilder<void>(
           future: init,
           builder: (context, snapshot) {
+            // Provide a localized semantic label for the step indicator
+            // so screen readers announce the current step.
+            final l10n = UbuntuBootstrapLocalizations.of(context);
+            WizardBar.defaultStepSemanticsLabel = l10n.stepIndicatorLabel;
+            
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const LoadingPage();
             } else if (snapshot.hasError) {

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -1114,5 +1114,16 @@
   "tpmActionFixActionCaveatRetry": "Then you will need to start the installation again.",
   "tpmActionErrorTitle": "This solution failed",
   "tpmActionErrorDescription": "Try a different solution or contact IT support.",
-  "manualPartitioningWarningBody": "Try something else. You may also <a href=\"\">send an error report</a>."
+  "manualPartitioningWarningBody": "Try something else. You may also <a href=\"\">send an error report</a>.",
+  "stepIndicatorLabel": "Step {CURRENT_STEP} of {TOTAL_STEPS}",
+  "@stepIndicatorLabel": {
+    "placeholders": {
+      "CURRENT_STEP": {
+        "type": "int"
+      },
+      "TOTAL_STEPS": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -2925,6 +2925,12 @@ abstract class UbuntuBootstrapLocalizations {
   /// In en, this message translates to:
   /// **'Try something else. You may also <a href=\"\">send an error report</a>.'**
   String get manualPartitioningWarningBody;
+
+  /// No description provided for @stepIndicatorLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Step {CURRENT_STEP} of {TOTAL_STEPS}'**
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS);
 }
 
 class _UbuntuBootstrapLocalizationsDelegate

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -1669,4 +1669,9 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -1673,4 +1673,9 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -1669,4 +1669,9 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -1668,4 +1668,9 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -1687,4 +1687,9 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -1682,4 +1682,9 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Zkuste něco jiného. Je také možné <a href=\"\">odeslat hlášení o chybě</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -1671,4 +1671,9 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -1668,4 +1668,9 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -1698,4 +1698,9 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Versuchen Sie etwas anderes. Sie können auch einen <a href=\"\">Fehlerbericht senden</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -1700,4 +1700,9 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Δοκιμάστε κάτι άλλο. Μπορείτε επίσης να <a href=\"\">στείλετε μια αναφορά σφάλματος</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -1683,4 +1683,9 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Provu ion alian. Vi ankaŭ rajtas <a href=\"\">raporti la eraron</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -1687,4 +1687,9 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Intente algo más. Puede además <a href=\"\">enviar un informe de error</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -1688,4 +1688,9 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Palun proovi mõnda muud võimalust. Lisaks võid <a href=\"\">meile saata veateate</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -1683,4 +1683,9 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Probatu beste zerbait. Horrez gain, <a href=\"\">errore-txosten bat bidal</a> dezakezu.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -1665,4 +1665,9 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -1677,4 +1677,9 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Kokeile jotain muuta. Voit myös <a href=\"\">lähettää virheraportin</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -1693,4 +1693,9 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Essayez autre chose. Vous pouvez également <a href=\"\">envoyer un rapport d’erreur</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -1687,4 +1687,9 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Bain triail as rud éigin eile. Féadfaidh tú <a href=\"\">tuairisc earráide a sheoladh</a> freisin.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -1690,4 +1690,9 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Proba con outra cousa. Tamén podes <a href=\"\">enviar un informe de erros</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -1653,4 +1653,9 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'עדיף לנסות משהו אחר. אפשר גם <a href=\"\">לדווח על שגיאה</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -1690,4 +1690,9 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Próbáljon valami mást. <a href=\"\">Küldhet hibajelentést is</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -1678,4 +1678,9 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Coba yang lain. Anda juga dapat <a href=\"\">mengirim laporan kesalahan</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -1685,4 +1685,9 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -1623,4 +1623,9 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -1683,4 +1683,9 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -1684,4 +1684,9 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -1639,4 +1639,9 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -1671,4 +1671,9 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'ລອງວິທີອື່ນເບິ່ງ. ທ່ານຍັງສາມາດ <a href=\"\">ສົ່ງລາຍງານຂໍ້ຜິດພາດ</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -1674,4 +1674,9 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -1674,4 +1674,9 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -1673,4 +1673,9 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -1685,4 +1685,9 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -1689,4 +1689,9 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Ensajatz quicòm mai. Podètz tanben <a href=\"\">enviar un rapòrt d’error</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -1671,4 +1671,9 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -1684,4 +1684,9 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Wypróbuj coś innego. Możesz również <a href=\"\">wysłać raport o błędzie</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -1681,6 +1681,11 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -1681,4 +1681,9 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Попробуйте что-нибудь еще. Вы также можете <a href=\"\">отправить отчет об ошибке</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -1664,4 +1664,9 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -1675,4 +1675,9 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Skúste niečo iné. Môžete tiež <a href=\"\">odoslať chybové hlásenie</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -1671,4 +1671,9 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -1673,4 +1673,9 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -1675,4 +1675,9 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Prova någonting annat. Du kan också <a href=\"\">skicka en felrapport</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -1691,4 +1691,9 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'வேறு ஏதாவது முயற்சிக்கவும். நீங்கள் <a href=\"\">ஒரு பிழை அறிக்கையையும் அனுப்பலாம்</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -1675,4 +1675,9 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -1681,4 +1681,9 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'باشقىنى سىناڭ. يەنە <a href=\"\">خاتالىق دوكلاتى يوللا</a>يالايسىز.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -1685,4 +1685,9 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Спробуйте щось інше. Ви також можете <a href=\"\">надіслати звіт про помилку</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -1670,4 +1670,9 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -1595,6 +1595,11 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   @override
   String get manualPartitioningWarningBody =>
       'Try something else. You may also <a href=\"\">send an error report</a>.';
+
+  @override
+  String stepIndicatorLabel(int CURRENT_STEP, int TOTAL_STEPS) {
+    return 'Step $CURRENT_STEP of $TOTAL_STEPS';
+  }
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).

--- a/packages/ubuntu_wizard/lib/src/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_bar.dart
@@ -7,6 +7,41 @@ import 'package:yaru/yaru.dart';
 /// The spacing between Continue and Back buttons.
 const kWizardBarSpacing = 8.0;
 
+/// Scopes a default step-semantics-label builder to all descendant
+/// [WizardBar] widgets that do not provide their own
+/// [WizardBar.stepSemanticsLabel].
+///
+/// Place this above the navigator (or any common ancestor of all [WizardBar]
+/// widgets) to apply a localized label without modifying each call site:
+/// ```dart
+/// WizardBarTheme(
+///   stepSemanticsLabel: (step, total) =>
+///       l10n.stepIndicatorLabel(step, total),
+///   child: ...,
+/// )
+/// ```
+class WizardBarTheme extends InheritedWidget {
+  const WizardBarTheme({
+    super.key,
+    required this.stepSemanticsLabel,
+    required super.child,
+  });
+
+  /// Builder that returns a semantic label for the step indicator.
+  ///
+  /// Applied to all descendant [WizardBar] widgets that have no per-widget
+  /// [WizardBar.stepSemanticsLabel] set.
+  final String? Function(int currentStep, int totalSteps) stepSemanticsLabel;
+
+  /// Returns the nearest [WizardBarTheme] ancestor, or `null` if none exists.
+  static WizardBarTheme? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<WizardBarTheme>();
+
+  @override
+  bool updateShouldNotify(WizardBarTheme oldWidget) =>
+      stepSemanticsLabel != oldWidget.stepSemanticsLabel;
+}
+
 class WizardBar extends StatefulWidget {
   const WizardBar({
     super.key,
@@ -27,24 +62,11 @@ class WizardBar extends StatefulWidget {
 
   /// Builder that returns a semantic label for the step indicator.
   ///
-  /// When provided, the step indicator is wrapped in a [Semantics] widget
-  /// with this label, communicating the current step to screen readers.
-  /// For example: `(currentStep, totalSteps) => 'Step $currentStep of $totalSteps'`.
+  /// When provided, this takes precedence over any [WizardBarTheme] ancestor.
+  /// Return `null` to explicitly suppress the semantics label for this bar.
   ///
-  /// If `null`, falls back to the static [defaultStepSemanticsLabel].
+  /// If omitted (`null`), falls back to the nearest [WizardBarTheme] ancestor.
   final String? Function(int currentStep, int totalSteps)? stepSemanticsLabel;
-
-  /// Global default builder for step semantic labels.
-  ///
-  /// Set this once at app startup with a localized string to apply
-  /// semantics to all [WizardBar] instances without modifying each call site:
-  /// ```dart
-  /// final l10n = UbuntuBootstrapLocalizations.of(context);
-  /// WizardBar.defaultStepSemanticsLabel = (step, total) =>
-  ///     l10n.stepIndicatorLabel(step, total);
-  /// ```
-  static String? Function(int currentStep, int totalSteps)?
-      defaultStepSemanticsLabel;
 
   @override
   State<WizardBar> createState() => _WizardBarState();
@@ -62,19 +84,23 @@ class _WizardBarState extends State<WizardBar> {
       layoutDelegate: YaruPageIndicatorSteppedDelegate(baseItemSpacing: 8),
     );
 
-    // Steps are 0-indexed internally; convert to 1-based for screen readers.
-    final label = widget.stepSemanticsLabel
-            ?.call(currentStep + 1, totalSteps) ??
-        WizardBar.defaultStepSemanticsLabel?.call(currentStep + 1, totalSteps);
+    // If a per-widget builder is provided, use it exclusively (even if it
+    // returns null to suppress the label). Otherwise fall back to the
+    // inherited WizardBarTheme.
+    final String? label;
+    if (widget.stepSemanticsLabel != null) {
+      // Steps are 0-indexed internally; convert to 1-based for screen readers.
+      label = widget.stepSemanticsLabel!.call(currentStep + 1, totalSteps);
+    } else {
+      label = WizardBarTheme.maybeOf(context)
+          ?.stepSemanticsLabel
+          .call(currentStep + 1, totalSteps);
+    }
     if (label == null) return indicator;
 
-    return Focus(
-      canRequestFocus: true,
-      descendantsAreFocusable: false,
-      child: Semantics(
-        label: label,
-        child: ExcludeSemantics(child: indicator),
-      ),
+    return Semantics(
+      label: label,
+      child: ExcludeSemantics(child: indicator),
     );
   }
 

--- a/packages/ubuntu_wizard/lib/src/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_bar.dart
@@ -59,15 +59,13 @@ class _WizardBarState extends State<WizardBar> {
       length: totalSteps,
       itemSizeBuilder: (index, selectedIndex, length) =>
           Size.square(index == selectedIndex ? 12.0 : 8.0),
-      layoutDelegate:
-          YaruPageIndicatorSteppedDelegate(baseItemSpacing: 8),
+      layoutDelegate: YaruPageIndicatorSteppedDelegate(baseItemSpacing: 8),
     );
 
     // Steps are 0-indexed internally; convert to 1-based for screen readers.
-    final label =
-        widget.stepSemanticsLabel?.call(currentStep + 1, totalSteps) ??
-            WizardBar.defaultStepSemanticsLabel
-                ?.call(currentStep + 1, totalSteps);
+    final label = widget.stepSemanticsLabel
+            ?.call(currentStep + 1, totalSteps) ??
+        WizardBar.defaultStepSemanticsLabel?.call(currentStep + 1, totalSteps);
     if (label == null) return indicator;
 
     return Focus(

--- a/packages/ubuntu_wizard/lib/src/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_bar.dart
@@ -18,17 +18,68 @@ class WizardBar extends StatefulWidget {
       kYaruPagePadding,
       kYaruPagePadding,
     ),
+    this.stepSemanticsLabel,
   });
 
   final Widget? leading;
   final List<Widget>? trailing;
   final EdgeInsetsGeometry padding;
 
+  /// Builder that returns a semantic label for the step indicator.
+  ///
+  /// When provided, the step indicator is wrapped in a [Semantics] widget
+  /// with this label, communicating the current step to screen readers.
+  /// For example: `(currentStep, totalSteps) => 'Step $currentStep of $totalSteps'`.
+  ///
+  /// If `null`, falls back to the static [defaultStepSemanticsLabel].
+  final String? Function(int currentStep, int totalSteps)? stepSemanticsLabel;
+
+  /// Global default builder for step semantic labels.
+  ///
+  /// Set this once at app startup with a localized string to apply
+  /// semantics to all [WizardBar] instances without modifying each call site:
+  /// ```dart
+  /// final l10n = UbuntuBootstrapLocalizations.of(context);
+  /// WizardBar.defaultStepSemanticsLabel = (step, total) =>
+  ///     l10n.stepIndicatorLabel(step, total);
+  /// ```
+  static String? Function(int currentStep, int totalSteps)?
+      defaultStepSemanticsLabel;
+
   @override
   State<WizardBar> createState() => _WizardBarState();
 }
 
 class _WizardBarState extends State<WizardBar> {
+  Widget? _buildPageIndicator(int? currentStep, int? totalSteps) {
+    if (currentStep == null || totalSteps == null) return null;
+
+    final indicator = YaruPageIndicator.builder(
+      page: currentStep,
+      length: totalSteps,
+      itemSizeBuilder: (index, selectedIndex, length) =>
+          Size.square(index == selectedIndex ? 12.0 : 8.0),
+      layoutDelegate:
+          YaruPageIndicatorSteppedDelegate(baseItemSpacing: 8),
+    );
+
+    // Steps are 0-indexed internally; convert to 1-based for screen readers.
+    final label =
+        widget.stepSemanticsLabel?.call(currentStep + 1, totalSteps) ??
+            WizardBar.defaultStepSemanticsLabel
+                ?.call(currentStep + 1, totalSteps);
+    if (label == null) return indicator;
+
+    return Focus(
+      canRequestFocus: true,
+      descendantsAreFocusable: false,
+      child: Semantics(
+        label: label,
+        child: ExcludeSemantics(child: indicator),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final wizardScope = Wizard.maybeOf(context);
@@ -44,16 +95,7 @@ class _WizardBarState extends State<WizardBar> {
         constraints: BoxConstraints(maxHeight: kPushButtonSize.height),
         child: NavigationToolbar(
           leading: widget.leading,
-          middle: currentStep != null && totalSteps != null
-              ? YaruPageIndicator.builder(
-                  page: currentStep,
-                  length: totalSteps,
-                  itemSizeBuilder: (index, selectedIndex, length) =>
-                      Size.square(index == selectedIndex ? 12.0 : 8.0),
-                  layoutDelegate:
-                      YaruPageIndicatorSteppedDelegate(baseItemSpacing: 8),
-                )
-              : null,
+          middle: _buildPageIndicator(currentStep, totalSteps),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/ubuntu_wizard/lib/src/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_bar.dart
@@ -22,9 +22,9 @@ const kWizardBarSpacing = 8.0;
 /// ```
 class WizardBarTheme extends InheritedWidget {
   const WizardBarTheme({
-    super.key,
     required this.stepSemanticsLabel,
     required super.child,
+    super.key,
   });
 
   /// Builder that returns a semantic label for the step indicator.
@@ -99,6 +99,7 @@ class _WizardBarState extends State<WizardBar> {
     if (label == null) return indicator;
 
     return Semantics(
+      key: const ValueKey('wizard-step-indicator'),
       label: label,
       child: ExcludeSemantics(child: indicator),
     );

--- a/packages/ubuntu_wizard/lib/src/wizard_bar.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_bar.dart
@@ -98,10 +98,14 @@ class _WizardBarState extends State<WizardBar> {
     }
     if (label == null) return indicator;
 
-    return Semantics(
-      key: const ValueKey('wizard-step-indicator'),
-      label: label,
-      child: ExcludeSemantics(child: indicator),
+    return Focus(
+      canRequestFocus: true,
+      descendantsAreFocusable: false,
+      child: Semantics(
+        key: const ValueKey('wizard-step-indicator'),
+        label: label,
+        child: ExcludeSemantics(child: indicator),
+      ),
     );
   }
 

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -498,10 +498,22 @@ void main() {
 
     // The page indicator is wrapped in ExcludeSemantics so individual dots
     // are hidden from assistive technology.
-    expect(find.byType(ExcludeSemantics), findsOneWidget);
+    final semanticsWidget = find.byKey(const ValueKey('wizard-step-indicator'));
+    expect(
+      find.descendant(
+        of: semanticsWidget,
+        matching: find.byType(ExcludeSemantics),
+      ),
+      findsOneWidget,
+    );
 
-    // The immediate parent of ExcludeSemantics must be Semantics, not Focus.
-    final excludeElement = tester.element(find.byType(ExcludeSemantics));
+    // The immediate parent of ExcludeSemantics must be Semantics.
+    final excludeElement = tester.element(
+      find.descendant(
+        of: semanticsWidget,
+        matching: find.byType(ExcludeSemantics),
+      ),
+    );
     Widget? immediateParentWidget;
     excludeElement.visitAncestorElements((element) {
       immediateParentWidget = element.widget;
@@ -545,11 +557,14 @@ void main() {
 
     // No semantics label should be present.
     expect(
-      find.bySemanticsLabel(RegExp(r'Should not appear')),
+      find.bySemanticsLabel(RegExp('Should not appear')),
       findsNothing,
     );
     // ExcludeSemantics is not added when there is no label.
-    expect(find.byType(ExcludeSemantics), findsNothing);
+    expect(
+      find.byKey(const ValueKey('wizard-step-indicator')),
+      findsNothing,
+    );
 
     handle.dispose();
   });
@@ -584,7 +599,7 @@ void main() {
 
     expect(find.bySemanticsLabel('Override 3/5'), findsOneWidget);
     expect(
-      find.bySemanticsLabel(RegExp(r'Inherited')),
+      find.bySemanticsLabel(RegExp('Inherited')),
       findsNothing,
     );
 

--- a/packages/ubuntu_wizard/test/wizard_page_test.dart
+++ b/packages/ubuntu_wizard/test/wizard_page_test.dart
@@ -415,6 +415,182 @@ void main() {
     );
   });
 
+  testWidgets('step semantics label - per-widget builder (1-based)',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Wizard(
+          userData: const WizardData(totalSteps: 5),
+          routes: {
+            '/foo': WizardRoute(
+              builder: (_) => WizardPage(
+                bottomBar: WizardBar(
+                  stepSemanticsLabel: (step, total) => 'Step $step of $total',
+                ),
+              ),
+              userData: const WizardRouteData(step: 0),
+            ),
+          },
+          initialRoute: '/foo',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 0-indexed step 0 should be announced as step 1.
+    expect(find.bySemanticsLabel('Step 1 of 5'), findsOneWidget);
+
+    handle.dispose();
+  });
+
+  testWidgets('step semantics label - WizardBarTheme fallback', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardBarTheme(
+          stepSemanticsLabel: (step, total) => 'Inherited $step/$total',
+          child: Wizard(
+            userData: const WizardData(totalSteps: 3),
+            routes: {
+              '/bar': WizardRoute(
+                builder: (_) => const WizardPage(bottomBar: WizardBar()),
+                userData: const WizardRouteData(step: 1),
+              ),
+            },
+            initialRoute: '/bar',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Step 1 (0-indexed) should be announced as step 2.
+    expect(find.bySemanticsLabel('Inherited 2/3'), findsOneWidget);
+
+    handle.dispose();
+  });
+
+  testWidgets('step semantics label - child dot semantics excluded',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardBarTheme(
+          stepSemanticsLabel: (step, total) => 'Step $step of $total',
+          child: Wizard(
+            userData: const WizardData(totalSteps: 3),
+            routes: {
+              '/baz': WizardRoute(
+                builder: (_) => const WizardPage(bottomBar: WizardBar()),
+                userData: const WizardRouteData(step: 0),
+              ),
+            },
+            initialRoute: '/baz',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The page indicator is wrapped in ExcludeSemantics so individual dots
+    // are hidden from assistive technology.
+    expect(find.byType(ExcludeSemantics), findsOneWidget);
+
+    // The immediate parent of ExcludeSemantics must be Semantics, not Focus.
+    final excludeElement = tester.element(find.byType(ExcludeSemantics));
+    Widget? immediateParentWidget;
+    excludeElement.visitAncestorElements((element) {
+      immediateParentWidget = element.widget;
+      return false;
+    });
+    expect(immediateParentWidget, isA<Semantics>());
+
+    // The label is accessible via the semantics tree.
+    expect(find.bySemanticsLabel('Step 1 of 3'), findsOneWidget);
+
+    handle.dispose();
+  });
+
+  testWidgets('step semantics label - per-widget null suppresses theme',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardBarTheme(
+          stepSemanticsLabel: (step, total) => 'Should not appear',
+          child: Wizard(
+            userData: const WizardData(totalSteps: 4),
+            routes: {
+              '/qux': WizardRoute(
+                builder: (_) => WizardPage(
+                  bottomBar: WizardBar(
+                    // Returning null opts this bar out of any semantics label.
+                    stepSemanticsLabel: (step, total) => null,
+                  ),
+                ),
+                userData: const WizardRouteData(step: 0),
+              ),
+            },
+            initialRoute: '/qux',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // No semantics label should be present.
+    expect(
+      find.bySemanticsLabel(RegExp(r'Should not appear')),
+      findsNothing,
+    );
+    // ExcludeSemantics is not added when there is no label.
+    expect(find.byType(ExcludeSemantics), findsNothing);
+
+    handle.dispose();
+  });
+
+  testWidgets('step semantics label - per-widget overrides WizardBarTheme',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WizardBarTheme(
+          stepSemanticsLabel: (step, total) => 'Inherited $step/$total',
+          child: Wizard(
+            userData: const WizardData(totalSteps: 5),
+            routes: {
+              '/quux': WizardRoute(
+                builder: (_) => WizardPage(
+                  bottomBar: WizardBar(
+                    stepSemanticsLabel: (step, total) =>
+                        'Override $step/$total',
+                  ),
+                ),
+                userData: const WizardRouteData(step: 2),
+              ),
+            },
+            initialRoute: '/quux',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Override 3/5'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(RegExp(r'Inherited')),
+      findsNothing,
+    );
+
+    handle.dispose();
+  });
+
   testWidgets('loading indicator', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
The wizard's step indicator (the dots at the bottom of each page) is
currently invisible to screen readers. This PR wraps it in a `Semantics`
widget so assistive technology announces the current position, e.g.
*"Step 2 of 5"*.

## What changed

- **`ubuntu_wizard`** — added a `stepSemanticsLabel` parameter and a
  static `defaultStepSemanticsLabel` builder to `WizardBar`. When a
  label is provided, the page indicator dots are wrapped in
  `Focus` + `Semantics` with `ExcludeSemantics` on the children (so
  individual dots aren't read separately). Steps are 0-indexed
  internally but announced as 1-based.

- **`ubuntu_bootstrap`** — added a localized `stepIndicatorLabel`
  string (`"Step {CURRENT_STEP} of {TOTAL_STEPS}"`) and wired up
  `WizardBar.defaultStepSemanticsLabel` once in `_InstallerApp.build`,
  so all pages get the behavior without individual call-site changes.