### PR TITLE
chore: resolute: bump flutter to 3.44.0 on riscv64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -183,13 +183,8 @@ parts:
       craftctl default
 
       if [ $CRAFT_ARCH_BUILD_FOR = riscv64 ]; then
-        FLUTTER_VERSION=3.38.9
+        FLUTTER_VERSION=3.44.0
         git clone -b ${FLUTTER_VERSION} --depth 1 https://github.com/flutter/flutter.git
-
-        # Apply tool patch for riscv64 support
-        curl -L -o "$CRAFT_PART_SRC/flutter/riscv64-tool.patch" "https://flutter-experimental.ubuntu.com/tool/${FLUTTER_VERSION}.patch"
-        git -C $CRAFT_PART_SRC/flutter apply riscv64-tool.patch
-        rm $CRAFT_PART_SRC/flutter/riscv64-tool.patch
       else
         FLUTTER_VERSION=$(sed -n "s/^flutter \([0-9.]\+\).*/\1/p" .tool-versions)
         git clone -b $FLUTTER_VERSION --depth 1 https://github.com/flutter/flutter.git


### PR DESCRIPTION
Also drop tool-patch as 3.44.0 has tool upstream support for riscv64