### PR TITLE
fix(network): guard wifiDeviceProvider against empty device list

### DIFF
--- a/packages/ubuntu_provision/lib/src/network/wifi_view.dart
+++ b/packages/ubuntu_provision/lib/src/network/wifi_view.dart
@@ -110,8 +110,11 @@ class _WifiViewState extends ConsumerState<WifiView> {
   }
 }
 
-final wifiDeviceProvider = Provider.family<WifiDevice, int>(
-  (ref, index) => ref.watch(wifiModelProvider).devices[index],
+final wifiDeviceProvider = Provider.family<WifiDevice?, int>(
+  (ref, index) {
+    final devices = ref.watch(wifiModelProvider).devices;
+    return index < devices.length ? devices[index] : null;
+  },
 );
 
 class WifiListView extends ConsumerWidget {
@@ -205,6 +208,7 @@ class WifiListTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final device = ref.watch(wifiDeviceProvider(deviceIndex));
+    if (device == null) return const SizedBox.shrink();
     final lang = NetworkLocalizations.of(context);
     final textColor = Theme.of(context).textTheme.titleMedium!.color;
     final iconSize = IconTheme.of(context).size;


### PR DESCRIPTION
## Problem

`wifiDeviceProvider` indexes the Wi-Fi device list with `devices[index]` and no bounds check:

```dart
final wifiDeviceProvider = Provider.family<WifiDevice, int>(
  (ref, index) => ref.watch(wifiModelProvider).devices[index],
);
```

`WifiView` guards the empty case for the widget tree (`if (model.devices.isEmpty) return const SizedBox.shrink();`), but that does **not** protect the Riverpod provider itself. When `wifiModelProvider` notifies a change, Riverpod re-evaluates the already-active `wifiDeviceProvider(0)` instance *before* the watching widget is disposed. If the list is momentarily empty, `devices[0]` throws:

```
RangeError: RangeError (length): Valid value range is empty: 0
#0  wifiDeviceProvider.<anonymous closure>
```

This crashes the Ubuntu 26.04 desktop installer (`ubuntu-desktop-bootstrap` snap, rev 589) on the "Connect to the network" screen when the Wi-Fi adapter briefly transitions to `unavailable` (e.g. during a scan), which empties the device list.

## Fix

Return `null` when the index is out of range and skip the tile in that case.

## Testing

- `flutter analyze` clean for the package.
- Manually: with the adapter flapping to `unavailable`, the provider no longer throws and `WifiView` renders the empty state instead of crashing.

Fixes a crash observed in the field (see https://github.com/marktantongco/ubuntu-26.04-installer-bootfix for the full diagnosis).