### PR TITLE
refactor: Use built-in providers for installer model

### DIFF
--- a/apps/ubuntu_bootstrap/lib/app/installer_model.dart
+++ b/apps/ubuntu_bootstrap/lib/app/installer_model.dart
@@ -1,42 +1,16 @@
-import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:safe_change_notifier/safe_change_notifier.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:subiquity_client/subiquity_client.dart';
 import 'package:ubuntu_bootstrap/services.dart';
 
+part 'installer_model.g.dart';
+
 final restartProvider = StateProvider((_) => 0);
 
-final installerModelProvider = ChangeNotifierProvider.autoDispose(
-  (_) => InstallerModel(
-    getService<InstallerService>(),
-  ),
-);
+@riverpod
+Stream<ApplicationStatus?> applicationStatus(Ref ref) =>
+    getService<InstallerService>().monitorStatus();
 
-class InstallerModel extends SafeChangeNotifier {
-  InstallerModel(this._installer);
-
-  final InstallerService _installer;
-
-  ApplicationStatus? _status;
-  StreamSubscription<ApplicationStatus?>? _statusChange;
-
-  ApplicationStatus? get status => _status;
-  bool get isInstalling => status?.isInstalling ?? false;
-
-  Future<void> init() async {
-    _statusChange = _installer.monitorStatus().listen((status) {
-      _status = status;
-      notifyListeners();
-    });
-  }
-
-  bool hasRoute(String route) => _installer.hasRoute(route);
-
-  @override
-  Future<void> dispose() async {
-    await _statusChange?.cancel();
-    _statusChange = null;
-    super.dispose();
-  }
-}
+@riverpod
+bool hasRoute(Ref ref, String route) =>
+    getService<InstallerService>().hasRoute(route);

