### PR TITLE
feat: Add accessibility labels to Wi-Fi list tiles for screen readers

### DIFF
--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_en.arb
@@ -151,5 +151,14 @@
   "maximizeIconSemanticLabel": "Maximize",
   "minimizeIconSemanticLabel": "Minimize",
   "expandIconSemanticLabel": "Expand",
-  "collapseIconSemanticLabel": "Collapse"
+  "collapseIconSemanticLabel": "Collapse",
+  "networkWifiSignalNone": "No signal",
+  "networkWifiSignalWeak": "Weak signal",
+  "networkWifiSignalOk": "OK signal",
+  "networkWifiSignalGood": "Good signal",
+  "networkWifiSignalExcellent": "Excellent signal",
+  "networkWifiOpenNetwork": "Open network",
+  "networkWifiSecureNetwork": "Secure network",
+  "networkWifiConnecting": "Connecting…",
+  "networkWifiConnected": "Connected"
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations.dart
@@ -944,6 +944,60 @@ abstract class UbuntuProvisionLocalizations {
   /// In en, this message translates to:
   /// **'Collapse'**
   String get collapseIconSemanticLabel;
+
+  /// No description provided for @networkWifiSignalNone.
+  ///
+  /// In en, this message translates to:
+  /// **'No signal'**
+  String get networkWifiSignalNone;
+
+  /// No description provided for @networkWifiSignalWeak.
+  ///
+  /// In en, this message translates to:
+  /// **'Weak signal'**
+  String get networkWifiSignalWeak;
+
+  /// No description provided for @networkWifiSignalOk.
+  ///
+  /// In en, this message translates to:
+  /// **'OK signal'**
+  String get networkWifiSignalOk;
+
+  /// No description provided for @networkWifiSignalGood.
+  ///
+  /// In en, this message translates to:
+  /// **'Good signal'**
+  String get networkWifiSignalGood;
+
+  /// No description provided for @networkWifiSignalExcellent.
+  ///
+  /// In en, this message translates to:
+  /// **'Excellent signal'**
+  String get networkWifiSignalExcellent;
+
+  /// No description provided for @networkWifiOpenNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Open network'**
+  String get networkWifiOpenNetwork;
+
+  /// No description provided for @networkWifiSecureNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Secure network'**
+  String get networkWifiSecureNetwork;
+
+  /// No description provided for @networkWifiConnecting.
+  ///
+  /// In en, this message translates to:
+  /// **'Connecting…'**
+  String get networkWifiConnecting;
+
+  /// No description provided for @networkWifiConnected.
+  ///
+  /// In en, this message translates to:
+  /// **'Connected'**
+  String get networkWifiConnected;
 }
 
 class _UbuntuProvisionLocalizationsDelegate

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_am.dart
@@ -382,4 +382,31 @@ class UbuntuProvisionLocalizationsAm extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ar.dart
@@ -379,4 +379,31 @@ class UbuntuProvisionLocalizationsAr extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_be.dart
@@ -386,4 +386,31 @@ class UbuntuProvisionLocalizationsBe extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bg.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsBg extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bn.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsBn extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bo.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsBo extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_bs.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsBs extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ca.dart
@@ -386,4 +386,31 @@ class UbuntuProvisionLocalizationsCa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cs.dart
@@ -385,4 +385,31 @@ class UbuntuProvisionLocalizationsCs extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Sbalit';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_cy.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsCy extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_da.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsDa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_de.dart
@@ -390,4 +390,31 @@ class UbuntuProvisionLocalizationsDe extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Einklappen';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_dz.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsDz extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_el.dart
@@ -388,4 +388,31 @@ class UbuntuProvisionLocalizationsEl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Σύμπτυξη';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_en.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsEn extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eo.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsEo extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Kaŝi';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_es.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsEs extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Colapsar';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_et.dart
@@ -389,4 +389,31 @@ class UbuntuProvisionLocalizationsEt extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Ahenda vaadet';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_eu.dart
@@ -386,4 +386,31 @@ class UbuntuProvisionLocalizationsEu extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Tolestu';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fa.dart
@@ -381,4 +381,31 @@ class UbuntuProvisionLocalizationsFa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'جمع‌کردن';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fi.dart
@@ -385,4 +385,31 @@ class UbuntuProvisionLocalizationsFi extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Supista';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_fr.dart
@@ -391,4 +391,31 @@ class UbuntuProvisionLocalizationsFr extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Réduire';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ga.dart
@@ -385,4 +385,31 @@ class UbuntuProvisionLocalizationsGa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Laghdaigh';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gl.dart
@@ -384,4 +384,31 @@ class UbuntuProvisionLocalizationsGl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Contraer';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_gu.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsGu extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_he.dart
@@ -377,4 +377,31 @@ class UbuntuProvisionLocalizationsHe extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'צמצום';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hi.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsHi extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hr.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsHr extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_hu.dart
@@ -386,4 +386,31 @@ class UbuntuProvisionLocalizationsHu extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Összecsukás';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_id.dart
@@ -388,4 +388,31 @@ class UbuntuProvisionLocalizationsId extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Kuncupkan';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_is.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsIs extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_it.dart
@@ -385,4 +385,31 @@ class UbuntuProvisionLocalizationsIt extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Riduci';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ja.dart
@@ -374,4 +374,31 @@ class UbuntuProvisionLocalizationsJa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => '隠す';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ka.dart
@@ -382,4 +382,31 @@ class UbuntuProvisionLocalizationsKa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'აკეცვა';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kk.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsKk extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_km.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsKm extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_kn.dart
@@ -388,4 +388,31 @@ class UbuntuProvisionLocalizationsKn extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'ಕುಗ್ಗಿಸು';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ko.dart
@@ -374,4 +374,31 @@ class UbuntuProvisionLocalizationsKo extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ku.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsKu extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lo.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsLo extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'ຫຍໍ້ເຂົ້າ';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lt.dart
@@ -388,4 +388,31 @@ class UbuntuProvisionLocalizationsLt extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Suskleisti';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_lv.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsLv extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mk.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsMk extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ml.dart
@@ -388,4 +388,31 @@ class UbuntuProvisionLocalizationsMl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_mr.dart
@@ -384,4 +384,31 @@ class UbuntuProvisionLocalizationsMr extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_my.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsMy extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nb.dart
@@ -382,4 +382,31 @@ class UbuntuProvisionLocalizationsNb extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ne.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsNe extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nl.dart
@@ -384,4 +384,31 @@ class UbuntuProvisionLocalizationsNl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Inklappen';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_nn.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsNn extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_oc.dart
@@ -384,4 +384,31 @@ class UbuntuProvisionLocalizationsOc extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Replegar';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pa.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsPa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pl.dart
@@ -387,4 +387,31 @@ class UbuntuProvisionLocalizationsPl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Zwiń';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_pt.dart
@@ -384,6 +384,33 @@ class UbuntuProvisionLocalizationsPt extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Recolher';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ro.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsRo extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ru.dart
@@ -387,4 +387,31 @@ class UbuntuProvisionLocalizationsRu extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Свернуть';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_se.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsSe extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_si.dart
@@ -379,4 +379,31 @@ class UbuntuProvisionLocalizationsSi extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sk.dart
@@ -388,4 +388,31 @@ class UbuntuProvisionLocalizationsSk extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Zbaliť';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sl.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsSl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sq.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsSq extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sr.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsSr extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_sv.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsSv extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Fäll ihop';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ta.dart
@@ -389,4 +389,31 @@ class UbuntuProvisionLocalizationsTa extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'சுருக்கு';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_te.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsTe extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tg.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsTg extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_th.dart
@@ -382,4 +382,31 @@ class UbuntuProvisionLocalizationsTh extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tl.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsTl extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_tr.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsTr extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_ug.dart
@@ -382,4 +382,31 @@ class UbuntuProvisionLocalizationsUg extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'يىغ';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_uk.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsUk extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Згорнути';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_vi.dart
@@ -383,4 +383,31 @@ class UbuntuProvisionLocalizationsVi extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }

