### PR TITLE
chore: update yaru to 10.2.0

### DIFF
--- a/apps/factory_reset_tools/pubspec.lock
+++ b/apps/factory_reset_tools/pubspec.lock
@@ -780,10 +780,10 @@ packages:
     dependency: "direct main"
     description:
       name: yaru
-      sha256: "8c2d9602963efd52479e77f0052ceea05f491e7a31d2ca337c44901f526f8226"
+      sha256: "95e801c52dfda458bcb772baee6b2575c711fd951616a24910d6d30e70f5fb0d"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.2.0"
   yaru_window:
     dependency: transitive
     description:

--- a/apps/factory_reset_tools/pubspec.yaml
+++ b/apps/factory_reset_tools/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   ubuntu_utils: ^0.1.0
   ubuntu_wizard: ^0.1.0
   yaml: ^3.1.2
-  yaru: ^10.0.0
+  yaru: ^10.2.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/ubuntu_bootstrap/pubspec.lock
+++ b/apps/ubuntu_bootstrap/pubspec.lock
@@ -1495,10 +1495,10 @@ packages:
     dependency: "direct main"
     description:
       name: yaru
-      sha256: "8c2d9602963efd52479e77f0052ceea05f491e7a31d2ca337c44901f526f8226"
+      sha256: "95e801c52dfda458bcb772baee6b2575c711fd951616a24910d6d30e70f5fb0d"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.2.0"
   yaru_test:
     dependency: "direct dev"
     description:

--- a/apps/ubuntu_bootstrap/pubspec.yaml
+++ b/apps/ubuntu_bootstrap/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   ubuntu_wizard: ^0.1.0
   xdg_desktop_portal: ^0.1.13
   yaml: ^3.1.2
-  yaru: ^10.0.0
+  yaru: ^10.2.0
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/apps/ubuntu_init/pubspec.lock
+++ b/apps/ubuntu_init/pubspec.lock
@@ -1389,10 +1389,10 @@ packages:
     dependency: "direct main"
     description:
       name: yaru
-      sha256: "8c2d9602963efd52479e77f0052ceea05f491e7a31d2ca337c44901f526f8226"
+      sha256: "95e801c52dfda458bcb772baee6b2575c711fd951616a24910d6d30e70f5fb0d"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.2.0"
   yaru_test:
     dependency: "direct dev"
     description:

--- a/apps/ubuntu_init/pubspec.yaml
+++ b/apps/ubuntu_init/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   ubuntu_utils: ^0.1.0
   ubuntu_widgets: ^0.8.1
   ubuntu_wizard: ^0.1.0
-  yaru: ^10.0.0
+  yaru: ^10.2.0
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/melos.yaml
+++ b/melos.yaml
@@ -54,7 +54,7 @@ command:
       xdg_directories: ^1.0.4
       xdg_locale: ^0.0.1
       yaml: ^3.1.2
-      yaru: ^10.0.0
+      yaru: ^10.2.0
       yaru_window: ^0.2.1
 
     dev_dependencies:

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   url_launcher: ^6.2.5
   xdg_desktop_portal: ^0.1.13
   yaml: ^3.1.2
-  yaru: ^10.0.0
+  yaru: ^10.2.0
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/packages/ubuntu_provision_test/pubspec.yaml
+++ b/packages/ubuntu_provision_test/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   ubuntu_test: ^0.2.2
   ubuntu_utils: ^0.1.0
   ubuntu_wizard: ^0.1.0
-  yaru: ^10.0.0
+  yaru: ^10.2.0
   yaru_test: ^0.3.1
 
 dev_dependencies:

--- a/packages/ubuntu_utils/pubspec.yaml
+++ b/packages/ubuntu_utils/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   ubuntu_wizard: ^0.1.0
   url_launcher: ^6.2.5
   yaml: ^3.1.2
-  yaru: ^10.0.0
+  yaru: ^10.2.0
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   ubuntu_localizations: ^0.5.2+4
   ubuntu_widgets: ^0.8.1
   wizard_router: ^1.2.0
-  yaru: ^10.0.0
+  yaru: ^10.2.0
 
 
 dev_dependencies:


### PR DESCRIPTION
Update to yaru 10.2.0. This includes https://github.com/ubuntu/yaru.dart/pull/1067

UDENG-11168