### PR TITLE
test: add integration test case for TPM/FDE w/o HWROT

### DIFF
--- a/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
+++ b/apps/ubuntu_bootstrap/integration_test/ubuntu_bootstrap_test.dart
@@ -528,6 +528,44 @@ void main() {
     },
   );
 
+  testWidgets(
+    'tpm action api no hwrot',
+    (tester) async {
+      await tester.runApp(
+        () => app.main([
+          '--source-catalog=examples/sources/tpm.yaml',
+          '--dry-run-config=examples/dry-run-configs/tpm.yaml',
+          '--',
+          '--bootloader=uefi',
+        ]),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.testLocalePage();
+      await tester.testAccessibilityPage();
+      await tester.testKeyboardPage();
+      await tester.testNetworkPage(mode: ConnectMode.none);
+      await tester.testRefreshPage();
+      await tester.testAutoinstallPage();
+      await tester.testSourceSelectionPage(
+        sourceId: 'src-no-hwrot',
+      );
+      await tester.testCodecsAndDriversPage();
+
+      await tester.testStoragePage(
+        type: StorageType.erase,
+      );
+      await tester.testGuidedCapabilityPage(
+        guidedCapability: GuidedCapability.CORE_BOOT_ENCRYPTED,
+      );
+      await tester.testTpmActionPage(action: CoreBootFixAction.PROCEED);
+      await tester.testPassphraseTypePage(
+        passphraseType: PassphraseType.pin,
+        disallowedPassphraseTypes: [PassphraseType.none],
+      );
+    },
+  );
+
   testWidgets('manual partitioning', (tester) async {
     final storage = [
       fakeDisk(

--- a/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
+++ b/packages/ubuntu_provision_test/lib/src/bootstrap_tester.dart
@@ -425,12 +425,13 @@ extension UbuntuBootstrapPageTester on WidgetTester {
           forUser: false,
         ).label(l10n),
       );
-      await pump();
+      await pumpAndSettle();
     }
   }
 
   Future<void> testPassphraseTypePage({
     PassphraseType passphraseType = PassphraseType.none,
+    List<PassphraseType> disallowedPassphraseTypes = const [],
     String? screenshot,
   }) async {
     await pumpUntilPage(PassphraseTypePage);
@@ -442,6 +443,13 @@ extension UbuntuBootstrapPageTester on WidgetTester {
 
     if (screenshot != null) {
       await takeScreenshot(screenshot);
+    }
+
+    for (final disallowedPassphraseType in disallowedPassphraseTypes) {
+      expect(
+        find.text(disallowedPassphraseType.localizedTileTitle(l10n)),
+        findsNothing,
+      );
     }
 
     await tap(find.text(passphraseType.localizedTileTitle(l10n)));


### PR DESCRIPTION
Adds an integration test using the test data from https://github.com/canonical/subiquity/pull/2404 to assert that setting up a PIN or passphrase is enforced when there's no HWROT.