### PR TITLE
fix(factory_reset): handle cli reboot failure by ptyxis with a message

### DIFF
--- a/apps/factory_reset_tools/lib/dbus/cmdline.dart
+++ b/apps/factory_reset_tools/lib/dbus/cmdline.dart
@@ -95,6 +95,20 @@ class RebootCommand extends Command<void> {
     await pkttyagent.start();
     try {
       await startCommandViaDbus(ResetOptionType.fromString(argResults.rest[0]));
+    } on RebootFailedException catch (e) {
+      stderr
+        ..writeln(e.message)
+        ..writeln()
+        ..writeln(
+          'The selected option has been set up and will be used on the next '
+          'boot, but the system could not restart by itself. This usually '
+          'happens when another program, such as this terminal, prevents the '
+          'system from rebooting.',
+        )
+        ..writeln()
+        ..writeln('Please close any running programs and reboot manually to '
+            'continue.');
+      exit(1);
     } finally {
       pkttyagent.stop();
     }

--- a/apps/factory_reset_tools/lib/dbus/dbus_daemon.dart
+++ b/apps/factory_reset_tools/lib/dbus/dbus_daemon.dart
@@ -48,7 +48,14 @@ class FactoryResetToolsObject extends ComCanonicalOemFactoryResetTools {
       return DBusMethodErrorResponse.authFailed();
     }
 
-    await startCommand(ResetOptionType.fromString(rebootOption));
+    try {
+      await startCommand(ResetOptionType.fromString(rebootOption));
+    } on RebootFailedException catch (e) {
+      return DBusMethodErrorResponse(
+        rebootFailedErrorName,
+        [DBusString(e.message)],
+      );
+    }
     return DBusMethodSuccessResponse();
   }
 }

--- a/apps/factory_reset_tools/lib/dbus/factory_reset.dart
+++ b/apps/factory_reset_tools/lib/dbus/factory_reset.dart
@@ -10,6 +10,23 @@ import 'package:yaml/yaml.dart';
 const defaultFilePath = '/usr/share/desktop-provision';
 const defaultFileName = 'reset.yaml';
 
+/// DBus error name used to report a boot option which has been set up
+/// successfully, but where rebooting the system failed.
+const rebootFailedErrorName =
+    'com.canonical.oem.FactoryResetTools.Error.RebootFailed';
+
+/// Thrown when the boot option has been applied but the system could not be
+/// rebooted, for instance because another program inhibits the reboot or
+/// because we lack the privileges to ignore those inhibitors.
+class RebootFailedException implements Exception {
+  RebootFailedException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 enum ResetOptionType {
   factoryReset('factory-reset'),
   fwSetup('fwsetup');
@@ -62,11 +79,19 @@ class GrubBootOption extends BootOption {
       name: 'org.freedesktop.login1',
       path: DBusObjectPath('/org/freedesktop/login1'),
     );
-    await loginObject.callMethod(
-      'org.freedesktop.login1.Manager',
-      'Reboot',
-      [const DBusBoolean(true)],
-    );
+    try {
+      await loginObject.callMethod(
+        'org.freedesktop.login1.Manager',
+        'Reboot',
+        [const DBusBoolean(false)],
+      );
+    } on DBusMethodResponseException catch (e) {
+      throw RebootFailedException(
+        'Failed to reboot the system automatically ($e).',
+      );
+    } finally {
+      await dbusClient.close();
+    }
   }
 }
 
@@ -188,10 +213,22 @@ Future<void> startCommandViaDbus(
   // as service is activated by dbus call, we should try to rerun if dbus gives
   // error
   const retryRunner = RetryOptions(maxAttempts: 5);
-  await retryRunner.retry(
-    () => object.callReboot(type.value),
-    retryIf: (e) =>
-        e is DBusMethodResponseException &&
-        e.errorName == 'org.freedesktop.DBus.Error.UnknownObject',
-  );
+  try {
+    await retryRunner.retry(
+      () => object.callReboot(type.value),
+      retryIf: (e) =>
+          e is DBusMethodResponseException &&
+          e.errorName == 'org.freedesktop.DBus.Error.UnknownObject',
+    );
+  } on DBusMethodResponseException catch (e) {
+    if (e.errorName == rebootFailedErrorName) {
+      final values = e.response.values;
+      throw RebootFailedException(
+        values.isNotEmpty && values.first is DBusString
+            ? values.first.asString()
+            : 'Failed to reboot the system automatically.',
+      );
+    }
+    rethrow;
+  }
 }


### PR DESCRIPTION
Running `factory-reset-tools.cli` in Ptyxis (Default terminal emulator in 26.04) to reboot into Factory Reset can fail, due to Ptyxis inhibiting logout when a program is running inside terminal.

This proposed "fix" is to provide an appropriate message that asks user to reboot the system manually.

To turn off the behavior on Ptyxis:
```
gsettings set org.gnome.Ptyxis inhibit-logout false
```

Internal Reference: OEX86-972