### PR TITLE
fix: use `NativePlatform` instead of deprecated `LocalPlatform`

### DIFF
--- a/apps/factory_reset_tools/pubspec.lock
+++ b/apps/factory_reset_tools/pubspec.lock
@@ -401,10 +401,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: a36d119c13416516a7b5913fbe8af8531e11633d784c550b2125f76c758524ec
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.2.0"
   platform_linux:
     dependency: transitive
     description:

--- a/apps/ubuntu_bootstrap/pubspec.lock
+++ b/apps/ubuntu_bootstrap/pubspec.lock
@@ -817,10 +817,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: a36d119c13416516a7b5913fbe8af8531e11633d784c550b2125f76c758524ec
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.2.0"
   platform_linux:
     dependency: transitive
     description:

--- a/apps/ubuntu_init/pubspec.lock
+++ b/apps/ubuntu_init/pubspec.lock
@@ -750,10 +750,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: a36d119c13416516a7b5913fbe8af8531e11633d784c550b2125f76c758524ec
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.2.0"
   platform_linux:
     dependency: transitive
     description:

--- a/packages/ubuntu_provision/lib/src/keyboard/keyboard_model.dart
+++ b/packages/ubuntu_provision/lib/src/keyboard/keyboard_model.dart
@@ -19,11 +19,11 @@ final keyboardModelProvider =
 /// Implements the business logic of the Keyboard page.
 class KeyboardModel extends SafeChangeNotifier {
   /// Creates a model with the specified service.
-  KeyboardModel(this._service, {@visibleForTesting Platform? platform})
-      : _platform = platform ?? const LocalPlatform();
+  KeyboardModel(this._service, {@visibleForTesting NativePlatform? platform})
+      : _platform = platform ?? Platform.current.nativePlatform!;
 
   final KeyboardService _service;
-  final Platform _platform;
+  final NativePlatform _platform;
   List<KeyboardLayout> _layouts = [];
 
   /// The number of available keyboard layouts.

--- a/packages/ubuntu_provision/test/keyboard/keyboard_model_test.dart
+++ b/packages/ubuntu_provision/test/keyboard/keyboard_model_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:platform/platform.dart';
+import 'package:platform/testing.dart';
 import 'package:ubuntu_provision/src/keyboard/keyboard_model.dart';
 import 'package:ubuntu_provision/src/services/keyboard_service.dart';
 
@@ -126,7 +126,7 @@ void main() {
 
       model = KeyboardModel(
         service,
-        platform: FakePlatform(environment: {'USERNAME': 'usr'}),
+        platform: TestNativePlatform(environment: {'USERNAME': 'usr'}),
       );
       await model.init();
     });


### PR DESCRIPTION
`flutter analyze` fails in CI due to the recent [`platform`](https://pub.dev/packages/platform) update (its version is not pinned in `ubuntu_provision`). This PR migrates to the new classes.