--- a/apps/ubuntu_bootstrap/lib/app/installer_model.g.dart
+++ b/apps/ubuntu_bootstrap/lib/app/installer_model.g.dart
@@ -1,0 +1,177 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'installer_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$applicationStatusHash() => r'2661f10ea4ddabe9cb6cc4f72608dae83221c0f7';
+
+/// See also [applicationStatus].
+@ProviderFor(applicationStatus)
+final applicationStatusProvider =
+    AutoDisposeStreamProvider<ApplicationStatus?>.internal(
+  applicationStatus,
+  name: r'applicationStatusProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$applicationStatusHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef ApplicationStatusRef = AutoDisposeStreamProviderRef<ApplicationStatus?>;
+String _$hasRouteHash() => r'32bb8603a06b805aaa82d47b387e18f369223075';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [hasRoute].
+@ProviderFor(hasRoute)
+const hasRouteProvider = HasRouteFamily();
+
+/// See also [hasRoute].
+class HasRouteFamily extends Family<bool> {
+  /// See also [hasRoute].
+  const HasRouteFamily();
+
+  /// See also [hasRoute].
+  HasRouteProvider call(
+    String route,
+  ) {
+    return HasRouteProvider(
+      route,
+    );
+  }
+
+  @override
+  HasRouteProvider getProviderOverride(
+    covariant HasRouteProvider provider,
+  ) {
+    return call(
+      provider.route,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'hasRouteProvider';
+}
+
+/// See also [hasRoute].
+class HasRouteProvider extends AutoDisposeProvider<bool> {
+  /// See also [hasRoute].
+  HasRouteProvider(
+    String route,
+  ) : this._internal(
+          (ref) => hasRoute(
+            ref as HasRouteRef,
+            route,
+          ),
+          from: hasRouteProvider,
+          name: r'hasRouteProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$hasRouteHash,
+          dependencies: HasRouteFamily._dependencies,
+          allTransitiveDependencies: HasRouteFamily._allTransitiveDependencies,
+          route: route,
+        );
+
+  HasRouteProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.route,
+  }) : super.internal();
+
+  final String route;
+
+  @override
+  Override overrideWith(
+    bool Function(HasRouteRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: HasRouteProvider._internal(
+        (ref) => create(ref as HasRouteRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        route: route,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<bool> createElement() {
+    return _HasRouteProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HasRouteProvider && other.route == route;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, route.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin HasRouteRef on AutoDisposeProviderRef<bool> {
+  /// The parameter `route` of this provider.
+  String get route;
+}
+
+class _HasRouteProviderElement extends AutoDisposeProviderElement<bool>
+    with HasRouteRef {
+  _HasRouteProviderElement(super.provider);
+
+  @override
+  String get route => (origin as HasRouteProvider).route;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/ubuntu_bootstrap/lib/app/installer_wizard.dart
+++ b/apps/ubuntu_bootstrap/lib/app/installer_wizard.dart
@@ -23,9 +23,6 @@ class _InstallerWizardState extends ConsumerState<InstallerWizard>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-
-    final model = ref.read(installerModelProvider);
-    model.init();
   }
 
   @override
@@ -45,7 +42,7 @@ class _InstallerWizardState extends ConsumerState<InstallerWizard>
 
   @override
   Widget build(BuildContext context) {
-    final status = ref.watch(installerModelProvider.select((m) => m.status));
+    final status = ref.watch(applicationStatusProvider).valueOrNull;
     if (status?.state == ApplicationState.ERROR) {
       return const _ErrorWizard();
     }
@@ -66,7 +63,6 @@ class _InstallWizard extends ConsumerWidget {
     };
     final totalSteps =
         InstallationStep.values.where((value) => value.discreteStep).length;
-    final hasRoute = ref.read(installerModelProvider).hasRoute;
 
     return WizardBuilder(
       initialRoute: InstallationStep.loading.route,
@@ -96,13 +92,9 @@ class _InstallWizard extends ConsumerWidget {
           builder: (_) => const ErrorPage(allowRestart: true),
         ),
       },
-      predicate: (route) {
-        if (InstallationStep.requiredRoutes.contains(route)) {
-          return true;
-        } else {
-          return hasRoute(route);
-        }
-      },
+      predicate: (route) =>
+          InstallationStep.requiredRoutes.contains(route) ||
+          ref.read(hasRouteProvider(route)),
       observers: [_InstallerObserver(getService<TelemetryService>())],
     );
   }
@@ -167,7 +159,7 @@ class _ErrorWizard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final status = ref.read(installerModelProvider.select((m) => m.status));
+    final status = ref.read(applicationStatusProvider).valueOrNull;
     return Wizard(
       routes: <String, WizardRoute>{
         InstallationStep.error.route: WizardRoute(

--- a/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
+++ b/apps/ubuntu_bootstrap/lib/pages/confirm/confirm_page.dart
@@ -50,7 +50,7 @@ class ConfirmPage extends ConsumerWidget with ProvisioningPage {
     final lang = UbuntuBootstrapLocalizations.of(context);
     final model = ref.watch(confirmModelProvider);
     final autoinstallNotifier = ref.read(autoinstallModelProvider.notifier);
-    final status = ref.watch(installerModelProvider.select((m) => m.status));
+    final status = ref.watch(applicationStatusProvider).valueOrNull;
 
     return HorizontalPage(
       windowTitle: lang.confirmPageTitle,

--- a/apps/ubuntu_bootstrap/test/confirm/test_confirm.dart
+++ b/apps/ubuntu_bootstrap/test/confirm/test_confirm.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:ubuntu_bootstrap/app/installer_model.dart';
 import 'package:ubuntu_bootstrap/pages/confirm/confirm_model.dart';
 import 'package:ubuntu_bootstrap/pages/confirm/confirm_page.dart';
 import 'package:ubuntu_bootstrap/pages/source/source_model.dart';
@@ -56,6 +57,7 @@ Widget buildConfirmPage({
   required ConfirmModel confirm,
   required StorageModel storage,
   required SourceModel source,
+  ApplicationStatus? status,
 }) {
   final udev = MockUdevService();
   final sda = MockUdevDeviceInfo();
@@ -75,6 +77,7 @@ Widget buildConfirmPage({
       confirmModelProvider.overrideWith((_) => confirm),
       storageModelProvider.overrideWith((_) => storage),
       sourceModelProvider.overrideWith((_) => source),
+      applicationStatusProvider.overrideWith((_) => Stream.value(status)),
     ],
     child: const ConfirmPage(),
   );

--- a/apps/ubuntu_bootstrap/test/installer_model_test.dart
+++ b/apps/ubuntu_bootstrap/test/installer_model_test.dart
@@ -1,38 +1,49 @@
-// ignore_for_file: close_sinks
-
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:subiquity_client/subiquity_client.dart';
+import 'package:subiquity_test/subiquity_test.dart';
 import 'package:ubuntu_bootstrap/app/installer_model.dart';
+import 'package:ubuntu_bootstrap/services.dart';
 
 import 'test_utils.dart';
 
 void main() {
-  test('init', () async {
+  test('application status', () async {
     final statusController = StreamController<ApplicationStatus>();
-
     final installer = MockInstallerService();
     when(installer.monitorStatus()).thenAnswer((_) => statusController.stream);
+    registerMockService<InstallerService>(installer);
 
-    final model = InstallerModel(installer);
-    await model.init();
+    final container = ProviderContainer();
+    container.listen(applicationStatusProvider, (_, __) {});
     verify(installer.monitorStatus()).called(1);
     expect(statusController.hasListener, isTrue);
+    expect(container.read(applicationStatusProvider).isLoading, isTrue);
 
-    await model.dispose();
+    final status = fakeApplicationStatus(ApplicationState.DONE);
+    statusController.add(status);
+    expect(await container.read(applicationStatusProvider.future), status);
+    expect(container.read(applicationStatusProvider).value, status);
+
+    container.dispose();
+    await Future<void>.delayed(Duration.zero);
     expect(statusController.hasListener, isFalse);
+    await statusController.close();
   });
 
-  test('has route', () async {
+  test('has route', () {
     final installer = MockInstallerService();
     when(installer.hasRoute('a')).thenReturn(true);
     when(installer.hasRoute('b')).thenReturn(false);
+    registerMockService<InstallerService>(installer);
 
-    final model = InstallerModel(installer);
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
 
-    expect(model.hasRoute('a'), isTrue);
-    expect(model.hasRoute('b'), isFalse);
+    expect(container.read(hasRouteProvider('a')), isTrue);
+    expect(container.read(hasRouteProvider('b')), isFalse);
   });
 }


### PR DESCRIPTION
Replaces the `InstallerModel` `ChangeNotifier` with two generated riverpod providers, `applicationStatusProvider` and `hasRouteProvider`, so the installer status stream and route lookup no longer need a manually initialized and disposed model.

- `installer_model.dart`: `InstallerModel` removed in favour of `@riverpod` providers (`restartProvider` unchanged).
- `installer_wizard.dart` and `confirm_page.dart`: read the status through `applicationStatusProvider` and routes through `hasRouteProvider`.
- `test_confirm.dart`: `buildConfirmPage` overrides `applicationStatusProvider` directly instead of stubbing the service.
- `installer_model_test.dart`: tests the providers through a mocked `InstallerService`, including subscription cleanup on dispose.

Part of #717
Supersedes #718, which was rebuilt from scratch on current `main` since the old branch predates the move to `apps/ubuntu_bootstrap`.
