### PR TITLE
fix: Pin html below 0.15.7 and regenerate mocks

### DIFF
--- a/packages/landscape_client/test/landscape_client_test.mocks.dart
+++ b/packages/landscape_client/test/landscape_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_accessibility_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_accessibility_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_chown_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_chown_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i6;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_gdm_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_gdm_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_keyboard_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_keyboard_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_locale_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_locale_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_privacy_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_privacy_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_pro_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_pro_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i8;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_telemetry_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_telemetry_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_timezone_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_timezone_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/provd_client/test/provd_user_client_test.mocks.dart
+++ b/packages/provd_client/test/provd_user_client_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i7;
 
 import 'package:grpc/service_api.dart' as _i2;

--- a/packages/subiquity_client/test/status_monitor_test.mocks.dart
+++ b/packages/subiquity_client/test/status_monitor_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 import 'dart:convert' as _i3;
 import 'dart:io' as _i2;

--- a/packages/subiquity_test/lib/src/generated.mocks.dart
+++ b/packages/subiquity_test/lib/src/generated.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;

--- a/packages/ubuntu_provision/pubspec.yaml
+++ b/packages/ubuntu_provision/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   form_field_validator: ^1.1.0
   freezed_annotation: ^3.1.0
   gsettings: ^0.2.8
+  # html 0.15.7 removed query_selector's matches(), which flutter_html 3.0.0 still calls
+  html: '>=0.15.4 <0.15.7'
   intl: ^0.20.2
   meta: ^1.11.0
   nm: ^0.5.0

--- a/packages/ubuntu_provision/test/accessibility/test_accessibility.mocks.dart
+++ b/packages/ubuntu_provision/test/accessibility/test_accessibility.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 import 'dart:collection' as _i2;
 import 'dart:ui' as _i5;

--- a/packages/ubuntu_provision/test/active_directory/test_active_directory.mocks.dart
+++ b/packages/ubuntu_provision/test/active_directory/test_active_directory.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 import 'dart:ui' as _i6;
 

--- a/packages/ubuntu_provision/test/identity/test_identity.mocks.dart
+++ b/packages/ubuntu_provision/test/identity/test_identity.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i5;
 import 'dart:ui' as _i6;
 

--- a/packages/ubuntu_provision/test/keyboard/test_keyboard.mocks.dart
+++ b/packages/ubuntu_provision/test/keyboard/test_keyboard.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 import 'dart:ui' as _i5;
 

--- a/packages/ubuntu_provision/test/network/ethernet_model_test.mocks.dart
+++ b/packages/ubuntu_provision/test/network/ethernet_model_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 
 import 'package:dbus/dbus.dart' as _i5;

--- a/packages/ubuntu_provision/test/network/hidden_wifi_model_test.mocks.dart
+++ b/packages/ubuntu_provision/test/network/hidden_wifi_model_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 
 import 'package:dbus/dbus.dart' as _i5;

--- a/packages/ubuntu_provision/test/network/network_device_test.mocks.dart
+++ b/packages/ubuntu_provision/test/network/network_device_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 
 import 'package:dbus/dbus.dart' as _i5;

--- a/packages/ubuntu_provision/test/network/test_network.mocks.dart
+++ b/packages/ubuntu_provision/test/network/test_network.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i6;
 import 'dart:ui' as _i7;
 

--- a/packages/ubuntu_provision/test/network/wifi_model_test.mocks.dart
+++ b/packages/ubuntu_provision/test/network/wifi_model_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 
 import 'package:dbus/dbus.dart' as _i5;

--- a/packages/ubuntu_provision/test/services/desktop_service_test.mocks.dart
+++ b/packages/ubuntu_provision/test/services/desktop_service_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i5;
 
 import 'package:dbus/dbus.dart' as _i2;

--- a/packages/ubuntu_provision/test/test_utils.mocks.dart
+++ b/packages/ubuntu_provision/test/test_utils.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i12;
 import 'dart:convert' as _i23;
 import 'dart:io' as _i9;

--- a/packages/ubuntu_provision/test/timezone/test_timezone.mocks.dart
+++ b/packages/ubuntu_provision/test/timezone/test_timezone.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 import 'dart:ui' as _i5;
 

--- a/packages/ubuntu_utils/test/command_line_test.mocks.dart
+++ b/packages/ubuntu_utils/test/command_line_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 import 'dart:convert' as _i2;
 import 'dart:io' as _i3;

--- a/packages/ubuntu_utils/test/proxy_asset_bundle_test.mocks.dart
+++ b/packages/ubuntu_utils/test/proxy_asset_bundle_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i2;
 import 'dart:typed_data' as _i4;
 import 'dart:ui' as _i5;

--- a/packages/ubuntu_wizard/pubspec.yaml
+++ b/packages/ubuntu_wizard/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  # html 0.15.7 removed query_selector's matches(), which flutter_html 3.0.0 still calls
+  html: '>=0.15.4 <0.15.7'
   ubuntu_lints: ^0.4.0
   ubuntu_test: ^0.2.2
   yaru_test: ^0.3.0


### PR DESCRIPTION
CI is currently red for every new PR, for two reasons that are both caused by `packages/*` having no lockfile:

- `html 0.15.7` (published 2026-08-28) removed the `matches()` helper from `query_selector.dart` that `flutter_html 3.0.0` still calls, so nothing in `ubuntu_provision` or `ubuntu_wizard` compiles under `flutter test` anymore. This pins `html` below `0.15.7` in those two packages, which are the only `packages/*` members that pull in `flutter_html`. The apps are unaffected because their lockfiles pin `html 0.15.6`.
- The mock generator now emits a blank line after the `ignore_for_file` header, so `flutter-mocks` and `subiquity-types` fail their outdated-files check on 27 files. This commits the output of `melos generate`.

No functional changes. Split out of #1531 so it can land on its own.

https://claude.ai/code/session_01K4ipmNnmKt7PB21TSeVtHK
