### PR TITLE
chore: bump curtin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,7 +92,7 @@ parts:
     plugin: nil
     source: https://github.com/canonical/curtin
     source-type: git
-    source-commit: 67962f8bbfc52d3222f62a5ca2c61130781925a8
+    source-commit: ab0c9258d481182ba024445261fdc4dd501cd321
     override-pull: |
       craftctl default
       # Since snapcraft 8.14, the tags are not automatically fetched


### PR DESCRIPTION
It looks like the CI, including the subiquity check, didn't run in #1424, so this PR fixes the curtin commit hash mismatch. Also, let's see if the CI runs on this PR, or if something's broken..

P.S. I'm realizing that was probably my fault - we need to close/reopen PRs that were opened by bots through automated workflows, since those don't trigger further github actions for security reasons