### PR TITLE
fix(ui): Force LTR Directionality to prevent installer crash on RTL locales

### DIFF
--- a/packages/ubuntu_wizard/lib/src/wizard_app.dart
+++ b/packages/ubuntu_wizard/lib/src/wizard_app.dart
@@ -30,6 +30,12 @@ class WizardApp extends StatelessWidget {
     return YaruTheme(
       builder: (context, yaru, child) {
         return MaterialApp(
+          builder: (context, child) {
+            return Directionality(
+              textDirection: TextDirection.ltr,
+              child: child ?? const SizedBox.shrink(),
+            );
+          },
           locale: locale,
           onGenerateTitle: (context) {
             final title = onGenerateTitle?.call(context) ?? '';
@@ -39,10 +45,12 @@ class WizardApp extends StatelessWidget {
           theme: (theme ?? flavor?.theme ?? yaru.theme).customize(),
           darkTheme:
               (darkTheme ?? flavor?.darkTheme ?? yaru.darkTheme).customize(),
-          highContrastTheme:
-              yaruHighContrastLight.customize(highContrast: true),
-          highContrastDarkTheme:
-              yaruHighContrastDark.customize(highContrast: true),
+          highContrastTheme: yaruHighContrastLight.customize(
+            highContrast: true,
+          ),
+          highContrastDarkTheme: yaruHighContrastDark.customize(
+            highContrast: true,
+          ),
           debugShowCheckedModeBanner: false,
           localizationsDelegates: localizationsDelegates,
           supportedLocales: supportedLocales,


### PR DESCRIPTION
Fixes #1420

### Bug Description
Changing the locale to an RTL language (e.g. Arabic, Uyghur) causes immediate layout exceptions (red screens) and UI overflows in the desktop installer wizard because the layout logic heavily relies on LTR constraints.

### Solution
This PR forces `Directionality` to `TextDirection.ltr` globally at the `MaterialApp` root level. 
While Arabic translations will still be rendered properly right-to-left intrinsically by the `Text` widget, this prevents the entire installer wizard layout (Rows, Columns, NavigationToolbar) from flipping and crashing.