--- a/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
+++ b/packages/ubuntu_provision/lib/src/l10n/ubuntu_provision_localizations_zh.dart
@@ -370,6 +370,33 @@ class UbuntuProvisionLocalizationsZh extends UbuntuProvisionLocalizations {
 
   @override
   String get collapseIconSemanticLabel => 'Collapse';
+
+  @override
+  String get networkWifiSignalNone => 'No signal';
+
+  @override
+  String get networkWifiSignalWeak => 'Weak signal';
+
+  @override
+  String get networkWifiSignalOk => 'OK signal';
+
+  @override
+  String get networkWifiSignalGood => 'Good signal';
+
+  @override
+  String get networkWifiSignalExcellent => 'Excellent signal';
+
+  @override
+  String get networkWifiOpenNetwork => 'Open network';
+
+  @override
+  String get networkWifiSecureNetwork => 'Secure network';
+
+  @override
+  String get networkWifiConnecting => 'Connecting…';
+
+  @override
+  String get networkWifiConnected => 'Connected';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -255,12 +255,13 @@ class WifiListTile extends ConsumerWidget {
   }
 }
 
+int _wifiStrength(AccessPoint model) => (model.strength ~/ 20 + 1).clamp(1, 5);
+
 String _wifiSemanticsLabel(
   AccessPoint model,
   UbuntuProvisionLocalizations lang,
 ) {
-  final strength = (model.strength ~/ 20 + 1).clamp(1, 5);
-  final strengthLabel = switch (strength) {
+  final strengthLabel = switch (_wifiStrength(model)) {
     1 => lang.networkWifiSignalNone,
     2 => lang.networkWifiSignalWeak,
     3 => lang.networkWifiSignalOk,
@@ -275,28 +276,24 @@ String _wifiSemanticsLabel(
 }
 
 IconData _wifiIcon(AccessPoint model) {
-  final strength = (model.strength ~/ 20 + 1).clamp(1, 5);
+  final strength = _wifiStrength(model);
   return model.isOpen ? _wifiIconOpen(strength) : _wifiIconLock(strength);
 }
 
-IconData _wifiIconOpen(int strength) {
-  const icons = <int, IconData>{
-    1: YaruIcons.network_wireless_signal_none,
-    2: YaruIcons.network_wireless_signal_weak,
-    3: YaruIcons.network_wireless_signal_ok,
-    4: YaruIcons.network_wireless_signal_good,
-    5: YaruIcons.network_wireless_signal_excellent,
-  };
-  return icons[strength]!;
-}
+IconData _wifiIconOpen(int strength) => switch (strength) {
+      1 => YaruIcons.network_wireless_signal_none,
+      2 => YaruIcons.network_wireless_signal_weak,
+      3 => YaruIcons.network_wireless_signal_ok,
+      4 => YaruIcons.network_wireless_signal_good,
+      5 => YaruIcons.network_wireless_signal_excellent,
+      _ => YaruIcons.network_wireless_signal_none,
+    };
 
-IconData _wifiIconLock(int strength) {
-  const icons = <int, IconData>{
-    1: YaruIcons.network_wireless_signal_none_secure,
-    2: YaruIcons.network_wireless_signal_weak_secure,
-    3: YaruIcons.network_wireless_signal_ok_secure,
-    4: YaruIcons.network_wireless_signal_good_secure,
-    5: YaruIcons.network_wireless_signal_excellent_secure,
-  };
-  return icons[strength]!;
-}
+IconData _wifiIconLock(int strength) => switch (strength) {
+      1 => YaruIcons.network_wireless_signal_none_secure,
+      2 => YaruIcons.network_wireless_signal_weak_secure,
+      3 => YaruIcons.network_wireless_signal_ok_secure,
+      4 => YaruIcons.network_wireless_signal_good_secure,
+      5 => YaruIcons.network_wireless_signal_excellent_secure,
+      _ => YaruIcons.network_wireless_signal_none_secure,
+    };

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -251,7 +251,10 @@ class WifiListTile extends ConsumerWidget {
   }
 }
 
-String _wifiSemanticsLabel(AccessPoint model, UbuntuProvisionLocalizations lang) {
+String _wifiSemanticsLabel(
+  AccessPoint model,
+  UbuntuProvisionLocalizations lang,
+) {
   final strength = (model.strength ~/ 20 + 1).clamp(1, 5);
   final strengthLabel = switch (strength) {
     1 => lang.networkWifiSignalNone,
@@ -261,8 +264,9 @@ String _wifiSemanticsLabel(AccessPoint model, UbuntuProvisionLocalizations lang)
     5 => lang.networkWifiSignalExcellent,
     _ => '',
   };
-  final securityLabel =
-      model.isOpen ? lang.networkWifiOpenNetwork : lang.networkWifiSecureNetwork;
+  final securityLabel = model.isOpen
+      ? lang.networkWifiOpenNetwork
+      : lang.networkWifiSecureNetwork;
   return '$strengthLabel, $securityLabel';
 }
 

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ubuntu_provision/l10n.dart';
 import 'package:ubuntu_provision/src/network/connect_model.dart';
 import 'package:ubuntu_provision/src/network/network_l10n.dart';
 import 'package:ubuntu_provision/src/network/network_tile.dart';
@@ -178,16 +179,23 @@ class WifiListTile extends ConsumerWidget {
     AccessPoint accessPoint,
     WifiDevice device,
     double? iconSize,
+    UbuntuProvisionLocalizations lang,
   ) {
     if (device.isActiveAccessPoint(accessPoint)) {
       if (device.isConnecting) {
         return SizedBox(
           width: iconSize,
           height: iconSize,
-          child: const YaruCircularProgressIndicator(strokeWidth: 3),
+          child: Semantics(
+            label: lang.networkWifiConnecting,
+            child: const YaruCircularProgressIndicator(strokeWidth: 3),
+          ),
         );
       } else {
-        return const Icon(YaruIcons.ok_simple);
+        return Semantics(
+          label: lang.networkWifiConnected,
+          child: const Icon(YaruIcons.ok_simple),
+        );
       }
     } else {
       return const SizedBox.shrink();
@@ -197,6 +205,7 @@ class WifiListTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final device = ref.watch(wifiDeviceProvider(deviceIndex));
+    final lang = NetworkLocalizations.of(context);
     final textColor = Theme.of(context).textTheme.titleMedium!.color;
     final iconSize = IconTheme.of(context).size;
 
@@ -205,12 +214,15 @@ class WifiListTile extends ConsumerWidget {
         ThemedListTile(
           key: ValueKey(accessPoint.name),
           title: Text(accessPoint.name),
-          leading: _leadingIcon(accessPoint, device, iconSize),
+          leading: _leadingIcon(accessPoint, device, iconSize, lang),
           selected: selected && device.isSelectedAccessPoint(accessPoint),
-          trailing: SizedBox(
-            width: iconSize,
-            height: iconSize,
-            child: Icon(_wifiIcon(accessPoint)),
+          trailing: Semantics(
+            label: _wifiSemanticsLabel(accessPoint, lang),
+            child: SizedBox(
+              width: iconSize,
+              height: iconSize,
+              child: Icon(_wifiIcon(accessPoint)),
+            ),
           ),
           onTap: () {
             device.selectAccessPoint(accessPoint);
@@ -237,6 +249,21 @@ class WifiListTile extends ConsumerWidget {
           )
         : Column(children: accessPoints);
   }
+}
+
+String _wifiSemanticsLabel(AccessPoint model, UbuntuProvisionLocalizations lang) {
+  final strength = (model.strength ~/ 20 + 1).clamp(1, 5);
+  final strengthLabel = switch (strength) {
+    1 => lang.networkWifiSignalNone,
+    2 => lang.networkWifiSignalWeak,
+    3 => lang.networkWifiSignalOk,
+    4 => lang.networkWifiSignalGood,
+    5 => lang.networkWifiSignalExcellent,
+    _ => '',
+  };
+  final securityLabel =
+      model.isOpen ? lang.networkWifiOpenNetwork : lang.networkWifiSecureNetwork;
+  return '$strengthLabel, $securityLabel';
 }
 
 IconData _wifiIcon(AccessPoint model) {

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -244,7 +244,8 @@ class WifiListTile extends ConsumerWidget {
                     height: iconSize,
                     child: Semantics(
                       label: lang.networkWifiConnecting,
-                      child: const YaruCircularProgressIndicator(strokeWidth: 3),
+                      child:
+                          const YaruCircularProgressIndicator(strokeWidth: 3),
                     ),
                   )
                 : null,

--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -242,7 +242,10 @@ class WifiListTile extends ConsumerWidget {
                 ? SizedBox(
                     width: iconSize,
                     height: iconSize,
-                    child: const YaruCircularProgressIndicator(strokeWidth: 3),
+                    child: Semantics(
+                      label: lang.networkWifiConnecting,
+                      child: const YaruCircularProgressIndicator(strokeWidth: 3),
+                    ),
                   )
                 : null,
             children: accessPoints,

--- a/packages/ubuntu_provision/test/network/wifi_view_test.dart
+++ b/packages/ubuntu_provision/test/network/wifi_view_test.dart
@@ -240,13 +240,21 @@ void main() {
 
     expect(
       find.bySemanticsLabel(
-        '${l10n.networkWifiSignalExcellent}, ${l10n.networkWifiOpenNetwork}',
+        RegExp(
+          RegExp.escape(
+            '${l10n.networkWifiSignalExcellent}, ${l10n.networkWifiOpenNetwork}',
+          ),
+        ),
       ),
       findsOneWidget,
     );
     expect(
       find.bySemanticsLabel(
-        '${l10n.networkWifiSignalWeak}, ${l10n.networkWifiSecureNetwork}',
+        RegExp(
+          RegExp.escape(
+            '${l10n.networkWifiSignalWeak}, ${l10n.networkWifiSecureNetwork}',
+          ),
+        ),
       ),
       findsOneWidget,
     );
@@ -319,12 +327,12 @@ void main() {
     // "Connecting…" appears at both device-level (ExpansionTile trailing)
     // and AP-level (leading icon) for device1's connecting state.
     expect(
-      find.bySemanticsLabel(l10n.networkWifiConnecting),
+      find.bySemanticsLabel(RegExp(RegExp.escape(l10n.networkWifiConnecting))),
       findsNWidgets(2),
     );
     // "Connected" appears at AP-level for device2's active (non-connecting) AP.
     expect(
-      find.bySemanticsLabel(l10n.networkWifiConnected),
+      find.bySemanticsLabel(RegExp(RegExp.escape(l10n.networkWifiConnected))),
       findsOneWidget,
     );
 

--- a/packages/ubuntu_provision/test/network/wifi_view_test.dart
+++ b/packages/ubuntu_provision/test/network/wifi_view_test.dart
@@ -194,6 +194,143 @@ void main() {
     expect(find.text(l10n.networkWifiNone), findsOneWidget);
   });
 
+  testWidgets('wifi semantics - signal and security labels', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    final device = MockWifiDevice();
+    when(device.model).thenReturn('device');
+    when(device.scanning).thenReturn(false);
+    when(device.isConnecting).thenReturn(false);
+    when(device.isAvailable).thenReturn(true);
+    when(device.isActive).thenReturn(false);
+
+    final apOpen = MockAccessPoint();
+    when(apOpen.name).thenReturn('open_ap');
+    when(apOpen.strength).thenReturn(80);
+    when(apOpen.isOpen).thenReturn(true);
+
+    final apSecure = MockAccessPoint();
+    when(apSecure.name).thenReturn('secure_ap');
+    when(apSecure.strength).thenReturn(20);
+    when(apSecure.isOpen).thenReturn(false);
+
+    when(device.accessPoints).thenReturn([apOpen, apSecure]);
+    when(device.isActiveAccessPoint(any)).thenReturn(false);
+    when(device.isSelectedAccessPoint(any)).thenReturn(false);
+
+    final model = buildWifiModel(devices: [device], isEnabled: true);
+
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          wifiModelProvider.overrideWith((_) => model),
+        ],
+        child: Material(
+          child: WifiView(
+            expanded: true,
+            onEnabled: () {},
+            onSelected: (device, accessPoint) {},
+          ),
+        ),
+      ),
+    );
+
+    final context = tester.element(find.byType(WifiListView));
+    final l10n = NetworkLocalizations.of(context);
+
+    expect(
+      find.bySemanticsLabel(
+        '${l10n.networkWifiSignalExcellent}, ${l10n.networkWifiOpenNetwork}',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.bySemanticsLabel(
+        '${l10n.networkWifiSignalWeak}, ${l10n.networkWifiSecureNetwork}',
+      ),
+      findsOneWidget,
+    );
+
+    handle.dispose();
+  });
+
+  testWidgets('wifi semantics - connection state labels', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    // Device 1: connecting with active AP
+    final device1 = MockWifiDevice();
+    when(device1.model).thenReturn('device1');
+    when(device1.scanning).thenReturn(false);
+    when(device1.isConnecting).thenReturn(true);
+    when(device1.isAvailable).thenReturn(true);
+    when(device1.isActive).thenReturn(true);
+
+    final ap1 = MockAccessPoint();
+    when(ap1.name).thenReturn('ap1');
+    when(ap1.strength).thenReturn(80);
+    when(ap1.isOpen).thenReturn(true);
+    when(device1.accessPoints).thenReturn([ap1]);
+    when(device1.isActiveAccessPoint(ap1)).thenReturn(true);
+    when(device1.isSelectedAccessPoint(ap1)).thenReturn(false);
+
+    // Device 2: connected (active AP, not connecting)
+    final device2 = MockWifiDevice();
+    when(device2.model).thenReturn('device2');
+    when(device2.scanning).thenReturn(false);
+    when(device2.isConnecting).thenReturn(false);
+    when(device2.isAvailable).thenReturn(true);
+    when(device2.isActive).thenReturn(true);
+
+    final ap2 = MockAccessPoint();
+    when(ap2.name).thenReturn('ap2');
+    when(ap2.strength).thenReturn(80);
+    when(ap2.isOpen).thenReturn(true);
+    when(device2.accessPoints).thenReturn([ap2]);
+    when(device2.isActiveAccessPoint(ap2)).thenReturn(true);
+    when(device2.isSelectedAccessPoint(ap2)).thenReturn(true);
+
+    final model = buildWifiModel(
+      devices: [device1, device2],
+      isEnabled: true,
+    );
+
+    await tester.pumpApp(
+      (_) => ProviderScope(
+        overrides: [
+          wifiModelProvider.overrideWith((_) => model),
+        ],
+        child: Material(
+          child: Column(
+            children: [
+              WifiView(
+                expanded: true,
+                onEnabled: () {},
+                onSelected: (device, accessPoint) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final context = tester.element(find.byType(WifiListView));
+    final l10n = NetworkLocalizations.of(context);
+
+    // "Connecting…" appears at both device-level (ExpansionTile trailing)
+    // and AP-level (leading icon) for device1's connecting state.
+    expect(
+      find.bySemanticsLabel(l10n.networkWifiConnecting),
+      findsNWidgets(2),
+    );
+    // "Connected" appears at AP-level for device2's active (non-connecting) AP.
+    expect(
+      find.bySemanticsLabel(l10n.networkWifiConnected),
+      findsOneWidget,
+    );
+
+    handle.dispose();
+  });
+
   testWidgets('starts periodic scanning', (tester) async {
     final model = buildWifiModel();
 


### PR DESCRIPTION
Currently, the Wi-Fi network list conveys signal strength and encryption
status only through icons (wifi signal icon with/without a lock), which
is inaccessible to screen reader users. The connection state
(connected/connecting) is similarly only shown via icons.

This PR adds Semantics widgets around the relevant icons in `WifiListTile`
so that screen readers can announce:

- Signal strength — one of: No signal, Weak signal, OK signal, Good
  signal, Excellent signal
- Security — Open network or Secure network
- Connection state — Connected or Connecting…

### Changes

- Added 9 new l10n keys: `networkWifiSignalNone` through
  `networkWifiSignalExcellent`, `networkWifiOpenNetwork`,
  `networkWifiSecureNetwork`, `networkWifiConnecting`,
  `networkWifiConnected`
- Wrapped the trailing wifi icon in
  `Semantics(label: _wifiSemanticsLabel(...))`
- Wrapped the leading status icon (checkmark/spinner) in `Semantics`
  with the appropriate connection state label
- Added `_wifiSemanticsLabel()` helper that maps
  `AccessPoint.strength` and `AccessPoint.isOpen` to localized strings