### PR TITLE
fix: prevent stale state in list on TPM action page

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
@@ -22,27 +22,32 @@ class TpmActionPage extends ConsumerWidget with ProvisioningPage {
   Widget build(BuildContext context, WidgetRef ref) {
     final lang = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(tpmActionModelProvider);
+    final actions = model.actions;
+    final actionsKey = ValueKey(
+      actions.map((a) => '${a.type.name}:${a.args}').join('|'),
+    );
 
     final children = [
       if (model.tpmError != null)
         ...[
           Text(model.tpmError!.kind.label(lang)),
           Text(
-            switch (model.actions.length) {
+            switch (actions.length) {
               0 => lang.tpmActionErrorSupportNoActionLabel,
               1 => lang.tpmActionErrorSupportSingleLabel,
               _ => lang.tpmActionErrorSupportLabel
             },
           ),
         ].withSpacing(kWizardSpacing / 2),
-      if (model.actions.isNotEmpty) ...[
+      if (actions.isNotEmpty) ...[
         const SizedBox(height: kWizardSpacing / 2),
         YaruExpansionPanel(
+          key: actionsKey,
           shrinkWrap: true,
           headers: [
-            for (final (i, action) in model.actions.indexed)
+            for (final (i, action) in actions.indexed)
               Text(
-                model.actions.length > 1
+                actions.length > 1
                     ? lang.tpmActionSolutionLabel(
                         i + 1,
                         action.title(lang, model.tpmError?.kind),
@@ -53,7 +58,7 @@ class TpmActionPage extends ConsumerWidget with ProvisioningPage {
               ),
           ],
           children: [
-            for (final action in model.actions)
+            for (final action in actions)
               _ActionBody(
                 action: action,
                 errorKind: model.tpmError?.kind,


### PR DESCRIPTION
This fixes a bug where the `YaruExpansionPanel` would throw an exception during `build()` due to a stale state, see screencast:

[Screencast From 2026-07-08 16-59-45.webm](https://github.com/user-attachments/assets/a094ff53-6b7f-4572-94c2-930de4fc128f)
