### PR TITLE
fix(tpm-action): only consider errors for the selected disk

### DIFF
--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
@@ -58,10 +58,17 @@ class TpmActionModel extends SafeChangeNotifier {
 
   Future<void> _updateGuidedStorage() async {
     final response = await _storage.getGuidedStorage();
+    final selectedTarget = _storage.guidedTarget;
+    if (selectedTarget is! GuidedStorageTargetReformat) {
+      _disallowedTarget = null;
+      return;
+    }
     _disallowedTarget = response.targets
         .whereType<GuidedStorageTargetReformat>()
-        .where((t) => t.hasDisallowedTpmCapability)
-        .firstOrNull;
+        .firstWhereOrNull(
+          (t) =>
+              t.hasDisallowedTpmCapability && t.diskId == selectedTarget.diskId,
+        );
   }
 
   Future<SubiquityException?> performAction(

--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_model.dart
@@ -69,6 +69,13 @@ class TpmActionModel extends SafeChangeNotifier {
           (t) =>
               t.hasDisallowedTpmCapability && t.diskId == selectedTarget.diskId,
         );
+    final newTarget = response.targets
+        .whereType<GuidedStorageTargetReformat>()
+        .firstWhereOrNull((t) => t.diskId == selectedTarget.diskId);
+    if (selectedTarget != newTarget) {
+      _log.info('updating guided target');
+      _storage.guidedTarget = newTarget;
+    }
   }
 
   Future<SubiquityException?> performAction(

--- a/apps/ubuntu_bootstrap/test/storage/tpm_action/tpm_action_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/storage/tpm_action/tpm_action_model_test.dart
@@ -15,6 +15,20 @@ void main() {
     diskId: 'diskA',
     allowed: [GuidedCapability.DIRECT, GuidedCapability.CORE_BOOT_ENCRYPTED],
   );
+  final smallDiskTpmTarget = GuidedStorageTargetReformat(
+    diskId: 'diskB',
+    allowed: [],
+    disallowed: [
+      GuidedDisallowedCapability(
+        capability: GuidedCapability.DIRECT,
+        reason: GuidedDisallowedCapabilityReason.TOO_SMALL,
+      ),
+      GuidedDisallowedCapability(
+        capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+        reason: GuidedDisallowedCapabilityReason.TOO_SMALL,
+      ),
+    ],
+  );
   final defunctTpmTarget = GuidedStorageTargetReformat(
     diskId: 'diskA',
     disallowed: [
@@ -56,29 +70,40 @@ void main() {
       (
         name: 'no tpm fde',
         capability: GuidedCapability.DIRECT,
-        target: nonTpmTarget,
+        selectedTarget: nonTpmTarget,
+        targets: [nonTpmTarget],
         skipPage: true,
       ),
       (
         name: 'tpm fde without errors',
         capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
-        target: tpmTarget,
+        selectedTarget: tpmTarget,
+        targets: [tpmTarget],
+        skipPage: true,
+      ),
+      (
+        name: 'tpm fde + errors for other disk',
+        capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+        selectedTarget: tpmTarget,
+        targets: [smallDiskTpmTarget, tpmTarget],
         skipPage: true,
       ),
       (
         name: 'tpm fde with errors',
         capability: GuidedCapability.CORE_BOOT_ENCRYPTED,
-        target: defunctTpmTarget,
+        selectedTarget: defunctTpmTarget,
+        targets: [defunctTpmTarget],
         skipPage: false,
       ),
     ]) {
       test(testCase.name, () async {
         final storage = MockStorageService();
         when(storage.guidedCapability).thenReturn(testCase.capability);
+        when(storage.guidedTarget).thenReturn(testCase.selectedTarget);
         when(storage.getGuidedStorage()).thenAnswer(
           (_) async => GuidedStorageResponseV2(
             status: ProbeStatus.DONE,
-            targets: [testCase.target],
+            targets: testCase.targets,
           ),
         );
         final subiquity = MockSubiquityClient();
@@ -93,6 +118,7 @@ void main() {
     final storage = MockStorageService();
     when(storage.guidedCapability)
         .thenReturn(GuidedCapability.CORE_BOOT_ENCRYPTED);
+    when(storage.guidedTarget).thenReturn(defunctTpmTarget);
     when(storage.getGuidedStorage()).thenAnswer(
       (_) async => GuidedStorageResponseV2(
         status: ProbeStatus.DONE,
@@ -115,6 +141,7 @@ void main() {
     when(storage.getGuidedStorage()).thenAnswer(
       (_) async => GuidedStorageResponseV2(status: ProbeStatus.DONE),
     );
+    when(storage.guidedTarget).thenReturn(defunctTpmTarget);
     final subiquity = MockSubiquityClient();
 
     final model = TpmActionModel(storage, subiquity);
@@ -145,12 +172,13 @@ void main() {
   test('automatically trigger subsequent reboot action', () async {
     var calls = 0;
     final storage = MockStorageService();
+    when(storage.guidedTarget).thenReturn(defunctTpmTarget);
     when(storage.getGuidedStorage()).thenAnswer(
       (_) async => GuidedStorageResponseV2(
         status: ProbeStatus.DONE,
         targets: [
           GuidedStorageTarget.reformat(
-            diskId: 'disk',
+            diskId: 'diskA',
             disallowed: [
               GuidedDisallowedCapability(
                 capability: GuidedCapability.CORE_BOOT_ENCRYPTED,


### PR DESCRIPTION
When attempting to do a TPM/FDE install while another disk which isn't large enough to accommodate the OS is present, the TPM action page currently prevents the user from proceeding. This happens because disallowed targets for all disks (instead of just the selected disk) are checked.

Example response from `/storage/v2/guided` in that case:
```json
{
  "status": "DONE",
  "error_report": null,
  "configured": null,
  "targets": [
    {
      "disk_id": "disk-nvme0n1",
      "ptable": null,
      "allowed": [
        "DIRECT",
        "LVM",
        "LVM_LUKS",
        "ZFS",
        "ZFS_LUKS_KEYSTORE",
        "CORE_BOOT_PREFER_ENCRYPTED"
      ],
      "disallowed": [],
      "$type": "GuidedStorageTargetReformat"
    },
   ...
    {
      "disk_id": "disk-mmcblk0",
      "ptable": null,
      "allowed": [],
      "disallowed": [
       ...
        {
          "capability": "CORE_BOOT_PREFER_ENCRYPTED",
          "reason": "TOO_SMALL",
          "message": null,
          "errors": null
        }
      ],
      "$type": "GuidedStorageTargetReformat"
    },
    ...
  ]
}
```

This PR addresses this by explicitly checking only the disallowed capabilities of the selected target.
I also noticed that we don't update the selected target if it changes after performing a `PROCEED` action (the lists for `allowed` and `disallowed` capabilities will be updated). It seems like subiquity doesn't look at those when posting to `/storage/v2/guided`, but I think we should send the correct data nonetheless.

UDENG-11056