### PR TITLE
feat(tpm-action): show single proceed action without expansion panel

### DIFF
--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_en.arb
@@ -1025,6 +1025,7 @@
   "maximizeIconSemanticLabel": "Maximize",
   "minimizeIconSemanticLabel": "Minimize",
   "tpmActionPageTitle": "Hardware-backed encryption could not be enabled",
+  "tpmActionPageTitleActionable": "There is an issue with hardware-backed encryption",
   "tpmActionBadgeLabel": "Action required",
   "tpmActionDetailsLabel": "Technical details",
   "tpmActionConfirmLabel": "Confirm",

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations.dart
@@ -2488,6 +2488,12 @@ abstract class UbuntuBootstrapLocalizations {
   /// **'Hardware-backed encryption could not be enabled'**
   String get tpmActionPageTitle;
 
+  /// No description provided for @tpmActionPageTitleActionable.
+  ///
+  /// In en, this message translates to:
+  /// **'There is an issue with hardware-backed encryption'**
+  String get tpmActionPageTitleActionable;
+
   /// No description provided for @tpmActionBadgeLabel.
   ///
   /// In en, this message translates to:

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_am.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsAm extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ar.dart
@@ -1401,6 +1401,10 @@ class UbuntuBootstrapLocalizationsAr extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_be.dart
@@ -1405,6 +1405,10 @@ class UbuntuBootstrapLocalizationsBe extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bg.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsBg extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bn.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsBn extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bo.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsBo extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_bs.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsBs extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ca.dart
@@ -1418,6 +1418,10 @@ class UbuntuBootstrapLocalizationsCa extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cs.dart
@@ -1410,6 +1410,10 @@ class UbuntuBootstrapLocalizationsCs extends UbuntuBootstrapLocalizations {
       'Šifrování jištěné hardwarem nebylo možné zapnout';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Vyžadována akce';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_cy.dart
@@ -1403,6 +1403,10 @@ class UbuntuBootstrapLocalizationsCy extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_da.dart
@@ -1400,6 +1400,10 @@ class UbuntuBootstrapLocalizationsDa extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_de.dart
@@ -1425,6 +1425,10 @@ class UbuntuBootstrapLocalizationsDe extends UbuntuBootstrapLocalizations {
       'Hardware-gestützte Verschlüsselung konnte nicht aktiviert werden';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Handlungsbedarf';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_dz.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsDz extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_el.dart
@@ -1425,6 +1425,10 @@ class UbuntuBootstrapLocalizationsEl extends UbuntuBootstrapLocalizations {
       'Δεν ήταν δυνατή η ενεργοποίηση της κρυπτογράφησης με υποστήριξη υλικού (hardware-backed encryption)';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Απαιτείται ενέργεια';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_en.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsEn extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eo.dart
@@ -1407,6 +1407,10 @@ class UbuntuBootstrapLocalizationsEo extends UbuntuBootstrapLocalizations {
   String get tpmActionPageTitle => 'Ne povas ŝalti aparato-bazan ĉifradon';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Ago necesas';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_es.dart
@@ -1416,6 +1416,10 @@ class UbuntuBootstrapLocalizationsEs extends UbuntuBootstrapLocalizations {
       'El cifrado con hardware en segundo plano no pudo ser habilitado';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Acción requerida';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_et.dart
@@ -1412,6 +1412,10 @@ class UbuntuBootstrapLocalizationsEt extends UbuntuBootstrapLocalizations {
       'Raudvarapõhist krüptimist ei saanud sisse lülitada';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Vajalik on kasutaja sekkumine';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_eu.dart
@@ -1409,6 +1409,10 @@ class UbuntuBootstrapLocalizationsEu extends UbuntuBootstrapLocalizations {
       'Ezin izan da hardware bidezko zifratzea gaitu';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Ekintza beharrezkoa da';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fa.dart
@@ -1396,6 +1396,10 @@ class UbuntuBootstrapLocalizationsFa extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fi.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsFi extends UbuntuBootstrapLocalizations {
       'Laitevarmennettua salausta ei voi ottaa käyttöön';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Toimia vaaditaan';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_fr.dart
@@ -1420,6 +1420,10 @@ class UbuntuBootstrapLocalizationsFr extends UbuntuBootstrapLocalizations {
       'Chiffrement assisté par matériel n’a pas pu être activé';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action requise';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ga.dart
@@ -1415,6 +1415,10 @@ class UbuntuBootstrapLocalizationsGa extends UbuntuBootstrapLocalizations {
       'Níorbh fhéidir criptiú crua-earraí-tacaithe a chumasú';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Gníomh riachtanach';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gl.dart
@@ -1419,6 +1419,10 @@ class UbuntuBootstrapLocalizationsGl extends UbuntuBootstrapLocalizations {
       'Non se puido activar o cifrado con respaldo de hardware';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Acción requirida';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_gu.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsGu extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_he.dart
@@ -1384,6 +1384,10 @@ class UbuntuBootstrapLocalizationsHe extends UbuntuBootstrapLocalizations {
   String get tpmActionPageTitle => 'לא ניתן להפעיל הצפנה בגיבוי חומרה';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'נדרשת התערבות';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hi.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsHi extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hr.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsHr extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_hu.dart
@@ -1417,6 +1417,10 @@ class UbuntuBootstrapLocalizationsHu extends UbuntuBootstrapLocalizations {
       'A hardveresen támogatott titkosítást nem sikerült engedélyezni';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Művelet szükséges';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_id.dart
@@ -1407,6 +1407,10 @@ class UbuntuBootstrapLocalizationsId extends UbuntuBootstrapLocalizations {
       'Enkripsi yang didukung perangkat keras tidak dapat diaktifkan';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Tindakan diperlukan';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_is.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsIs extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_it.dart
@@ -1416,6 +1416,10 @@ class UbuntuBootstrapLocalizationsIt extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ja.dart
@@ -1358,6 +1358,10 @@ class UbuntuBootstrapLocalizationsJa extends UbuntuBootstrapLocalizations {
   String get tpmActionPageTitle => 'ハードウェアベースの暗号化を有効にできません';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ka.dart
@@ -1411,6 +1411,10 @@ class UbuntuBootstrapLocalizationsKa extends UbuntuBootstrapLocalizations {
       'აპარატურით მხარდაჭერილი დაშიფვრის ჩართვა შეუძლებელია';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'საჭიროა ქმედება';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kk.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsKk extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_km.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsKm extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_kn.dart
@@ -1419,6 +1419,10 @@ class UbuntuBootstrapLocalizationsKn extends UbuntuBootstrapLocalizations {
       'ಹಾರ್ಡ್‌ವೇರ್-ಬೆಂಬಲಿತ ಎನ್‌ಕ್ರಿಪ್ಶನ್ ಅನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಲಿಲ್ಲ';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'ಕ್ರಮ ಅಗತ್ಯವಿದೆ';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ko.dart
@@ -1371,6 +1371,10 @@ class UbuntuBootstrapLocalizationsKo extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ku.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsKu extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lo.dart
@@ -1400,6 +1400,10 @@ class UbuntuBootstrapLocalizationsLo extends UbuntuBootstrapLocalizations {
       'ບໍ່ສາມາດເປີດໃຊ້ງານການເຂົ້າລະຫັດທີ່ຮອງຮັບໂດຍຮາດແວໄດ້';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'ຈຳເປັນຕ້ອງມີການດຳເນີນການ';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lt.dart
@@ -1406,6 +1406,10 @@ class UbuntuBootstrapLocalizationsLt extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_lv.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsLv extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mk.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsMk extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ml.dart
@@ -1406,6 +1406,10 @@ class UbuntuBootstrapLocalizationsMl extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_mr.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsMr extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_my.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsMy extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nb.dart
@@ -1405,6 +1405,10 @@ class UbuntuBootstrapLocalizationsNb extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ne.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsNe extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nl.dart
@@ -1416,6 +1416,10 @@ class UbuntuBootstrapLocalizationsNl extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_nn.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsNn extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_oc.dart
@@ -1417,6 +1417,10 @@ class UbuntuBootstrapLocalizationsOc extends UbuntuBootstrapLocalizations {
       'Lo chiframent material a pas pogut èsser activat';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Accion requerida';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pa.dart
@@ -1401,6 +1401,10 @@ class UbuntuBootstrapLocalizationsPa extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'ਕਾਰਵਾਈ ਚਾਹੀਦੀ ਹੈ';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pl.dart
@@ -1408,6 +1408,10 @@ class UbuntuBootstrapLocalizationsPl extends UbuntuBootstrapLocalizations {
   String get tpmActionPageTitle => 'Nie można włączyć szyfrowania sprzętowego';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Wymagana czynność';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_pt.dart
@@ -1412,6 +1412,10 @@ class UbuntuBootstrapLocalizationsPt extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ro.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsRo extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ru.dart
@@ -1410,6 +1410,10 @@ class UbuntuBootstrapLocalizationsRu extends UbuntuBootstrapLocalizations {
   String get tpmActionPageTitle => 'Не удалось включить аппаратное шифрование';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Требуется действие';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_se.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsSe extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_si.dart
@@ -1396,6 +1396,10 @@ class UbuntuBootstrapLocalizationsSi extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sk.dart
@@ -1405,6 +1405,10 @@ class UbuntuBootstrapLocalizationsSk extends UbuntuBootstrapLocalizations {
       'Hardvérom podporované šifrovanie sa nepodarilo zapnúť';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Vyžaduje sa akcia';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sl.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsSl extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sq.dart
@@ -1403,6 +1403,10 @@ class UbuntuBootstrapLocalizationsSq extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sr.dart
@@ -1405,6 +1405,10 @@ class UbuntuBootstrapLocalizationsSr extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_sv.dart
@@ -1405,6 +1405,10 @@ class UbuntuBootstrapLocalizationsSv extends UbuntuBootstrapLocalizations {
       'Hårdvarubaserad kryptering kunde inte aktiveras';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Åtgärd krävs';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ta.dart
@@ -1419,6 +1419,10 @@ class UbuntuBootstrapLocalizationsTa extends UbuntuBootstrapLocalizations {
       'வன்பொருள் உதவி குறியாக்கத்தை இயக்க முடியவில்லை';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'நடவடிக்கை தேவை';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_te.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsTe extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tg.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsTg extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_th.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsTh extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tl.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsTl extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_tr.dart
@@ -1406,6 +1406,10 @@ class UbuntuBootstrapLocalizationsTr extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_ug.dart
@@ -1407,6 +1407,10 @@ class UbuntuBootstrapLocalizationsUg extends UbuntuBootstrapLocalizations {
       'قاتتىق دېتال قوللايدىغان شىفىرلاشنى قوزغاتقىلى بولمايدۇ';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'زۆرۈر مەشغۇلات';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_uk.dart
@@ -1410,6 +1410,10 @@ class UbuntuBootstrapLocalizationsUk extends UbuntuBootstrapLocalizations {
       'Апаратне шифрування не може бути увімекнено';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Потрібна дія';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_vi.dart
@@ -1402,6 +1402,10 @@ class UbuntuBootstrapLocalizationsVi extends UbuntuBootstrapLocalizations {
       'Hardware-backed encryption could not be enabled';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => 'Action required';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
+++ b/apps/ubuntu_bootstrap/lib/l10n/ubuntu_bootstrap_localizations_zh.dart
@@ -1334,6 +1334,10 @@ class UbuntuBootstrapLocalizationsZh extends UbuntuBootstrapLocalizations {
   String get tpmActionPageTitle => '硬件加密';
 
   @override
+  String get tpmActionPageTitleActionable =>
+      'There is an issue with hardware-backed encryption';
+
+  @override
   String get tpmActionBadgeLabel => '需要操作';
 
   @override

--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
@@ -27,45 +27,58 @@ class TpmActionPage extends ConsumerWidget with ProvisioningPage {
       actions.map((a) => '${a.type.name}:${a.args}').join('|'),
     );
 
+    final hasSingleProceedAction =
+        model.actions.singleOrNull?.type == CoreBootFixAction.PROCEED;
+
+    final actionsPanel = hasSingleProceedAction
+        ? _ActionBody(
+            action: model.actions.singleOrNull!,
+            errorKind: model.tpmError?.kind,
+            isLoading: model.isLoading,
+            padding: EdgeInsets.zero,
+          )
+        : YaruExpansionPanel(
+            key: actionsKey,
+            shrinkWrap: true,
+            headers: [
+              for (final (i, action) in actions.indexed)
+                Text(
+                  actions.length > 1
+                      ? lang.tpmActionSolutionLabel(
+                          i + 1,
+                          action.title(lang, model.tpmError?.kind),
+                        )
+                      : lang.tpmActionSingleSolutionLabel(
+                          action.title(lang, model.tpmError?.kind),
+                        ),
+                ),
+            ],
+            children: [
+              for (final action in actions)
+                _ActionBody(
+                  action: action,
+                  errorKind: model.tpmError?.kind,
+                  isLoading: model.isLoading,
+                ),
+            ],
+          );
+
     final children = [
       if (model.tpmError != null)
         ...[
           Text(model.tpmError!.kind.label(lang)),
-          Text(
-            switch (actions.length) {
-              0 => lang.tpmActionErrorSupportNoActionLabel,
-              1 => lang.tpmActionErrorSupportSingleLabel,
-              _ => lang.tpmActionErrorSupportLabel
-            },
-          ),
+          if (!hasSingleProceedAction)
+            Text(
+              switch (actions.length) {
+                0 => lang.tpmActionErrorSupportNoActionLabel,
+                1 => lang.tpmActionErrorSupportSingleLabel,
+                _ => lang.tpmActionErrorSupportLabel
+              },
+            ),
         ].withSpacing(kWizardSpacing / 2),
       if (actions.isNotEmpty) ...[
         const SizedBox(height: kWizardSpacing / 2),
-        YaruExpansionPanel(
-          key: actionsKey,
-          shrinkWrap: true,
-          headers: [
-            for (final (i, action) in actions.indexed)
-              Text(
-                actions.length > 1
-                    ? lang.tpmActionSolutionLabel(
-                        i + 1,
-                        action.title(lang, model.tpmError?.kind),
-                      )
-                    : lang.tpmActionSingleSolutionLabel(
-                        action.title(lang, model.tpmError?.kind),
-                      ),
-              ),
-          ],
-          children: [
-            for (final action in actions)
-              _ActionBody(
-                action: action,
-                errorKind: model.tpmError?.kind,
-                isLoading: model.isLoading,
-              ),
-          ],
-        ),
+        actionsPanel,
       ],
       const SizedBox(height: kWizardSpacing / 2),
       Html(
@@ -116,11 +129,17 @@ class _ActionBody extends ConsumerStatefulWidget {
     required this.action,
     this.errorKind,
     this.isLoading = false,
+    this.padding = const EdgeInsetsGeometry.only(
+      left: kYaruPagePadding,
+      right: kYaruPagePadding,
+      bottom: kYaruPagePadding,
+    ),
   });
 
   final CoreBootFixActionWithCategoryAndArgs action;
   final CoreBootAvailabilityErrorKind? errorKind;
   final bool isLoading;
+  final EdgeInsetsGeometry padding;
 
   @override
   ConsumerState<_ActionBody> createState() => _ActionBodyState();
@@ -171,11 +190,7 @@ class _ActionBodyState extends ConsumerState<_ActionBody> {
     final caveats = widget.action.caveats(lang);
 
     return Padding(
-      padding: EdgeInsetsGeometry.only(
-        left: kYaruPagePadding,
-        right: kYaruPagePadding,
-        bottom: kYaruPagePadding,
-      ),
+      padding: widget.padding,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [

--- a/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/storage/tpm_action/tpm_action_page.dart
@@ -112,7 +112,9 @@ class TpmActionPage extends ConsumerWidget with ProvisioningPage {
 
     return HorizontalPage(
       windowTitle: lang.installationTypeAdvancedTitle,
-      title: lang.tpmActionPageTitle,
+      title: (model.tpmError?.actions.isEmpty ?? true)
+          ? lang.tpmActionPageTitle
+          : lang.tpmActionPageTitleActionable,
       bottomBar: WizardBar(
         leading: const BackWizardButton(),
         trailing: [if (model.isFixed) NextWizardButton()],


### PR DESCRIPTION
This PR simplifies the UI of the TPM action page in case there is only a single 'proceed' (ignore) action:

Before:
<img width="2024" height="1464" alt="Screenshot From 2026-07-21 16-47-55" src="https://github.com/user-attachments/assets/8df3d63f-54e3-4e36-8e9b-1c5045f056f7" />

After:
<img width="2024" height="1464" alt="Screenshot From 2026-07-21 16-54-50" src="https://github.com/user-attachments/assets/dcb2a8bb-052d-4738-b47f-7b2259a551b1" />

UDENG-11012