### PR TITLE
fix: riscv64 __frexp/__ldexp fully dynamic resolution (no libc6)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,11 +66,6 @@ parts:
     source-commit: &commit-ref 8e5255f2e18e00e61f534b71feb5f091a44646f3
     source-type: git
     build-attributes: [enable-patchelf]
-    stage-packages:
-      - to riscv64:
-        - libc6
-        - libc6-dev
-        - libgcc-s1
     override-build: |
       if [ $CRAFT_ARCH_BUILD_FOR = riscv64 ]; then
         export FLUTTER_STORAGE_BASE_URL=https://flutter-experimental.ubuntu.com
@@ -234,6 +229,22 @@ parts:
   libraries:
     plugin: nil
     build-attributes: [enable-patchelf]
+    stage:
+      - to riscv64:
+        # libc6-dev (pulled in as a dependency of libglib2.0-dev and other -dev
+        # packages) ships static archives and GNU ld linker scripts for libc/libm.
+        # On riscv64 the linker scripts cause libm.a to be included in every -lm
+        # link; libm.a in glibc 2.39 has undefined __frexp/__ldexp that only exist
+        # in libc.a, so building libhandy_flutter.so fails with "undefined
+        # reference to __frexp".  Excluding static archives and the unversioned
+        # .so linker scripts from stage forces the Flutter build to fall back to
+        # the system's real libm.so.6/libc.so.6 (pure dynamic linking), where all
+        # symbols are resolved at run-time.
+        - "*"
+        - -usr/lib/riscv64-linux-gnu/libc.a
+        - -usr/lib/riscv64-linux-gnu/libm.a
+        - -usr/lib/riscv64-linux-gnu/libc.so
+        - -usr/lib/riscv64-linux-gnu/libm.so
     stage-packages:
       - libatk1.0-0t64
       - libcairo-gobject2
@@ -303,6 +314,13 @@ parts:
       - -usr/lib/pkgconfig
       - -usr/share/pkgconfig
       - -usr/lib/${CRAFT_ARCH_TRIPLET}/libgallium*
+      - to riscv64:
+        # These are excluded from stage (see the stage: filter above); list them
+        # here too so snapcraft does not try to copy absent files during prime.
+        - -usr/lib/riscv64-linux-gnu/libc.a
+        - -usr/lib/riscv64-linux-gnu/libm.a
+        - -usr/lib/riscv64-linux-gnu/libc.so
+        - -usr/lib/riscv64-linux-gnu/libm.so
 
   dri-no-patchelf:
     after: [libraries]


### PR DESCRIPTION
On riscv64, the build used to fail with:
```
:: [   +2 ms] /usr/bin/ld: plugins/handy_window/libhandy/libhandy_flutter.so: undefined reference to `__frexp'
:: [   +2 ms] /usr/bin/ld: plugins/handy_window/libhandy/libhandy_flutter.so: undefined reference to `__ldexp'
:: [   +2 ms] clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

A first solution to the problem was to stage `libc6` package, but it was not a good solution as it led to runtime issue (not being able to start the installer).

The reason for that issue is the fact that libm on riscv64 uses __frexp and others as links to libc, contrary to amd64 where those symbols are only present in libc. Some packages in the snap were pulling static versions of those libraries (libc.a, libm.a) and the linker tried to statically link to libm.a which was missing those symbols as they were dynamically pointing to the libc.so ones.

The right solution to that issue seems to be making sure that we don't stage libc.a/libm.a/libc.so/libm.so on riscv64.

This commits removed the previously staged-package libc6 and instead uses the previously described solution of not staging the libc/libm files at all.

See also:
- https://github.com/ubuntu/gnome-sdk/issues/240
- https://github.com/ubuntu/gnome-sdk/pull/294
- https://github.com/ubuntu/gnome-sdk/pull/296