### PR TITLE
feat: include flutter 3.41+ a11y fixes in resolute

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -139,7 +139,7 @@ class ConfirmPage extends ConsumerWidget with ProvisioningPage {
                           const SizedBox(height: kWizardSpacing),
                           Focus(
                             child: Semantics(
-                              header: true,
+                              // TODO: Re-enable `header: true` once upstream Flutter Linux AT-SPI bug is fixed. https://github.com/flutter/flutter/issues/184568
                               child: Text(
                                 lang.confirmPartitionsTitle,
                                 style: Theme.of(context).textTheme.titleMedium,
@@ -171,7 +171,7 @@ class _SummarySection extends StatelessWidget {
       children: [
         Focus(
           child: Semantics(
-            header: true,
+            // TODO: Re-enable `header: true` once upstream Flutter Linux AT-SPI bug is fixed. https://github.com/flutter/flutter/issues/184568
             child: Text(title, style: Theme.of(context).textTheme.titleMedium),
           ),
         ),

--- a/apps/ubuntu_bootstrap/lib/pages/done/done_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/done/done_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/done/done_model.dart';
@@ -7,7 +8,7 @@ import 'package:ubuntu_utils/ubuntu_utils.dart';
 import 'package:ubuntu_wizard/ubuntu_wizard.dart';
 import 'package:yaru/yaru.dart';
 
-class DonePage extends ConsumerWidget with ProvisioningPage {
+class DonePage extends ConsumerStatefulWidget with ProvisioningPage {
   const DonePage({super.key});
 
   @override
@@ -16,13 +17,38 @@ class DonePage extends ConsumerWidget with ProvisioningPage {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DonePage> createState() => _DonePageState();
+}
+
+class _DonePageState extends ConsumerState<DonePage> {
+  bool _announced = false;
+
+  @override
+  Widget build(BuildContext context) {
     final lang = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(doneModelProvider);
     final theme = Theme.of(context);
     final mascot = ref.watch(pageImagesProvider).get('done');
     final isCoreDesktop =
         model.provisioningMode == ProvisioningMode.coreDesktop;
+
+    final view = View.of(context);
+
+    final statusMessage = isCoreDesktop
+        ? lang.rebootToConfigure(model.productInfo.toString())
+        : lang.readyToUse(model.productInfo.toString());
+
+    // Fire the imperative announcement once the page loads
+    if (!_announced) {
+      _announced = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        SemanticsService.sendAnnouncement(
+          view,
+          '${lang.installationCompleteTitle}. $statusMessage',
+          TextDirection.ltr,
+        );
+      });
+    }
 
     return WizardPage(
       title: YaruWindowTitleBar(
@@ -46,9 +72,7 @@ class DonePage extends ConsumerWidget with ProvisioningPage {
                   ),
                 const SizedBox(),
                 Text(
-                  isCoreDesktop
-                      ? lang.rebootToConfigure(model.productInfo.toString())
-                      : lang.readyToUse(model.productInfo.toString()),
+                  statusMessage,
                   style: theme.textTheme.headlineSmall,
                   textAlign: TextAlign.center,
                 ),

--- a/apps/ubuntu_bootstrap/lib/pages/install/install_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/install/install_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_bootstrap/l10n.dart';
 import 'package:ubuntu_bootstrap/pages/install/bottom_bar.dart';
@@ -57,6 +58,7 @@ class _SlidePage extends ConsumerStatefulWidget {
 
 class _SlidePageState extends ConsumerState<_SlidePage> {
   final _slideController = ValueNotifier(0);
+  bool _announcedInitialState = false;
 
   @override
   void dispose() {
@@ -68,6 +70,36 @@ class _SlidePageState extends ConsumerState<_SlidePage> {
   Widget build(BuildContext context) {
     final lang = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(installModelProvider);
+
+    final view = View.of(context);
+
+    // Initial load announcement
+    if (!_announcedInitialState &&
+        model.event.action != InstallationAction.none) {
+      _announcedInitialState = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        SemanticsService.sendAnnouncement(
+          view,
+          model.event.action.localize(lang),
+          TextDirection.ltr,
+        );
+      });
+    }
+
+    // Subsequent state change announcements
+    ref.listen(
+      installModelProvider.select((m) => m.event.action),
+      (previous, next) {
+        if (previous != next && next != InstallationAction.none) {
+          SemanticsService.sendAnnouncement(
+            view,
+            next.localize(lang),
+            TextDirection.ltr,
+          );
+        }
+      },
+    );
+
     final htmlSlides = ref.watch(slidesProvider).slides;
     return WizardPage(
       headerPadding: EdgeInsets.zero,

--- a/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_page.dart
@@ -24,11 +24,7 @@ class RefreshPage extends ConsumerWidget with ProvisioningPage {
 
     return WizardPage(
       title: YaruWindowTitleBar(
-        title: Semantics(
-          focused: true,
-          header: true,
-          child: Text(l10n.refreshPageTitle),
-        ),
+        title: Text(l10n.refreshPageTitle),
         style: model.state.busy
             ? YaruTitleBarStyle.undecorated
             : YaruTitleBarStyle.normal,

--- a/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/refresh/refresh_widgets.dart
@@ -51,13 +51,19 @@ class RefreshView extends ConsumerWidget {
             style: Theme.of(context).textTheme.titleLarge,
           ),
         ),
-        Text(
-          switch (state) {
-            RefreshStateStatus() => l10n.refreshHeader,
-            RefreshStateDone() => l10n.refreshReady,
-            _ => ''
-          },
-          style: Theme.of(context).textTheme.titleLarge,
+        Focus(
+          autofocus: true,
+          child: Semantics(
+            // TODO: Re-enable `header: true` once upstream Flutter Linux AT-SPI bug is fixed. https://github.com/flutter/flutter/issues/184568
+            child: Text(
+              switch (state) {
+                RefreshStateStatus() => l10n.refreshHeader,
+                RefreshStateDone() => l10n.refreshReady,
+                _ => ''
+              },
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
         ),
         const Flexible(child: SizedBox(height: kWizardSpacing / 2)),
         Text(

--- a/packages/ubuntu_provision/lib/src/error/error_page.dart
+++ b/packages/ubuntu_provision/lib/src/error/error_page.dart
@@ -102,12 +102,14 @@ class ErrorPage extends ConsumerWidget with ProvisioningPage {
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Semantics(
-                        focused: true,
-                        header: true,
-                        child: Text(
-                          errorDetails?.title ?? lang.errorPageTitle,
-                          style: Theme.of(context).textTheme.titleLarge,
+                      Focus(
+                        autofocus: true,
+                        child: Semantics(
+                          // TODO: Re-enable `header: true` once upstream Flutter Linux AT-SPI bug is fixed. https://github.com/flutter/flutter/issues/184568
+                          child: Text(
+                            errorDetails?.title ?? lang.errorPageTitle,
+                            style: Theme.of(context).textTheme.titleLarge,
+                          ),
                         ),
                       ),
                       SizedBox(height: kWizardSpacing),

--- a/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
+++ b/packages/ubuntu_provision/lib/src/widgets/horizontal_page.dart
@@ -273,12 +273,14 @@ class _Headline extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Expanded(
-            child: Semantics(
-              focused: true,
-              header: true,
-              child: Text(
-                title,
-                style: theme.textTheme.titleLarge,
+            child: Focus(
+              autofocus: true,
+              child: Semantics(
+                // TODO: Re-enable `header: true` once upstream Flutter Linux AT-SPI bug is fixed. https://github.com/flutter/flutter/issues/184568
+                child: Text(
+                  title,
+                  style: theme.textTheme.titleLarge,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
This backports the following PRs to `ubuntu/26.04`:
- #1375
- #1388

UDENG-10596